### PR TITLE
Add elpy.backends to the list of packages

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -19,7 +19,7 @@ try:
           author_email="forcer@forcix.cx",
           url="https://github.com/jorgenschaefer/elpy",
           license="GPL",
-          packages=["elpy"],
+          packages=["elpy", "elpy.backends"],
           data_files=[('elpy', ["LICENSE"])],
           classifiers=[
               "Development Status :: 5 - Production/Stable",


### PR DESCRIPTION
When the elpy (python) package is installed the "elpy.backends" isn't included in the installation.

This patch adds elpy.backends to the list of packages in the setup.py file
