### PR TITLE
Supoort python2.6

### DIFF
--- a/elpy.el
+++ b/elpy.el
@@ -824,7 +824,7 @@ See `elpy-rpc-call'.")
       (kill-buffer elpy-rpc-buffer))
     (condition-case err
         (setq elpy-rpc-buffer
-              (elpy-rpc-open "*elpy-rpc*" "python" "-m" "elpy"))
+              (elpy-rpc-open "*elpy-rpc*" "python" "-m" "elpy.__main__"))
       (error
        (elpy-installation-instructions
         (format "Could not start the Python subprocess: %s"


### PR DESCRIPTION
Python 2.6 doesn't support running packages as a scripts.
Instead of 'python -m elpy' should be 'python -m elpy.**main**'.
