### PR TITLE
Make {pip,easy_install} a variable

### DIFF
--- a/elpy.el
+++ b/elpy.el
@@ -248,6 +248,12 @@ explain how to install the elpy module."
                 "that virtualenv.")
         (fill-region (point-min) (point-max))))))
 
+(defvar elpy-set-pip-command "pip"
+  "What the `pip' command is installed as.")
+
+(defvar elpy-set-easy-install-command "easy_install"
+  "What the `easy_install' command is installed as.")
+
 (defun elpy-installation-command (python-module)
   "Insert an installation command description for PYTHON-MODULE."
   (let* ((do-user-install (not (or (getenv "VIRTUAL_ENV")
@@ -256,10 +262,12 @@ explain how to install the elpy module."
                           "--user "
                         ""))
          (command (cond
-                   ((executable-find "pip")
-                    (format "pip install %s%s" user-option python-module))
-                   ((executable-find "easy_install")
-                    (format "easy_install %s%s" user-option python-module))
+                   ((executable-find elpy-set-pip-command)
+                    (format "%s install %s%s" elpy-set-pip-command user-option
+                            python-module))
+                   ((executable-find elpy-set-easy-install-command)
+                    (format "easy_install %s%s" elpy-set-easy-install-command
+                            user-option python-module))
                    (t
                     nil))))
     (if (not command)


### PR DESCRIPTION
On some systems there are multiple versions of `pip' and`easy_install'.  For
instance, on Arch Linux, there exists `pip' (python 3.x, provided by
`python-pip'), `pip2' (python 2.x, provided by`python2-pip'),
`easy_install-3.3' (python 3.x, provided by`python-distribute'),
`easy_install-2.7' (python 2.x, provided by`python2-distribute').  Hence, these
should be variables!
