### PR TITLE
Run rpc-server in '.emacs.d' directory

### DIFF
--- a/elpy.el
+++ b/elpy.el
@@ -913,10 +913,12 @@ arguments.
 This function returns the buffer created to communicate with
 elpy-rpc. This buffer needs to be the current buffer for
 subsequent calls to `elpy-rpc-call'."
+
   (let* ((buffer (generate-new-buffer name))
          ;; Leaving process-connection-type non-nil can truncate
          ;; communication
-         (proc (let ((process-connection-type nil))
+         (proc (let ((process-connection-type nil)
+		     (default-directory user-emacs-directory))
                  (apply #'start-process name buffer program program-args))))
     (set-process-query-on-exit-flag proc nil)
     (with-current-buffer buffer


### PR DESCRIPTION
Currently 'rpc-server' runs in directory with edited files. It may cause collisions with stantard libraries.

I have 'mylib/json.py' in my project (it is legacy project and I can't rename this file). Rpc-server loads wrong 'json.py' when I try to open 'mylib/anymodulename.py'.
