### PR TITLE
Set ffip-project-root local

### DIFF
--- a/elpy.el
+++ b/elpy.el
@@ -169,7 +169,7 @@ more structured list.
   (cond
    (elpy-mode
     (when buffer-file-name
-      (setq ffip-project-root (elpy-project-root)))
+      (set (make-local-variable 'ffip-project-root) (elpy-project-root)))
     (set (make-local-variable 'eldoc-documentation-function)
          'elpy-eldoc-documentation)
     (add-to-list 'ac-sources 'ac-source-elpy)
@@ -179,7 +179,7 @@ more structured list.
     ;; Enable modes, hence the 1.
     (run-hook-with-args 'elpy-default-minor-modes 1))
    (t
-    (setq ffip-project-root nil)
+    (kill-local-variable 'ffip-project-root)
     (kill-local-variable 'eldoc-documentation-function)
     (setq ac-sources
           (delq 'ac-source-elpy


### PR DESCRIPTION
Set ffip-project-root variable local to make find-file-in-project work also for other open projects.
