### PR TITLE
Add elpy-project-root to safe-local-variabes

### DIFF
--- a/elpy.el
+++ b/elpy.el
@@ -351,6 +351,7 @@ This should be run from `python-mode-hook'."
 (defvar elpy-project-root 'not-initialized
   "The root of the project the current buffer is in.")
 (make-variable-buffer-local 'elpy-project-root)
+(put 'elpy-project-root 'safe-local-variable 'file-directory-p)
 
 (defun elpy-project-root ()
   "Return the root of the current buffer's project.


### PR DESCRIPTION
Set `elpy-project-root` safe-local to be able to set the variable for example in `.dir-locals.el` without having to confirm every time that it is safe.
