### PR TITLE
introduce project specific elpy-rpc processes

### DIFF
--- a/elpy.el
+++ b/elpy.el
@@ -371,7 +371,7 @@ You can set the variable `elpy-project-root' in, for example,
 .dir-locals.el to configure this."
   (when (eq elpy-project-root 'not-initialized)
     ;; Set it to nil so when the user runs C-g on the project root
-    ;; prompt, it's set to "no project-root".
+    ;; prompt, it's set to "no project root".
     (setq elpy-project-root nil)
     (setq elpy-project-root
           (or (elpy-project-find-root)


### PR DESCRIPTION
when elpy-rpc-ensure-open in a new buffer is used:
- if there is an RPC process associated with the project, use that one
- if elpy-rpc-project-specific is:
  - nil : the project is associated with the global RPC process
        (which is started, if necessary), (default)
  - ask : if the users answers yes to a prompt, start a project-specific
        RPC process and associate it with the current project
  - t   : start a project-specific RPC process and associate it

at any point a project-specific RPC process can be started and
associated with all buffers belonging to the current project by
invoking elpy-rpc-open-project-specific.

elpy-rpc-pool-gc kills unused rpc buffers.
