### PR TITLE
suppress warning messages in rpc python processes

### DIFF
--- a/elpy.el
+++ b/elpy.el
@@ -872,7 +872,7 @@ See `elpy-rpc-call'.")
     (condition-case err
         (setq elpy-rpc-buffer
               (elpy-rpc-open "*elpy-rpc*"
-                             elpy-rpc-python-command "-m" "elpy.__main__"))
+                             elpy-rpc-python-command "-W" "ignore" "-m" "elpy.__main__"))
       (error
        (elpy-installation-instructions
         (format "Could not start the Python subprocess: %s"


### PR DESCRIPTION
they confound the protocol and thus produce random json-readtable
signals without any benefit.
