### PR TITLE
M-* (pop-tag-mark) works after elpy-goto-definition

### DIFF
--- a/elpy.el
+++ b/elpy.el
@@ -38,6 +38,7 @@
 
 (require 'auto-complete-config)
 (require 'elpy-refactor)
+(require 'etags)
 (require 'find-file-in-project)
 (require 'flymake)
 (require 'highlight-indentation)
@@ -535,6 +536,7 @@ screen."
 
 (defun elpy-goto-location (filename offset)
   "Show FILENAME at OFFSET to the user."
+  (ring-insert find-tag-marker-ring (point-marker))
   (let ((buffer (find-file filename)))
     (with-current-buffer buffer
       (with-selected-window (get-buffer-window buffer)


### PR DESCRIPTION
`M-.' in other language major modes is often bound to`find-tag', which,
after jumping to the tag's definition, allows you to use `pop-tag-mark'
(M-*) to jump back to the location where you invoked`find-tag'.

This commit makes `elpy-goto-definition' populate the same location
"marker ring" used by`find-tag' and `pop-tag-mark'.

Using etags.el's `find-tag-marker-ring' variable might be a bit hacky,
but the alternative is to create our own version of`pop-tag-mark',
duplicating ~20 lines of code from etags.el. I don't know how you tell
if a variable like `find-tag-marker-ring' is considered part of
etags.el's stable API (it isn't autoloaded, so maybe it isn't) but it
hasn't changed since 1998:
http://git.savannah.gnu.org/cgit/emacs.git/commit/?id=0553b7d6
(note that etags.el is part of Emacs).
## 

Let me know if you'd prefer our own `elpy-pop-location-mark'
implementation and I can do that instead.
