### PR TITLE
Add elpy-doctest-buffer function for running a buffers doctests.

### DIFF
--- a/elpy.el
+++ b/elpy.el
@@ -503,6 +503,17 @@ execution of code. With prefix argument, this code is executed."
                                 (region-end))
     (python-shell-send-buffer arg)))
 
+(defun elpy-doctest-buffer (&optional arg)
+  "Send the active buffer to the Python shell and run any doctests.
+
+With the prefix argument it will run the doctest in verbose mode"
+  (interactive "P")
+  (python-shell-send-buffer)
+  (python-shell-send-string "import doctest")
+  (if arg
+      (python-shell-send-string "doctest.testmod(verbose=True)")
+    (python-shell-send-string "doctest.testmod(verbose=False)")))
+
 (defun elpy-check ()
   "Run `python-check-command' on the current buffer's file."
   (interactive)


### PR DESCRIPTION
This is fairly basic now but I can imagine we could jump to failing doctests if we scrape data from the python buffer.
