### PR TITLE
Fixed a bug where incorrect arguments were given to the run-python command

### DIFF
--- a/elpy.el
+++ b/elpy.el
@@ -529,8 +529,15 @@ execution of code. With prefix argument, this code is executed."
          (proc (get-buffer-process bufname)))
     (if proc
         proc
-      (run-python (python-shell-parse-command))
-      (get-buffer-process bufname))))
+      (run-python
+       (if (get-buffer-process bufname)
+	   (get-buffer-process bufname)
+	 "")
+       (python-shell-parse-command)
+       )
+      )
+    )
+)
 
 (defun elpy-check ()
   "Run `python-check-command' on the current buffer's file."


### PR DESCRIPTION
So I was getting some pretty funny errors, and I decided to fix it. I thought that since it was a public package that I would share my fix. I don't know if you guys were getting the same errors, but mine was a show stopper.
