### PR TITLE
elpy.el: append elpy snippets to directory

### DIFF
--- a/elpy.el
+++ b/elpy.el
@@ -347,9 +347,10 @@ using (defalias 'elpy-initialize-variables 'identity)"
       (yas--trigger-key-reload old)))
 
   ;; We provide some YASnippet snippets. Add them.
-  (add-to-list 'yas-snippet-dirs
-               (concat (file-name-directory (locate-library "elpy"))
-                       "snippets/"))
+  (add-to-list
+   'yas-snippet-dirs
+   (concat (file-name-directory (locate-library "elpy")) "snippets/")
+   t)
 
   ;; Now load yasnippets.
   (yas-reload-all))


### PR DESCRIPTION
The documentation for yas-snippet-dirs specifies that it treats the
first directory specially as the default for storing new snippets. If
elpy grabs that spot by being initialised later then yasnippet will
keep bugging the user to save a new snippet file every time they edit
their own snippets. By appending the directory we ensure this can't
happen.
