### PR TITLE
send refactoring RPC requests args as lists

### DIFF
--- a/elpy-refactor.el
+++ b/elpy-refactor.el
@@ -264,17 +264,21 @@ The user can review the changes and confirm them with
   "Get a list of refactoring options from the Elpy RPC."
   (if (use-region-p)
       (elpy-rpc "get_refactor_options"
-                (elpy-project-root) (buffer-file-name)
-                (1- (region-beginning)) (1- (region-end)))
+                (list (elpy-project-root)
+                      (buffer-file-name)
+                      (1- (region-beginning))
+                      (1- (region-end))))
     (elpy-rpc "get_refactor_options"
-              (elpy-project-root) (buffer-file-name)
-              (1- (point)))))
+              (list (elpy-project-root)
+                    (buffer-file-name)
+                    (1- (point))))))
 
 (defun elpy-refactor-rpc-get-changes (method args)
   "Get a list of changes from the Elpy RPC after applying METHOD with ARGS."
   (elpy-rpc "refactor"
-            (elpy-project-root) (buffer-file-name)
-            method args))
+            (list (elpy-project-root)
+                  (buffer-file-name)
+                  method args)))
 
 (provide 'elpy-refactor)
 ;;; elpy-refactor.el ends here


### PR DESCRIPTION
The `params` of the request was being set to the first arg. Since this was a string (the project root path, specifically), the arguments to the server methods were being set to the list of characters in the path. This ultimatedly caused Emacs error messages like "`error in process filter: Invalid function 12345`" when trying to refactor.
