### PR TITLE
New defcustom: elpy-show-installation-instructions

### DIFF
--- a/elpy.el
+++ b/elpy.el
@@ -1416,7 +1416,7 @@ description."
 
 (defun elpy-flymake-show-error ()
   "Show the flymake error message at point."
-  (let* ((lineno (flymake-current-line-no))
+  (let* ((lineno (line-number-at-pos))
          (err-info (car (flymake-find-err-info flymake-err-info
                                                lineno)))
          (text (mapconcat #'flymake-ler-text


### PR DESCRIPTION
Prevents the _Elpy Installation_ buffer from popping up.

I've been using this for a few weeks and it's made my life nicer.
