### PR TITLE
ensure elpy--ac-document returns either nil or real documentation

### DIFF
--- a/elpy.el
+++ b/elpy.el
@@ -1493,7 +1493,12 @@ This uses `elpy--ac-cache'."
 
 (defun elpy--ac-document (name)
   "Return the documentation for the symbol NAME."
-  (assoc-default name elpy--ac-cache))
+  ;; popup.el silently chokes on empty strings and thus fails to properly
+  ;; create/destory a quick help popup, leaving blank lines behind
+  (let ((doc (assoc-default name elpy--ac-cache)))
+    (if (> (length doc) 0)
+        doc
+      nil)))
 
 (ac-define-source elpy
   '((init       . elpy--ac-init)


### PR DESCRIPTION
auto-complete.el shows a so called "quick help" to display documentation
for the symbol at point (after a certain time delay). To do this, it queries
the registered documentation function (here: elpy--ac-document) for a help
string and if it gets anything besides nil, it will create a new popup
through popup.el to display said help string. popup.el then in turn inserts a
dynamic amount of blank lines at the end of the buffer to make room for the
new popup and displays it. After the popup is no longer needed, auto-complete.el
deletes said popup again through popup.el which in turn also removes any
previously added blank lines.

Though if the documentation function (here: elpy--ac-document) returns an empty
string, popup.el silently chokes on it and still inserts those blank lines which
it later never removes. This is obviously a bug in popup.el.

Nevertheless, when there is no documentation available, nil should be returned
either way and not just an empty string.
