### PR TITLE
Add support for using projectile to find the project root, optionally

### DIFF
--- a/elpy.el
+++ b/elpy.el
@@ -1052,11 +1052,12 @@ creating one if necessary."
             default-directory project-root))
     (let ((proc (condition-case err
                     (let ((process-connection-type nil))
-                      (start-process "elpy-rpc"
-                                     new-elpy-rpc-buffer
-                                     python-command
-                                     "-W" "ignore"
-                                     "-m" "elpy.__main__"))
+                      (let ((default-directory project-root))
+                        (start-process "elpy-rpc"
+                                       new-elpy-rpc-buffer
+                                       python-command
+                                       "-W" "ignore"
+                                       "-m" "elpy.__main__")))
                   (error
                    (elpy-installation-instructions
                     (format "Could not start the Python subprocess: %s"


### PR DESCRIPTION
I ran into this when working on cpython itself; it turns out that the Lib directory doesn't have **init**.py in it.

So, given that projectile exists anyway, why not use it if it's available? Hence, this.

It should work fine without projectile enabled, as well.
