### PR TITLE
yas/minor-mode name fixed

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,4 @@ dist/
 build/
 .tox/
 elpy.egg-info/
+commit.txt

--- a/elpy.el
+++ b/elpy.el
@@ -98,7 +98,7 @@ native - Do not use any backend, use native Python methods only."
 (defcustom elpy-default-minor-modes '(eldoc-mode
                                       flymake-mode
                                       highlight-indentation-mode
-                                      yas-minor-mode
+                                      yas/minor-mode
                                       auto-complete-mode)
   "Minor modes enabled when `elpy-mode' is enabled."
   :group 'elpy)
@@ -525,7 +525,7 @@ It's not necessary to see (Python Elpy yas AC ElDoc) all the
 time. Honestly."
   (interactive)
   (setq eldoc-minor-mode-string nil)
-  (dolist (mode '(elpy-mode yas-minor-mode auto-complete-mode
+  (dolist (mode '(elpy-mode yas/minor-mode auto-complete-mode
                             flymake-mode))
     (setcdr (assq mode minor-mode-alist)
             (list ""))))

--- a/test/elpy-mode-test.el
+++ b/test/elpy-mode-test.el
@@ -74,6 +74,6 @@
     (elpy-clean-modeline)
     (dolist ((mode-display minor-mode-alist))
       (when (memq (car mode-display)
-                  '(elpy-mode yas-minor-mode auto-complete-mode flymake-mode))
+                  '(elpy-mode yas/minor-mode auto-complete-mode flymake-mode))
         (should (equal (cdr mode-display)
                        ""))))))


### PR DESCRIPTION
Backtrace was:

Debugger entered--Lisp error: (void-function yas-minor-mode)
  yas-minor-mode(1)
  run-hook-with-args(yas-minor-mode 1)
  (cond (elpy-mode (if buffer-file-name (progn (set (make-local-variable (quote ffip-project-root)) (elpy-project-root)))) (set (make-local-variable (quote eldoc-documentation-function)) (quote elpy-eldoc-documentation)) (add-to-list (quote ac-sources) (quote ac-source-elpy)) (add-to-list (quote ac-sources) (quote ac-source-elpy-dot)) (run-hook-with-args (quote elpy-default-minor-modes) 1)) (t (kill-local-variable (quote ffip-project-root)) (kill-local-variable (quote eldoc-documentation-function)) (setq ac-sources (delq (quote ac-source-elpy) (delq (quote ac-source-elpy-dot) ac-sources)))))
...
