### PR TITLE
Add "rename in superclass" and "replace in strings" option to rename

### DIFF
--- a/elpy/refactor.py
+++ b/elpy/refactor.py
@@ -234,12 +234,18 @@ class Refactor(object):
 
     @options("Rename symbol at point", category="Symbol",
              args=[("offset", "offset", None),
-                   ("new_name", "string", "Rename to: ")],
+                   ("new_name", "string", "Rename to: "),
+                   ("in_hierarchy", "boolean",
+                    "Rename in super-/subclasses as well? "),
+                   ("docs", "boolean",
+                    "Replace occurences in docs and strings? ")
+                   ],
              available=ROPE_AVAILABLE)
-    def refactor_rename_at_point(self, offset, new_name):
+    def refactor_rename_at_point(self, offset, new_name, in_hierarchy, docs):
         """Rename the symbol at point."""
         refactor = Rename(self.project, self.resource, offset)
-        changes = refactor.get_changes(new_name)
+        changes = refactor.get_changes(new_name, in_hierarchy=in_hierarchy,
+                                       docs=docs)
         return translate_changes(changes)
 
     @options("Rename current module", category="Module",


### PR DESCRIPTION
Rope supports renaming methods and members in the complete hierarchy.

For example, in the following

  class A(object):
    def foo(self): pass

  class A2(A):
    def foo(self): pass

We want to be able to rename A2's foo as well as A's foo at the same
time.

Rope supports this as "in_hierarchy" so add it to the rename dialog.

Also, rope allows to change occurences in strings and docstrings, let
the user choose whether he wants that as well.
