### PR TITLE
updated yasnippet variable 'text' to 'yas-text'

### DIFF
--- a/snippets/python-mode/__init__
+++ b/snippets/python-mode/__init__
@@ -7,4 +7,4 @@ def __init__(self${1:, args}):
     """$2
 
     """
-    ${1:$(elpy-snippet-init-assignments text)}
+    ${1:$(elpy-snippet-init-assignments yas-text)}

--- a/snippets/python-mode/__new__
+++ b/snippets/python-mode/__new__
@@ -7,4 +7,4 @@ def __new__(cls${1:, args}):
     """$2
 
     """
-    ${1:$(elpy-snippet-init-assignments text)}
+    ${1:$(elpy-snippet-init-assignments yas-text)}

--- a/snippets/python-mode/class
+++ b/snippets/python-mode/class
@@ -9,5 +9,5 @@ class ${1:ClassName}(${2:object}):
     """
     def __init__(self${4:, args}):
         super($1, self).__init__($5)
-        ${4:$(elpy-snippet-init-assignments text)}
+        ${4:$(elpy-snippet-init-assignments yas-text)}
         $0


### PR DESCRIPTION
Variable 'text' does not exist in yasnippet version 0.8.0. Use 'yas-text' instead, otherwise yasnippet gives below error:

`[yas] elisp error: Symbol's value as variable is void: text`
