### PR TITLE
Windows pythonpath compat

### DIFF
--- a/elpy.el
+++ b/elpy.el
@@ -2657,7 +2657,9 @@ This includes `elpy-rpc-pythonpath' in the PYTHONPATH, if set."
       process-environment
     (let* ((old-pythonpath (getenv "PYTHONPATH"))
            (new-pythonpath (if old-pythonpath
-                               (concat elpy-rpc-pythonpath ":" old-pythonpath)
+                               (concat elpy-rpc-pythonpath
+                                       path-separator
+                                       old-pythonpath)
                              elpy-rpc-pythonpath)))
       (cons (concat "PYTHONPATH=" new-pythonpath)
             process-environment))))


### PR DESCRIPTION
This came up in #379 and I had a shot at it.

0155caf snuck in here, but is otherwise unrelated to the issue at hand. Ok?

1ae2232 fixes the problem of path separator character specific to the OS.
