### PR TITLE
Test commands do not need quote escapes on Windows

### DIFF
--- a/elpy.el
+++ b/elpy.el
@@ -1827,8 +1827,11 @@ This uses the `elpy-test-runner-p' symbol property."
 
 (defun elpy-test-run (working-directory command &rest args)
   "Run COMMAND with ARGS in WORKING-DIRECTORY as a test command."
-  (let ((default-directory working-directory))
-    (compile (mapconcat #'shell-quote-argument
+  (let ((default-directory working-directory)
+        (quote-fun (if (eq system-type 'windows-nt)
+                       #'identity
+                     #'shell-quote-argument)))
+    (compile (mapconcat quote-fun
                         (cons command args)
                         " "))))
 

--- a/elpy.el
+++ b/elpy.el
@@ -1827,13 +1827,11 @@ This uses the `elpy-test-runner-p' symbol property."
 
 (defun elpy-test-run (working-directory command &rest args)
   "Run COMMAND with ARGS in WORKING-DIRECTORY as a test command."
-  (let ((default-directory working-directory)
-        (quote-fun (if (eq system-type 'windows-nt)
-                       #'identity
-                     #'shell-quote-argument)))
-    (compile (mapconcat quote-fun
-                        (cons command args)
-                        " "))))
+  (let ((default-directory working-directory))
+    (compile (concat command " "
+                     (if args
+                         (shell-quote-argument (car args))
+                       "")))))
 
 (defun elpy-test-discover-runner (top file module test)
   "Test the project using the python unittest discover runner.

--- a/test/elpy-test-run-test.el
+++ b/test/elpy-test-run-test.el
@@ -16,11 +16,22 @@
 
       (should (equal command "ls foo")))))
 
-(ert-deftest elpy-test-run-should-escape-arguments ()
+(ert-deftest elpy-test-run-should-escape-arguments-on-unix ()
   (elpy-testcase ()
     (mletf* ((command nil)
-             (compile (arg) (setq command arg)))
+             (compile (arg) (setq command arg))
+             (system-type 'gnu))
 
       (elpy-test-run "/" "ls" "foo bar")
 
       (should (equal command "ls foo\\ bar")))))
+
+(ert-deftest elpy-test-run-should-not-escape-arguments-on-windows ()
+  (elpy-testcase ()
+    (mletf* ((command nil)
+             (compile (arg) (setq command arg))
+             (system-type 'windows-nt))
+
+      (elpy-test-run "/" "ls" "foo bar")
+
+      (should (equal command "ls foo bar")))))

--- a/test/elpy-test-run-test.el
+++ b/test/elpy-test-run-test.el
@@ -16,7 +16,7 @@
 
       (should (equal command "ls foo")))))
 
-(ert-deftest elpy-test-run-should-escape-arguments-on-unix ()
+(ert-deftest elpy-test-run-should-escape-arguments ()
   (elpy-testcase ()
     (mletf* ((command nil)
              (compile (arg) (setq command arg))
@@ -25,13 +25,3 @@
       (elpy-test-run "/" "ls" "foo bar")
 
       (should (equal command "ls foo\\ bar")))))
-
-(ert-deftest elpy-test-run-should-not-escape-arguments-on-windows ()
-  (elpy-testcase ()
-    (mletf* ((command nil)
-             (compile (arg) (setq command arg))
-             (system-type 'windows-nt))
-
-      (elpy-test-run "/" "ls" "foo bar")
-
-      (should (equal command "ls foo bar")))))


### PR DESCRIPTION
Another one for Windows compatibility. In essence, on Windows we do not need to escape quotes in the test run command. Test commands started from elpy will fail.

My approach was to `let` bind the correct function depending on OS and leave the mapping in. For Windows the `identity` function is mapped.

The Travis CI results show that this does not work on Emacs version 24.3. Any ideas why it is just failing for that version?

Also, I was trying to add a test for this, but found no `test-quote-escape-in-test-run` or similar in the test suite. Also, I do not quite know how I would go about to test this function. Should we refactor the quote escape mapping to a separate function that just returns the test command string (so we can test it separately)?