### PR TITLE
Importmagic: wrap index building in a try-except

### DIFF
--- a/elpy/impmagic.py
+++ b/elpy/impmagic.py
@@ -19,22 +19,29 @@ class ImportMagic(object):
 
     def __init__(self):
         self.is_enabled = bool(importmagic)
+        # fail_message is reported to the user when symbol_index
+        # is (still) None
+        self.fail_message = "symbol index is not yet ready"
         self.project_root = None
         self.symbol_index = None
         self.favorites = set()
         self._thread = None
 
     def _build_symbol_index(self, project_root, custom_path, blacklist_re):
-        index = importmagic.index.SymbolIndex(blacklist_re=blacklist_re)
-        if os.environ.get('ELPY_TEST'):
-            # test suite support: do not index the whole PYTHONPATH, it
-            # takes much too long
-            index.build_index([])
-        elif custom_path:
-            index.build_index(custom_path)
+        try:
+            index = importmagic.index.SymbolIndex(blacklist_re=blacklist_re)
+            if os.environ.get('ELPY_TEST'):
+                # test suite support: do not index the whole PYTHONPATH, it
+                # takes much too long
+                index.build_index([])
+            elif custom_path:
+                index.build_index(custom_path)
+            else:
+                index.build_index([project_root] + sys.path)
+        except Exception as e:
+            self.fail_message = "symbol index failed to build: %s" % e
         else:
-            index.build_index([project_root] + sys.path)
-        self.symbol_index = index
+            self.symbol_index = index
 
     def build_index(self, project_root, custom_path=None, blacklist_re=None):
         self.project_root = None

--- a/elpy/server.py
+++ b/elpy/server.py
@@ -201,7 +201,7 @@ class ElpyRPCServer(JSONRPCServer):
             raise Fault("fixup_imports not enabled; install importmagic module",
                         code=400)
         if not self.import_magic.symbol_index:
-            raise Fault("symbol index is not yet ready", code=200)  # XXX code?
+            raise Fault(self.import_magic.fail_message, code=200)  # XXX code?
 
     def rpc_get_import_symbols(self, filename, source, symbol):
         """Return a list of modules from which the given symbol can be imported.


### PR DESCRIPTION
If an exception occurs, report it to the user instead of always
saying "symbol index not yet ready"

Part of #479