### PR TITLE
Docstring: show what exact object the docstring is for

### DIFF
--- a/elpy/jedibackend.py
+++ b/elpy/jedibackend.py
@@ -68,7 +68,8 @@ class JediBackend(object):
         except jedi.NotFoundError:
             return None
         if locations:
-            return locations[-1].docstring()
+            return ('Documentation for {0}:\n\n'.format(
+                locations[-1].full_name) + locations[-1].docstring())
         else:
             return None
 

--- a/elpy/tests/support.py
+++ b/elpy/tests/support.py
@@ -649,6 +649,14 @@ class RPCGetCalltipTests(GenericRPCTests):
 class RPCGetDocstringTests(GenericRPCTests):
     METHOD = "rpc_get_docstring"
 
+    def check_docstring(self, docstring):
+
+        def first_line(s):
+            return s[:s.index("\n")]
+
+        self.assertEqual(first_line(docstring),
+                         self.THREAD_JOIN_DOCSTRING)
+
     def test_should_get_docstring(self):
         source, offset = source_and_offset(
             "import threading\nthreading.Thread.join_|_(")
@@ -656,12 +664,7 @@ class RPCGetDocstringTests(GenericRPCTests):
         docstring = self.backend.rpc_get_docstring(filename,
                                                    source,
                                                    offset)
-
-        def first_line(s):
-            return s[:s.index("\n")]
-
-        self.assertEqual(first_line(docstring),
-                         self.THREAD_JOIN_DOCSTRING)
+        self.check_docstring(docstring)
 
     def test_should_return_none_for_bad_identifier(self):
         source, offset = source_and_offset(

--- a/elpy/tests/test_jedibackend.py
+++ b/elpy/tests/test_jedibackend.py
@@ -48,6 +48,11 @@ class TestRPCGetDocstring(RPCGetDocstringTests,
                           JediBackendTestCase):
     THREAD_JOIN_DOCSTRING = 'join(self, timeout = None)'
 
+    def check_docstring(self, docstring):
+        lines = docstring.splitlines()
+        self.assertEqual(lines[0], 'Documentation for threading.Thread.join:')
+        self.assertEqual(lines[2], self.THREAD_JOIN_DOCSTRING)
+
 
 class TestRPCGetDefinition(RPCGetDefinitionTests,
                            JediBackendTestCase):


### PR DESCRIPTION
Reasoning: the Jedi docstring usually only includes the function name without full qualification. (And for modules, not even that.)

If you're fine with this change, I'll adapt the tests.