### PR TITLE
Don't message "nil" when there is no error.

### DIFF
--- a/elpy.el
+++ b/elpy.el
@@ -3315,7 +3315,9 @@ description."
 (defun elpy-flymake-show-error ()
   "Show the flymake error message at point."
   (interactive)
-  (message "%s" (elpy-flymake-error-at-point)))
+  (let ((error-message (elpy-flymake-error-at-point)))
+    (when error-message
+      (message "%s" error-message))))
 
 (defun elpy-flymake-error-at-point ()
   "Return the flymake error at point, or nil if there is none."


### PR DESCRIPTION
Calling `elpy-flymake-next-error`, `elpy-flymake-previous-error`, or `elpy-flymake-show-error` when there is no errors in the buffer, produces the message "nil", which isn't very helpful. This patch silences it. Or maybe displaying a proper message would be better?