### PR TITLE
remove link to nonexistent documentation

### DIFF
--- a/elpy.el
+++ b/elpy.el
@@ -474,9 +474,6 @@ virtualenv using \\[pyvenv-workon], you can use
 \\[elpy-rpc-restart] to make the elpy Python process use your
 virtualenv.
 
-See https://github.com/jorgenschaefer/elpy/wiki/Keybindings for a
-more structured list.
-
 \\{elpy-mode-map}"
   :lighter " Elpy"
   (when (not (eq major-mode 'python-mode))


### PR DESCRIPTION
there is nothing at https://github.com/jorgenschaefer/elpy/wiki/Keybindings
and I don't see any other page with keybinding info; probably better to not
have a link than to have a broken link.