### PR TITLE
Include python-indent when moving region left/right

### DIFF
--- a/elpy.el
+++ b/elpy.el
@@ -1689,9 +1689,10 @@ indentation levels."
           (end (region-end)))
       (goto-char beg)
       (goto-char (point-at-bol))
-      (while (< (point) end)
+      (while (<= (point) end)
         (elpy--nav-move-line-left)
-        (forward-line 1)))
+        (forward-line 1)
+        (setq end (- end python-indent))))
     (setq deactivate-mark nil)))
 
 (defun elpy--nav-move-region-right ()
@@ -1700,8 +1701,9 @@ indentation levels."
           (end (region-end)))
       (goto-char beg)
       (goto-char (point-at-bol))
-      (while (< (point) end)
+      (while (<= (point) end)
         (elpy--nav-move-line-right)
+        (setq end (+ end python-indent))
         (forward-line 1)))
     (setq deactivate-mark nil)))
 


### PR DESCRIPTION
While moving a block left/right, empty space equivalent to
python-indent will be removed/added. So, it should be considered
while calculating effective end point of region.