### PR TITLE
Added support for autopep8

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -31,6 +31,7 @@ install:
       pip install rope_py3k ;
     fi
   - pip install importmagic
+  - pip install autopep8
   - pip install coveralls
 script:
   - nosetests

--- a/Makefile
+++ b/Makefile
@@ -36,7 +36,7 @@ elisp-coverage:
 
 python-test:
 	# python -Qwarnall -tt -W error -m unittest discover elpy
-	python -Qwarnall -tt -m unittest discover elpy
+	python -tt -m unittest discover elpy
 
 python-test-all:
 	tox

--- a/README.rst
+++ b/README.rst
@@ -29,8 +29,10 @@ First, install the required Python packages:::
   pip install jedi
   # flake8 for code checks
   pip install flake8
-  # and importmagic for automatic imports
+  # importmagic for automatic imports
   pip install importmagic
+  # and autopep8 for automatic PEP8 formatting
+  pip install autopep8
 
 
 Evaluate this in your ``*scratch*`` buffer:

--- a/elpy-refactor.el
+++ b/elpy-refactor.el
@@ -281,5 +281,17 @@ The user can review the changes and confirm them with
             (list (buffer-file-name)
                   method args)))
 
+(defun elpy-refactor-options (option)
+  "Show available refactor options and let user choose one."
+  (interactive "c[i]: importmagic-fixup [p]: autopep8-fix-code [r]: refactor")
+  (let ((choice (char-to-string option)))
+    (cond
+     ((string-equal choice "i")
+      (elpy-importmagic-fixup))
+     ((string-equal choice "p")
+      (elpy-autopep8-fix-code))
+     ((string-equal choice "r")
+      (elpy-refactor)))))
+
 (provide 'elpy-refactor)
 ;;; elpy-refactor.el ends here

--- a/elpy.el
+++ b/elpy.el
@@ -314,21 +314,22 @@ edited instead. Setting this variable to nil disables this feature."
     ;; (define-key map (kbd "C-M-x")   'python-shell-send-defun)
     ;; (define-key map (kbd "C-c <")   'python-indent-shift-left)
     ;; (define-key map (kbd "C-c >")   'python-indent-shift-right)
+    (define-key map (kbd "C-c RET") 'elpy-importmagic-add-import)
     (define-key map (kbd "C-c C-b") 'elpy-nav-expand-to-indentation)
     (define-key map (kbd "C-c C-c") 'elpy-shell-send-region-or-buffer)
     (define-key map (kbd "C-c C-d") 'elpy-doc)
     (define-key map (kbd "C-c C-e") 'elpy-multiedit-python-symbol-at-point)
     (define-key map (kbd "C-c C-f") 'elpy-find-file)
-    (define-key map (kbd "C-c RET") 'elpy-importmagic-add-import)
-    (define-key map (kbd "C-c <S-return>") 'elpy-importmagic-fixup)
     (define-key map (kbd "C-c C-n") 'elpy-flymake-next-error)
     (define-key map (kbd "C-c C-o") 'elpy-occur-definitions)
     (define-key map (kbd "C-c C-p") 'elpy-flymake-previous-error)
-    (define-key map (kbd "C-c C-r") 'elpy-refactor)
     (define-key map (kbd "C-c C-s") 'elpy-rgrep-symbol)
     (define-key map (kbd "C-c C-t") 'elpy-test)
     (define-key map (kbd "C-c C-v") 'elpy-check)
     (define-key map (kbd "C-c C-z") 'elpy-shell-switch-to-shell)
+    (define-key map (kbd "C-c C-r i") 'elpy-importmagic-fixup)
+    (define-key map (kbd "C-c C-r p") 'elpy-autopep8-fix-code)
+    (define-key map (kbd "C-c C-r r") 'elpy-refactor)
 
     (define-key map (kbd "<S-return>") 'elpy-open-and-indent-line-below)
     (define-key map (kbd "<C-S-return>") 'elpy-open-and-indent-line-above)
@@ -553,6 +554,14 @@ try:
 except:
     config['importmagic_version'] = None
     config['importmagic_latest'] = latest('importmagic')
+
+try:
+    import autopep8
+    config['autopep8_version'] = autopep8.__version__
+    config['autopep8_latest'] = latest('autopep8', config['autopep8_version'])
+except:
+    config['autopep8_version'] = None
+    config['autopep8_latest'] = latest('autopep8')
 
 json.dump(config, sys.stdout)
 ")
@@ -787,6 +796,26 @@ item in another window.\n\n")
                      :package "importmagic" :upgrade t)
       (insert "\n\n"))
 
+    ;; No autopep8 available
+    (when (not (gethash "autopep8_version" config))
+      (elpy-insert--para
+       "The autopep8 package is not available. Commands using this will "
+       "not work.\n")
+      (insert "\n")
+      (widget-create 'elpy-insert--pip-button
+                     :package "autopep8")
+      (insert "\n\n"))
+
+    ;; Newer version of autopep8 available
+    (when (and (gethash "autopep8_version" config)
+               (gethash "autopep8_latest" config))
+      (elpy-insert--para
+       "There is a newer version of the autopep8 package available.\n")
+      (insert "\n")
+      (widget-create 'elpy-insert--pip-button
+                     :package "autopep8" :upgrade t)
+      (insert "\n\n"))
+
     ;; flake8, the default syntax checker, not found
     (when (not (executable-find python-check-command))
       (elpy-insert--para
@@ -875,6 +904,8 @@ virtual_env_short"
         (rope-latest (gethash "rope_latest" config))
         (importmagic-version (gethash "importmagic_version" config))
         (importmagic-latest (gethash "importmagic_latest" config))
+        (autopep8-version (gethash "importmagic_version" config))
+        (autopep8-latest (gethash "importmagic_latest" config))
         (virtual-env (gethash "virtual_env" config))
         (virtual-env-short (gethash "virtual_env_short" config))
         table maxwidth)
@@ -926,6 +957,9 @@ virtual_env_short"
             ("Importmagic" . ,(elpy-config--package-link "importmagic"
                                                          importmagic-version
                                                          importmagic-latest))
+            ("Autopep8" . ,(elpy-config--package-link "autopep8"
+                                                         autopep8-version
+                                                         autopep8-latest))
             ("Syntax checker" . ,(let ((syntax-checker
                                         (executable-find
                                          python-check-command)))
@@ -1970,10 +2004,10 @@ prefix argument is given, prompt for a symbol from the user."
         nil))))
 
 ;;;;;;;;;;;;;;
-;;; Import manipulation
+;;; Buffer manipulation
 
-(defun elpy-importmagic--replace-block (spec)
-  "Replace an imports block. SPEC is (startline endline newblock)."
+(defun elpy-buffer--replace-block (spec)
+  "Replace a block.  SPEC is (startline endline newblock)."
   (let ((start-line (nth 0 spec))
         (end-line (nth 1 spec))
         (new-block (nth 2 spec)))
@@ -1988,6 +2022,18 @@ prefix argument is given, prompt for a symbol from the user."
           (unless (string-equal (buffer-substring beg end) new-block)
             (delete-region beg end)
             (insert new-block)))))))
+
+(defun elpy-buffer--replace-region (beg end rep)
+  "Replace text in BUFFER in region (BEG END) with REP."
+  (unless (string-equal (buffer-substring beg end) rep)
+    (save-excursion
+      (goto-char end)
+      (insert rep)
+      (delete-region beg end))))
+
+
+;;;;;;;;;;;;;;
+;;; Import manipulation
 
 (defun elpy-importmagic--add-import-read-args (&optional object prompt)
   (let* ((default-object (save-excursion
@@ -2019,7 +2065,7 @@ prefix argument is given, prompt for a symbol from the user."
     (let* ((res (elpy-rpc "add_import" (list buffer-file-name
                                              (elpy-rpc--buffer-contents)
                                              statement))))
-      (elpy-importmagic--replace-block res))))
+      (elpy-buffer--replace-block res))))
 
 (defun elpy-importmagic-fixup ()
   "Query for new imports of unresolved symbols, and remove unreferenced imports.
@@ -2039,7 +2085,7 @@ Also sort the imports in the import statement blocks."
   (let* ((res (elpy-rpc "remove_unreferenced_imports" (list buffer-file-name
                                                             (elpy-rpc--buffer-contents)))))
     (unless (stringp res)
-      (elpy-importmagic--replace-block res))))
+      (elpy-buffer--replace-block res))))
 
 ;;;;;;;;;;;;;;
 ;;; Multi-Edit
@@ -2797,6 +2843,11 @@ protocol if the buffer is larger than
       `((filename . ,file-name)
         (delete_after_use . t)))))
 
+(defun elpy-rpc--region-contents ()
+  "Return the selected region as a string."
+  (if (use-region-p)
+      (buffer-substring (region-beginning) (region-end))))
+
 ;; RPC API functions
 
 (defun elpy-rpc-restart ()
@@ -3333,6 +3384,20 @@ description."
     (`buffer-stop
      (yas-minor-mode -1))))
 
+;;;;;;;;;;;;;;;;;;
+;;; Module: autopep8
+
+(defun elpy-autopep8-fix-code ()
+  "Automatically formats Python code to conform to the PEP 8 style guide."
+  (interactive)
+  (if (use-region-p)
+    (let ((new-block (elpy-rpc "fix_code" (list (elpy-rpc--region-contents))))
+          (beg (region-beginning)) (end (region-end)))
+      (elpy-buffer--replace-region beg end new-block))
+    (let ((new-block (elpy-rpc "fix_code" (list (elpy-rpc--buffer-contents))))
+          (beg (point-min)) (end (point-max)))
+      (elpy-buffer--replace-region beg end new-block))))
+
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;;; Backwards compatibility
 
@@ -3437,6 +3502,7 @@ which we're looking."
      ((and (<= on-or-off 0)
            highlight-indent-active)
       (highlight-indentation)))))
+
 
 (provide 'elpy)
 ;;; elpy.el ends here

--- a/elpy/auto_pep8.py
+++ b/elpy/auto_pep8.py
@@ -1,0 +1,14 @@
+"""Glue for the "autopep8" library.
+
+"""
+try:
+    import autopep8
+except ImportError:  # pragma: no cover
+    autopep8 = None
+
+
+def fix_code(code):
+    """Formats Python code to conform to the PEP 8 style guide.
+
+    """
+    return autopep8.fix_code(code)

--- a/elpy/server.py
+++ b/elpy/server.py
@@ -12,6 +12,7 @@ import pydoc
 from elpy.pydocutils import get_pydoc_completions
 from elpy.rpc import JSONRPCServer, Fault
 from elpy.impmagic import ImportMagic
+from elpy.auto_pep8 import fix_code
 
 
 try:
@@ -233,6 +234,13 @@ class ElpyRPCServer(JSONRPCServer):
         self._ensure_import_magic()
         source = get_source(source)
         return self.import_magic.remove_unreferenced_imports(source)
+
+    def rpc_fix_code(self, source):
+        """Formats Python code to conform to the PEP 8 style guide.
+
+        """
+        source = get_source(source)
+        return fix_code(source)
 
 
 def get_source(fileobj):

--- a/elpy/tests/test_auto_pep8.py
+++ b/elpy/tests/test_auto_pep8.py
@@ -1,0 +1,20 @@
+# coding: utf-8
+
+"""Tests for the elpy.autopep8 module"""
+
+import unittest
+
+from elpy import auto_pep8
+from elpy.tests.support import BackendTestCase
+
+
+class Autopep8TestCase(BackendTestCase):
+
+    def setUp(self):
+        if not auto_pep8.autopep8:
+            raise unittest.SkipTest
+
+    def test_fix_code(self):
+        code_block = 'x=       123\n'
+        new_block = auto_pep8.fix_code(code_block)
+        self.assertEqual(new_block, 'x = 123\n')

--- a/elpy/tests/test_server.py
+++ b/elpy/tests/test_server.py
@@ -411,3 +411,11 @@ class TestPysymbolKey(BackendTestCase):
 
     def test_should_sort_dunder_symbols_after_public_symbols(self):
         self.keyLess("bar", "__foo")
+
+
+class Autopep8TestCase(ServerTestCase):
+
+    def test_rpc_fix_code_should_return_formatted_string(self):
+        code_block = 'x=       123\n'
+        new_block = self.srv.rpc_fix_code(code_block)
+        self.assertEqual(new_block, 'x = 123\n')

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,3 +2,4 @@ flake8==2.4.1
 jedi==0.9.0
 rope==0.10.2
 importmagic==0.1.3
+autopep8==1.1.1

--- a/test/elpy-buffer--replace-block-test.el
+++ b/test/elpy-buffer--replace-block-test.el
@@ -1,5 +1,5 @@
-(ert-deftest elpy-importmagic--replace-block-basic-functionality ()
+(ert-deftest elpy-buffer--replace-block-basic-functionality ()
   (elpy-testcase ()
     (insert "line 1\nline 2\nline 3\nline 4\nline 5\n")
-    (elpy-importmagic--replace-block '(1 3 "new\nblock\n"))
+    (elpy-buffer--replace-block '(1 3 "new\nblock\n"))
     (should (equal (buffer-string) "line 1\nnew\nblock\nline 4\nline 5\n"))))


### PR DESCRIPTION
Automatically format code to PEP8 style using autopep8.
If a region is selected format only that region else format entire buffer.
