### PR TITLE
Retain point when expanding to indentation

### DIFF
--- a/elpy.el
+++ b/elpy.el
@@ -431,7 +431,8 @@ edited instead. Setting this variable to nil disables this feature."
                      "Emacs 24 and above"))))
   (elpy-modules-global-init)
   (define-key inferior-python-mode-map (kbd "C-c C-z") 'elpy-shell-switch-to-buffer)
-  (add-hook 'python-mode-hook 'elpy-mode))
+  (add-hook 'python-mode-hook 'elpy-mode)
+  (add-hook 'post-command-hook 'elpy-nav--restore-initial-position))
 
 (defun elpy-disable ()
   "Disable Elpy in all future Python buffers."
@@ -1585,6 +1586,10 @@ with a prefix argument)."
 ;;;;;;;;;;;;;;
 ;;; Navigation
 
+(defvar elpy-nav-expand--initial-position nil
+  "Initial position before expanding to indentation.")
+(make-variable-buffer-local 'elpy-nav-expand--initial-position)
+
 (defun elpy-goto-definition ()
   "Go to the definition of the symbol at point, if found."
   (interactive)
@@ -1729,9 +1734,14 @@ indentation levels."
     (insert "\n"))
   (indent-according-to-mode))
 
+(defun elpy-nav--restore-initial-position ()
+  (when (eq this-command 'keyboard-quit)
+    (goto-char elpy-nav-expand--initial-pos)))
+
 (defun elpy-nav-expand-to-indentation ()
   "Select surrounding lines with current indentation."
   (interactive)
+  (setq elpy-nav-expand--initial-position (point))
   (let ((indentation (current-indentation)))
     (while (<= indentation (current-indentation))
       (forward-line -1))

--- a/test/elpy-nav-expand-to-indentation-test.el
+++ b/test/elpy-nav-expand-to-indentation-test.el
@@ -10,3 +10,19 @@
                  (should (= (region-beginning) 12))
                  (should (= (region-end) 38))))
 
+
+(ert-deftest elpy-nav-expand-to-indentation-should-restore-original-position-on-quit ()
+  (elpy-testcase ()
+                 (set-buffer-string-with-point
+                  "def foo():"
+                  "    if _|_True:"
+                  "        x = 1"
+                  )
+                 (elpy-nav-expand-to-indentation)
+                 (keyboard-quit)
+                 (should
+                  (buffer-be
+                   "def foo():"
+                   "    if _|_True:"
+                   "        x = 1"
+                   ))))


### PR DESCRIPTION
After executing `expand-to-indentation`, if `C-g` is pressed, point
should return to original position

Test is failing, don't know how to  handle `keyboard-quit`.