### PR TITLE
fixed elpy-goto-location: find-file returns nil on 24.5.1

### DIFF
--- a/elpy.el
+++ b/elpy.el
@@ -1610,7 +1610,8 @@ with a prefix argument)."
 (defun elpy-goto-location (filename offset)
   "Show FILENAME at OFFSET to the user."
   (ring-insert find-tag-marker-ring (point-marker))
-  (let ((buffer (find-file filename)))
+  (find-file filename)
+  (let ((buffer (get-file-buffer filename)))
     (with-current-buffer buffer
       (with-selected-window (get-buffer-window buffer)
         (goto-char (1+ offset))


### PR DESCRIPTION
- OS: ubuntu 14.04 LTS 64bit
- Emacs Version: 24.5.1
- Elpy installed from latest source

Every time I invoke `elpy-goto-definition`, emacs gave me error `save-current-buffer: Wrong type argument: stringp, nil`. Using edebug I find it's because ` find-file` returns nil. 

