### PR TITLE
support yapf as another formatter

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,4 @@ build/
 .tox/
 elpy.egg-info/
 _build
+.cache

--- a/.travis.yml
+++ b/.travis.yml
@@ -30,6 +30,7 @@ install:
     fi
   - pip install importmagic
   - pip install autopep8
+  - pip install yapf
   - pip install coveralls
 script:
   - nosetests

--- a/README.rst
+++ b/README.rst
@@ -33,6 +33,8 @@ First, install the required Python packages:::
   pip install importmagic
   # and autopep8 for automatic PEP8 formatting
   pip install autopep8
+  # and yapf for code formatting
+  pip install yapf
 
 
 Evaluate this in your ``*scratch*`` buffer:

--- a/elpy/server.py
+++ b/elpy/server.py
@@ -13,6 +13,7 @@ from elpy.pydocutils import get_pydoc_completions
 from elpy.rpc import JSONRPCServer, Fault
 from elpy.impmagic import ImportMagic, ImportMagicError
 from elpy.auto_pep8 import fix_code
+from elpy.yapfutil import fix_code as fix_code_with_yapf
 
 
 try:
@@ -253,6 +254,13 @@ class ElpyRPCServer(JSONRPCServer):
         """
         source = get_source(source)
         return fix_code(source)
+
+    def rpc_fix_code_with_yapf(self, source):
+        """Formats Python code to conform to the PEP 8 style guide.
+
+        """
+        source = get_source(source)
+        return fix_code_with_yapf(source)
 
 
 def get_source(fileobj):

--- a/elpy/tests/test_yapf.py
+++ b/elpy/tests/test_yapf.py
@@ -1,0 +1,28 @@
+# coding: utf-8
+"""Tests for the elpy.yapf module"""
+
+import sys
+import unittest
+
+from elpy import yapfutil
+from elpy.tests.support import BackendTestCase
+
+
+@unittest.skipIf(yapfutil.YAPF_NOT_SUPPORTED,
+                 'yapf not supported for current python version')
+class YAPFTestCase(BackendTestCase):
+    def setUp(self):
+        if not yapfutil.YAPF_NOT_SUPPORTED:
+            raise unittest.SkipTest
+
+    def test_fix_code(self):
+        testdata = [
+            ('x=       123\n', 'x = 123\n'),
+            ('x=1; \ny=2 \n', 'x = 1\ny = 2\n'),
+        ]
+        for src, expected in testdata:
+            self._assert_format(src, expected)
+
+    def _assert_format(self, src, expected):
+        new_block = yapfutil.fix_code(src)
+        self.assertEqual(new_block, expected)

--- a/elpy/yapfutil.py
+++ b/elpy/yapfutil.py
@@ -1,0 +1,33 @@
+"""Glue for the "yapf" library.
+
+"""
+
+import os
+import sys
+from elpy.rpc import Fault
+
+YAPF_NOT_SUPPORTED = sys.version_info < (2, 7) or (
+    sys.version_info >= (3, 0) and sys.version_info <= (3, 3))
+
+try:
+    if YAPF_NOT_SUPPORTED:
+        yapf_api = None
+    else:
+        from yapf.yapflib import yapf_api
+        from yapf.yapflib import file_resources
+except ImportError:  # pragma: no cover
+    yapf_api = None
+
+
+def fix_code(code):
+    """Formats Python code to conform to the PEP 8 style guide.
+
+    """
+    if not yapf_api:
+        raise Fault('yapf not installed', code=400)
+    style_config = file_resources.GetDefaultStyleForDir(os.getcwd())
+    reformatted_source, _ = yapf_api.FormatCode(code,
+                                                filename='<stdin>',
+                                                style_config=style_config,
+                                                verify=False)
+    return reformatted_source

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,3 +3,4 @@ jedi==0.9.0
 rope==0.10.2
 importmagic==0.1.3
 autopep8==1.2.1
+yapf==0.6.2

--- a/test/elpy-yapf-fix-code-test.el
+++ b/test/elpy-yapf-fix-code-test.el
@@ -1,0 +1,17 @@
+(ert-deftest elpy-yapf-fix-code-should-retain-line-and-column ()
+  (let* ((pyversion (getenv "TRAVIS_PYTHON_VERSION"))
+         (yapf-not-supported (or (string< pyversion "2.7")
+                                 (and (not (string< pyversion "3.0"))
+                                      (string< pyversion "3.4")))))
+    (unless yapf-not-supported
+      (elpy-testcase ()
+                     (set-buffer-string-with-point
+                      "x  =  1"
+                      "y = 2_|_"
+                      )
+
+                     (elpy-yapf-fix-code)
+                     (should
+                      (buffer-be
+                       "x = 1"
+                       "y = 2_|_"))))))


### PR DESCRIPTION
[YAPF](https://github.com/google/yapf) is a more advanced python code formatter/pretty-printer than pep8. It works by first parsing the code into an AST, and then re-generating the source code by walking the tree, doing pretty print with the specified style config along the way.

In contrast, autopep8 only handles the part of the code that's inconsistent with PEP8.