### PR TITLE
Include yapf in elpy config

### DIFF
--- a/docs/ide.rst
+++ b/docs/ide.rst
@@ -325,22 +325,24 @@ Elpy supports various forms of refactoring Python code.
    occurrences of the text in the region.
 
 
+.. command:: elpy-format-code
+   :kbd: C-c C-r f
+
+   Format code using the available formatter.
+
+   This command formats code using `yapf`_ or `autopep8`_ formatter. If a
+   region is selected, only that region is formatted. Otherwise current
+   buffer is formatted.
+
+.. _autopep8: https://github.com/hhatto/autopep8
+.. _yapf: https://github.com/google/yapf
+
 .. command:: elpy-importmagic-fixup
    :kbd: C-c C-r i
 
    Query for new imports of unresolved symbols, and remove unreferenced
    imports. Also sort the imports in the import statement blocks.
 
-.. command:: elpy-autopep8-fix-code
-   :kbd: C-c C-r p
-
-   Automatically formats Python code to conform to the PEP 8 style guide.
-
-   This command uses `autopep8`_ package to format the code. If a region
-   is selected, only that region is formatted. Otherwise current buffer is
-   formatted.
-
-.. _autopep8: https://github.com/hhatto/autopep8
 
 
 .. command:: elpy-refactor
@@ -352,4 +354,3 @@ Elpy supports various forms of refactoring Python code.
    options depending on the context.
 
 .. _rope: https://github.com/python-rope/rope
-

--- a/elpy.el
+++ b/elpy.el
@@ -337,7 +337,7 @@ edited instead. Setting this variable to nil disables this feature."
     (define-key map (kbd "C-c C-v") 'elpy-check)
     (define-key map (kbd "C-c C-z") 'elpy-shell-switch-to-shell)
     (define-key map (kbd "C-c C-r i") 'elpy-importmagic-fixup)
-    (define-key map (kbd "C-c C-r p") 'elpy-autopep8-fix-code)
+    (define-key map (kbd "C-c C-r f") 'elpy-format-code)
     (define-key map (kbd "C-c C-r r") 'elpy-refactor)
 
     (define-key map (kbd "<S-return>") 'elpy-open-and-indent-line-below)
@@ -3516,6 +3516,17 @@ description."
         (elpy-buffer--replace-region beg end new-block)))
     (forward-line (1- line))
     (forward-char col)))
+
+(defun elpy-format-code ()
+  "Format code using the available formatter."
+  (interactive)
+  (cond
+   ((executable-find "yapf")
+    (elpy-yapf-fix-code))
+   ((executable-find "autopep8")
+    (elpy-autopep8-fix-code))
+   (t
+    (message "Install yapf/autopep8 to format code."))))
 
 ;;;;;;;;;;;;;;;;;;
 ;;; Module: autopep8

--- a/elpy.el
+++ b/elpy.el
@@ -573,6 +573,14 @@ except:
     config['autopep8_version'] = None
     config['autopep8_latest'] = latest('autopep8')
 
+try:
+    import yapf
+    config['yapf_version'] = yapf.__version__
+    config['yapf_latest'] = latest('yapf', config['yapf_version'])
+except:
+    config['yapf_version'] = None
+    config['yapf_latest'] = latest('yapf')
+
 json.dump(config, sys.stdout)
 ")
 
@@ -826,6 +834,26 @@ item in another window.\n\n")
                      :package "autopep8" :upgrade t)
       (insert "\n\n"))
 
+    ;; No yapf available
+    (when (not (gethash "yapf_version" config))
+      (elpy-insert--para
+       "The yapf package is not available. Commands using this will "
+       "not work.\n")
+      (insert "\n")
+      (widget-create 'elpy-insert--pip-button
+                     :package "yapf")
+      (insert "\n\n"))
+
+    ;; Newer version of yapf available
+    (when (and (gethash "yapf_version" config)
+               (gethash "yapf_latest" config))
+      (elpy-insert--para
+       "There is a newer version of the yapf package available.\n")
+      (insert "\n")
+      (widget-create 'elpy-insert--pip-button
+                     :package "yapf" :upgrade t)
+      (insert "\n\n"))
+
     ;; flake8, the default syntax checker, not found
     (when (not (executable-find python-check-command))
       (elpy-insert--para
@@ -916,6 +944,8 @@ virtual_env_short"
         (importmagic-latest (gethash "importmagic_latest" config))
         (autopep8-version (gethash "autopep8_version" config))
         (autopep8-latest (gethash "autopep8_latest" config))
+        (yapf-version (gethash "yapf_version" config))
+        (yapf-latest (gethash "yapf_latest" config))
         (virtual-env (gethash "virtual_env" config))
         (virtual-env-short (gethash "virtual_env_short" config))
         table maxwidth)
@@ -970,6 +1000,9 @@ virtual_env_short"
             ("Autopep8" . ,(elpy-config--package-link "autopep8"
                                                       autopep8-version
                                                       autopep8-latest))
+            ("Yapf" . ,(elpy-config--package-link "yapf"
+                                                  yapf-version
+                                                  yapf-latest))
             ("Syntax checker" . ,(let ((syntax-checker
                                         (executable-find
                                          python-check-command)))


### PR DESCRIPTION
Added yapf to elpy config.
Key binding(`C-c C-r y`) to call yapf formatter.