### PR TITLE
Fixed a bug (on my end) removing incorrect args

### DIFF
--- a/elpy.el
+++ b/elpy.el
@@ -1565,8 +1565,15 @@ code is executed."
          (proc (get-buffer-process bufname)))
     (if proc
         proc
-      (run-python (python-shell-parse-command))
-      (get-buffer-process bufname))))
+      (run-python
+       (if (get-buffer-process bufname)
+	   (get-buffer-process bufname)
+	 "")
+       (python-shell-parse-command)
+       )
+      )
+    )
+)
 
 (defun elpy-shell--region-without-indentation (beg end)
   "Return the current region as a string, but without indentation."


### PR DESCRIPTION
The run-python command was shorting out. I fixed this some time ago,
but never took the time to share it with the community. Here it is; it worked
on my end when I used it, but someone please do a checkout and test, because
I hate having "it runs on my box" issues, and I would be sorely pissed at myself
if I ruined anybody else's experience causing unnecessary complications. 
Maybe it's small, but hopefully it helps :D