### PR TITLE
Add goto-definition function with grep fallback

### DIFF
--- a/elpy.el
+++ b/elpy.el
@@ -1647,6 +1647,16 @@ with a prefix argument)."
         (elpy-goto-location (car location) (cadr location))
       (error "No definition found"))))
 
+(defun elpy-goto-definition-or-rgrep ()
+  "Go to the definition of the symbol at point, if found. Otherwise, run `elpy-rgrep-symbol'.
+
+This first tries `elpy-goto-definition' on the symbol. If it fails to find the definition
+it passes the symbol, wrapped in a regexp for class/function definitions, off to `elpy-rgrep-symbol'"
+    (interactive)
+    (condition-case nil (elpy-goto-definition)
+        (error (elpy-rgrep-symbol
+                   (concat "\\(def\\|class\\)\s" (thing-at-point 'symbol) "(")))))
+
 (defun elpy-goto-location (filename offset)
   "Show FILENAME at OFFSET to the user."
   (ring-insert find-tag-marker-ring (point-marker))


### PR DESCRIPTION
I found myself always calling `elpy-goto-definition`, and if it failed calling `elpy-rgrep-symbol` on the same symbol. To speed this process up a little bit, I wrote my own function that will try to run `elpy-goto-definition`, but will run `elpy-rgrep-symbol` on the symbol at point if the former function fails to find the definition. 

I am not sure if this belongs in Elpy, but it has been very useful for me, so I figured a pull request wouldn't hurt. I have bound it to `M-.`, but I didn't want to make that decision for the user, so I didn't add a default binding. Also, I am VERY new to elisp, so I would appreciate any feedback if something here is done in a problematic or non-idiomatic way. Thank you! 
