### PR TITLE
elpy.el: fix compiler warning

### DIFF
--- a/elpy.el
+++ b/elpy.el
@@ -514,8 +514,8 @@ virtualenv.
   (with-current-buffer (get-buffer-create "*Elpy News*")
     (let ((inhibit-read-only t))
       (erase-buffer)
-      (insert-file (concat (file-name-directory (locate-library "elpy"))
-                           "NEWS.rst"))
+      (insert-file-contents (concat (file-name-directory (locate-library "elpy"))
+                                    "NEWS.rst"))
       (help-mode))
     (pop-to-buffer (current-buffer))))
 


### PR DESCRIPTION
When compiling elpy.el the byte compilers complains that insert-file is
intended for interactive use and insert-file-contents should be used
instead. As the function seems to have existed forever it seems pretty
safe to use.