### PR TITLE
Use "python -m pip" to install python modules instead of "pip".

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,6 @@
 language: python
 sudo: no
 python:
-  - 2.6
   - 2.7
   - 3.3
   - 3.4

--- a/elpy.el
+++ b/elpy.el
@@ -1130,9 +1130,10 @@ PyPI, or nil if that's VERSION."
                         ""))
 
          (command (cond
-                   ((executable-find "pip")
-                    (format "pip install %s%s%s"
-                            user-option upgrade-option python-package))
+                    ((= (call-process elpy-rpc-python-command
+                          nil nil nil "-m" "pip" "--help") 0)
+                      (format "%s -m pip install %s%s%s" elpy-rpc-python-command
+                        user-option upgrade-option python-package))
                    ((executable-find "easy_install")
                     (format "easy_install %s%s"
                             user-option python-package))

--- a/test/elpy-insert--pip-button-value-create-test.el
+++ b/test/elpy-insert--pip-button-value-create-test.el
@@ -12,8 +12,11 @@
     (mletf* ((executable-find
               (command)
               (cond
-                ((equal command "pip") t)
                 ((equal command "easy_install") t)))
+             (call-process
+              (program &optional infile destination display &rest args)
+               (when (and (equal program "python") (equal args '("-m" "pip"))))
+               0)
              (widget (widget-create 'elpy-insert--pip-button "test-module")))
       (should (string-match "pip" (widget-get widget :command)))
       (should (string-match "pip" (buffer-string))))))
@@ -23,8 +26,11 @@
     (mletf* ((executable-find
               (command)
               (cond
-                ((equal command "pip") nil)
                 ((equal command "easy_install") t)))
+             (call-process
+              (program &optional infile destination display &rest args)
+               (when (and (equal program "python") (equal args '("-m" "pip"))))
+               1)
              (widget (widget-create 'elpy-insert--pip-button "test-module")))
       (should (string-match "easy_install" (widget-get widget :command)))
       (should (string-match "easy_install" (buffer-string))))))
@@ -33,5 +39,9 @@
   (elpy-testcase ()
     (mletf* ((executable-find
               (command)
-              nil))
+               nil)
+             (call-process
+              (program &optional infile destination display &rest args)
+               (when (and (equal program "python") (equal args '("-m" "pip"))))
+               1))
       (should-error (widget-create 'elpy-insert--pip-button "test-module")))))


### PR DESCRIPTION
Currently "pip" is used to install missing modules in "elpy-config".
However, this may call the wrong version of pip, e.g. python3 often has
a pip executable "pip3" instead of "pip". This commit uses "python -m
pip" to call pip instead of the pip executable.