### PR TITLE
Fix dedicated shells support 

### DIFF
--- a/elpy.el
+++ b/elpy.el
@@ -153,6 +153,15 @@ uninteresting information, but if you rely on your modeline in other modes,
 you might want to keep it."
   :type 'boolean
   :group 'elpy)
+  
+(defcustom elpy-dedicated-shells nil
+  "Non-nil if Elpy should use dedicated shells.
+
+Elpy can use a unique python shell for all buffers and support
+manually started dedicated shells. Setting this option to non-nil
+force the creation of dedicated shells for each buffers."
+  :type 'boolean
+  :group 'elpy)
 
 (defcustom elpy-rpc-backend nil
   "Your preferred backend.
@@ -1604,11 +1613,20 @@ code is executed."
 (defun elpy-shell-get-or-create-process ()
   "Get or create an inferior Python process for current buffer and return it."
   (let* ((bufname (format "*%s*" (python-shell-get-process-name nil)))
-         (proc (get-buffer-process bufname)))
-    (if proc
-        proc
-      (run-python (python-shell-parse-command))
-      (get-buffer-process bufname))))
+	 (dedbufname (format "*%s*" (python-shell-get-process-name t)))
+	 (proc (get-buffer-process bufname))
+	 (dedproc (get-buffer-process dedbufname)))
+    (if elpy-dedicated-shells
+	(if dedproc
+	    dedproc
+	  (run-python (python-shell-parse-command) t)
+	  (get-buffer-process dedbufname))
+      (if dedproc
+	  dedproc
+	(if proc
+	    proc
+	  (run-python (python-shell-parse-command))
+	  (get-buffer-process bufname))))))
 
 (defun elpy-shell--region-without-indentation (beg end)
   "Return the current region as a string, but without indentation."


### PR DESCRIPTION
I use a lot of dedicated shells and I had some troubles with that (c.f. issue #690).
I modified `elpy-shell-get-or-create-process` so that `elpy-shell-send-region-or-buffer` behave correctly.

I also added a new option to force the use of dedicated shells for each buffers
(to avoid having to launch `run-python` manually each time).
I ran some test and it also work with different virtual environments for each buffer.

I can run some more tests if the idea seems interesting enough.