### PR TITLE
Add basic Django support

### DIFF
--- a/Cask
+++ b/Cask
@@ -10,6 +10,7 @@
 (depends-on "highlight-indentation" "0.5.0")
 (depends-on "pyvenv" "1.2")
 (depends-on "yasnippet" "0.8.0")
+(depends-on "s" "1.10.0")
 
 (development
  (depends-on "dash")

--- a/docs/ide.rst
+++ b/docs/ide.rst
@@ -359,3 +359,24 @@ Elpy supports various forms of refactoring Python code.
    options depending on the context.
 
 .. _rope: https://github.com/python-rope/rope
+
+
+Django
+======
+
+Elpy has basic Django support such as parsing either `manage.py` or `django-admin.py` (If it
+does not find `manage.py` it falls back to `django-admin.py`) for command completion assistance.
+Can also start `runserver` automatically and you can give an ip address and port.
+
+.. command:: elpy-django-command
+   :kbd: C-c C-x c
+
+   Choose what command you'd like to run via `django-admin.py` or `manage.py`.
+
+.. command:: elpy-django-runserver
+   :kbd: C-c C-x r
+
+
+   Start the development server command, `runserver`. Default arguments are `127.0.0.1` for
+   ip address and `8000` for port. These can be changed via ``elpy-django-server-ipaddr`` and
+   ``elpy-django-server-port``.

--- a/elpy-django.el
+++ b/elpy-django.el
@@ -40,14 +40,14 @@ Best to set it to full path to 'manage.py' if it's available."
 (defcustom elpy-django-server-ipaddr "127.0.0.1"
   "What address Django will use when running the dev server."
   :type 'string
-  :type 'stringp
+  :safe 'stringp
   :group 'elpy)
 (make-variable-buffer-local 'elpy-django-server-ipaddr)
 
 (defcustom elpy-django-server-port "8000"
   "What port Django will use when running the dev server."
   :type 'string
-  :type 'stringp
+  :safe 'stringp
   :group 'elpy)
 (make-variable-buffer-local 'elpy-django-server-port)
 
@@ -55,7 +55,7 @@ Best to set it to full path to 'manage.py' if it's available."
   "When non-nil, it will always prompt for extra arguments
 to pass with the chosen command."
   :type 'boolean
-  :type 'booleanp
+  :safe 'booleanp
   :group 'elpy)
 (make-variable-buffer-local 'elpy-django-always-prompt)
 

--- a/elpy-django.el
+++ b/elpy-django.el
@@ -1,0 +1,149 @@
+;;; elpy-django.el --- Django extension for elpy
+
+;; Copyright (C) 2013-2016  Jorgen Schaefer
+
+;; Author: Daniel Gopar <gopardaniel@gmail.com>
+;; URL: https://github.com/jorgenschaefer/elpy
+
+;; This program is free software; you can redistribute it and/or
+;; modify it under the terms of the GNU General Public License
+;; as published by the Free Software Foundation; either version 3
+;; of the License, or (at your option) any later version.
+
+;; This program is distributed in the hope that it will be useful,
+;; but WITHOUT ANY WARRANTY; without even the implied warranty of
+;; MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+;; GNU General Public License for more details.
+
+;; You should have received a copy of the GNU General Public License
+;; along with this program. If not, see <http://www.gnu.org/licenses/>.
+
+;;; Commentary:
+
+;; This file serves as an extension to elpy by adding django support
+
+;;; Code:
+
+(require 's)
+
+;;;;;;;;;;;;;;;;;;;;;;
+;;; User customization
+
+(defcustom elpy-django-command "django-admin.py"
+  "Command to use when running Django specific commands.
+Best to set it to full path to 'manage.py' if it's available."
+  :type 'string
+  :safe 'stringp
+  :group 'elpy)
+(make-variable-buffer-local 'elpy-django-command)
+
+(defcustom elpy-django-server-ipaddr "127.0.0.1"
+  "What address Django will use when running the dev server."
+  :type 'string
+  :type 'stringp
+  :group 'elpy)
+(make-variable-buffer-local 'elpy-django-server-ipaddr)
+
+(defcustom elpy-django-server-port "8000"
+  "What port Django will use when running the dev server."
+  :type 'string
+  :type 'stringp
+  :group 'elpy)
+(make-variable-buffer-local 'elpy-django-server-port)
+
+(defcustom elpy-django-always-prompt nil
+  "When non-nil, it will always prompt for extra arguments
+to pass with the chosen command."
+  :type 'boolean
+  :type 'booleanp
+  :group 'elpy)
+(make-variable-buffer-local 'elpy-django-always-prompt)
+
+;;;;;;;;;;;;;;;;;;;;;;
+;; Key map
+
+(defvar elpy-django-mode-map
+  (let ((map (make-sparse-keymap)))
+    (define-key map (kbd "c") 'elpy-django-command)
+    (define-key map (kbd "r") 'elpy-django-runserver)
+    map)
+  "Key map for django extension")
+
+;;;;;;;;;;;;;;;;;;;;;;
+;;; Helper Functions
+
+(defun elpy-django-setup ()
+  "Decides whether to start the minor mode or not."
+  ;; Make sure we're in an actual file and we can find
+  ;; manage.py. Otherwise user will have to manually
+  ;; start this mode if they're using 'django-admin.py'
+  (when (locate-dominating-file default-directory "manage.py")
+    ;; Let's be nice and point to full path of 'manage.py'
+    ;; This only affects the buffer if there's no directory
+    ;; variable overwriting it.
+    (setq elpy-django-command
+          (concat (locate-dominating-file default-directory "manage.py") "manage.py"))
+    (elpy-django 1)))
+
+(defun elpy-django--get-commands ()
+  "Return list of django commands."
+  (let ((dj-commands-str nil)
+        (help-output
+         (shell-command-to-string (concat elpy-django-command " -h"))))
+    (setq dj-commands-str
+          (with-temp-buffer
+            (progn
+              (insert help-output)
+              (beginning-of-buffer)
+              (delete-region (point) (search-forward "Available subcommands:" nil nil nil))
+              ;; cleanup [auth] and stuff
+              (beginning-of-buffer)
+              (save-excursion
+                (replace-regexp "\\[.*\\]" ""))
+              (buffer-string))))
+    ;; get a list of commands from the output of manage.py -h
+    ;; What would be the pattern to optimize this ?
+    (setq dj-commands-str (split-string dj-commands-str "\n"))
+    (setq dj-commands-str (-remove (lambda (x) (string= x "")) dj-commands-str))
+    (setq dj-commands-str (mapcar (lambda (x) (s-trim x)) dj-commands-str))
+    (sort dj-commands-str 'string-lessp)))
+
+;;;;;;;;;;;;;;;;;;;;;;
+;;; User Functions
+
+(defun elpy-django-command (cmd)
+  "Prompt user for Django command. If called with `C-u',
+it will prompt for other flags/arguments to run."
+  (interactive (list (completing-read "Command: " (elpy-django--get-commands) nil nil)))
+  ;; Called with C-u or variable is set
+  (when (or current-prefix-arg elpy-django-always-prompt)
+    (setq cmd (read-shell-command (concat cmd ": ") "--noinput")))
+  (compile (concat elpy-django-command " " cmd)))
+
+(defun elpy-django-runserver (arg)
+  "Start the server and automatically add the ipaddr and port.
+Also create it's own special buffer so that we can have multiple
+servers running per project.
+
+When called with a prefix (C-u), it will prompt for additional args."
+  (interactive "P")
+  (let* ((cmd (concat elpy-django-command " runserver"))
+         (proj-root (file-name-base (directory-file-name (elpy-project-root))))
+         (buff-name (format "*runserver[%s]*" proj-root)))
+    ;; Kill any previous instance of runserver since we might be doing something new
+    (when (get-buffer buff-name)
+      (kill-buffer buff-name))
+    (setq cmd (concat cmd " " elpy-django-server-ipaddr ":" elpy-django-server-port))
+    (when (or arg elpy-django-always-prompt)
+      (setq cmd (concat cmd " "(read-shell-command (concat cmd ": ")))))
+    (compile cmd)
+    (with-current-buffer "*compilation*"
+      (rename-buffer buff-name))))
+
+(define-minor-mode elpy-django
+  "Minor mode to for Django commands."
+  :group 'elpy)
+
+(provide 'elpy-django)
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;;; elpy-django.el ends here

--- a/elpy-django.el
+++ b/elpy-django.el
@@ -125,7 +125,7 @@ it will prompt for other flags/arguments to run."
   (interactive (list (completing-read "Command: " (elpy-django--get-commands) nil nil)))
   ;; Called with C-u or variable is set
   (when (or current-prefix-arg elpy-django-always-prompt)
-    (setq cmd (read-shell-command (concat cmd ": ") "--noinput")))
+    (setq cmd (concat cmd " " (read-shell-command (concat cmd ": ") "--noinput"))))
   (compile (concat elpy-django-command " " cmd)))
 
 (defun elpy-django-runserver (arg)

--- a/elpy-django.el
+++ b/elpy-django.el
@@ -51,6 +51,14 @@ Best to set it to full path to 'manage.py' if it's available."
   :group 'elpy)
 (make-variable-buffer-local 'elpy-django-server-port)
 
+(defcustom elpy-django-server-command "runserver"
+  "When executing `elpy-django-runserver' what should be the server
+command to use."
+  :type 'string
+  :safe 'stringp
+  :group 'elpy)
+(make-variable-buffer-local 'elpy-django-server-command)
+
 (defcustom elpy-django-always-prompt nil
   "When non-nil, it will always prompt for extra arguments
 to pass with the chosen command."
@@ -127,7 +135,7 @@ servers running per project.
 
 When called with a prefix (C-u), it will prompt for additional args."
   (interactive "P")
-  (let* ((cmd (concat elpy-django-command " runserver"))
+  (let* ((cmd (concat elpy-django-command " " elpy-django-server-command))
          (proj-root (file-name-base (directory-file-name (elpy-project-root))))
          (buff-name (format "*runserver[%s]*" proj-root)))
     ;; Kill any previous instance of runserver since we might be doing something new

--- a/elpy-django.el
+++ b/elpy-django.el
@@ -67,6 +67,17 @@ to pass with the chosen command."
   :group 'elpy)
 (make-variable-buffer-local 'elpy-django-always-prompt)
 
+(defcustom elpy-django-commands-with-req-arg '("startapp" "startproject"
+                                               "loaddata" "sqlmigrate"
+                                               "sqlsequencereset"
+                                               "squashmigrations")
+  "Used to determine if we should prompt for arguments. Some commands
+require arguments in order for it to work."
+  :type 'list
+  :safe 'listp
+  :group 'elpy)
+(make-variable-buffer-local 'elpy-django-commands-with-req-arg)
+
 ;;;;;;;;;;;;;;;;;;;;;;
 ;; Key map
 
@@ -123,8 +134,10 @@ to pass with the chosen command."
   "Prompt user for Django command. If called with `C-u',
 it will prompt for other flags/arguments to run."
   (interactive (list (completing-read "Command: " (elpy-django--get-commands) nil nil)))
-  ;; Called with C-u or variable is set
-  (when (or current-prefix-arg elpy-django-always-prompt)
+  ;; Called with C-u, variable is set or is a cmd that requires an argument
+  (when (or current-prefix-arg
+            elpy-django-always-prompt
+            (member cmd elpy-django-commands-with-req-arg))
     (setq cmd (concat cmd " " (read-shell-command (concat cmd ": ") "--noinput"))))
   (compile (concat elpy-django-command " " cmd)))
 

--- a/elpy.el
+++ b/elpy.el
@@ -6,7 +6,7 @@
 ;; URL: https://github.com/jorgenschaefer/elpy
 ;; Version: 1.12.0
 ;; Keywords: Python, IDE, Languages, Tools
-;; Package-Requires: ((company "0.8.2") (find-file-in-project "3.3")  (highlight-indentation "0.5.0") (pyvenv "1.3") (yasnippet "0.8.0"))
+;; Package-Requires: ((company "0.8.2") (find-file-in-project "3.3")  (highlight-indentation "0.5.0") (pyvenv "1.3") (yasnippet "0.8.0") (s "1.10.0")
 
 ;; This program is free software; you can redistribute it and/or
 ;; modify it under the terms of the GNU General Public License
@@ -44,6 +44,7 @@
 (require 'python)
 
 (require 'elpy-refactor)
+(require 'elpy-django)
 (require 'pyvenv)
 
 (defconst elpy-version "1.12.0"
@@ -71,7 +72,8 @@ This can be used to enable minor modes for Python development."
                           elpy-module-flymake
                           elpy-module-highlight-indentation
                           elpy-module-pyvenv
-                          elpy-module-yasnippet)
+                          elpy-module-yasnippet
+                          elpy-module-django)
   "Which Elpy modules to use.
 
 Elpy can use a number of modules for additional features, which
@@ -88,6 +90,8 @@ can be inidividually enabled or disabled."
                      elpy-module-highlight-indentation)
               (const :tag "Expand code snippets (YASnippet)"
                      elpy-module-yasnippet)
+              (const :tag "Django configurations (Elpy-Django)"
+                     elpy-module-django)
               (const :tag "Configure some sane defaults for Emacs"
                      elpy-module-sane-defaults))
   :group 'elpy)
@@ -387,6 +391,7 @@ edited instead. Setting this variable to nil disables this feature."
     (define-key map (kbd "C-c C-v") 'elpy-check)
     (define-key map (kbd "C-c C-z") 'elpy-shell-switch-to-shell)
     (define-key map (kbd "C-c C-r") elpy-refactor-map)
+    (define-key map (kbd "C-c C-x") elpy-django-mode-map)
 
     (define-key map (kbd "<S-return>") 'elpy-open-and-indent-line-below)
     (define-key map (kbd "<C-S-return>") 'elpy-open-and-indent-line-above)
@@ -544,6 +549,7 @@ virtualenv.
     ("Snippets (YASnippet)" yasnippet "yas-")
     ("Directory Grep (rgrep)" grep "grep-")
     ("Search as You Type (ido)" ido "ido-")
+    ("Django Extension" elpy-django "elpy-django-")
     ;; ffip does not use defcustom
     ;; highlight-indent does not use defcustom, either. Its sole face
     ;; is defined in basic-faces.
@@ -3727,6 +3733,17 @@ description."
      (yas-minor-mode 1))
     (`buffer-stop
      (yas-minor-mode -1))))
+
+;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;;; Module: Elpy-Django
+
+(defun elpy-module-django (command &rest args)
+  "Module to provide Django support."
+  (pcase command
+    (`buffer-init
+     (elpy-django-setup))
+    (`buffer-stop
+     (elpy-django -1))))
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;;; Backwards compatibility

--- a/test/elpy-module-django-test.el
+++ b/test/elpy-module-django-test.el
@@ -40,6 +40,13 @@ default to `django-admin.py'."
            (output (elpy-django-command "migrate")))
           (should (string= output "django-admin.py migrate"))))
 
+(ert-deftest elpy-module-django-commands-with-required-arg ()
+  (dolist (cmd elpy-django-commands-with-req-arg)
+    (mletf* ((compile (arg) arg)
+             (read-shell-command (arg1 agr2) "test")
+             (output (elpy-django-command cmd)))
+            (should (string= output (concat "django-admin.py " cmd " test"))))))
+
 ;; Test the parsing. Also, another way of shortening string?
 ;; Already made it shorter but still seems to long
 (ert-deftest elpy-module-django-get-commands ()

--- a/test/elpy-module-django-test.el
+++ b/test/elpy-module-django-test.el
@@ -1,0 +1,65 @@
+;; Better way of doing tests? Since, I actually need a Django project
+;; to test out the `runserver' command
+(ert-deftest elpy-module-django-buffer-init ()
+  "elpy-django should not be activated since it won't find the
+`manage.py' file."
+  (elpy-testcase ()
+    (elpy-module-django 'buffer-init)
+
+    (should (not elpy-django))))
+
+(ert-deftest elpy-module-django-buffer-stop ()
+  (elpy-testcase ()
+    (elpy-module-django 'buffer-stop)
+
+    (should (not elpy-django))))
+
+(ert-deftest elpy-module-django-buffer-init-with-manage-file ()
+  "When doing a buffer-init, elpy-django should activate when finding
+the `manage.py' file."
+  (elpy-testcase ()
+    (with-temp-file (concat default-directory "manage.py"))
+    (elpy-module-django 'buffer-init)
+
+    (should elpy-django)
+    (should (string= elpy-django-command (concat default-directory "manage.py")))
+
+    (delete-file (concat default-directory "manage.py"))))
+
+(ert-deftest elpy-module-django-manual-init ()
+  "When turning elpy-django manually, `elpy-django-command' should
+default to `django-admin.py'."
+  (elpy-testcase ()
+    (elpy-django 1)
+
+    (should elpy-django)
+    (should (string= "django-admin.py" elpy-django-command))))
+
+(ert-deftest elpy-module-django-command ()
+  (mletf* ((compile (arg) arg)
+           (output (elpy-django-command "migrate")))
+          (should (string= output "django-admin.py migrate"))))
+
+;; Test the parsing. Also, another way of shortening string?
+;; Already made it shorter but still seems to long
+(ert-deftest elpy-module-django-get-commands ()
+  (mletf* ((shell-command-to-string (arg) "Type 'manage.py help <subcommand>' for help on a specific subcommand.
+
+Available subcommands:
+
+[auth]
+    changepassword
+
+[django]
+    migrate
+
+[sessions]
+    clearsessions
+
+[staticfiles]
+    runserver
+"))
+    (should (member "runserver" (elpy-django--get-commands)))
+    (should (member "clearsessions" (elpy-django--get-commands)))
+    (should (member "migrate" (elpy-django--get-commands)))
+    (should (member "changepassword" (elpy-django--get-commands)))))


### PR DESCRIPTION
You can now parse through `manage.py` (If it is found, otherwise it
falls back to `django-admin.py`) for commands to run and emacs will
provide completion assistance.

Another function is to automatically start the development server
command, `runserver`, with default variables that are set to
`127.0.0.1`(for ip address) and `8000` (for port). Each Django project
has the ability of starting their own dev server.

One question I have regarding this is if we should also allow changing
the command for starting the development server, `runserver`? I know
other people like `runserver_plus` from the `django-extensions` module.

Commit also introduces a new dependency, `s`, for string
manipulation. Currently, it is only used on one line for trimming
whitespace. Should the commit introduce this new dep or simply create
a function that does this?

Forgot to mentioned: User can specify extra arguments by starting the command with a prefix `C-u` or if they'd like to always prompt for extra arguments, there is a variable for that as well.
