### PR TITLE
One-line python requirements install line added

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -36,7 +36,7 @@ First, install the required Python packages:::
   # and yapf for code formatting
   pip install yapf
 
-One-line install: **sudo pip install rope jedi flake8 importmagic autopep8 yapf**
+One-line install: **pip install rope jedi flake8 importmagic autopep8 yapf**
 
 Evaluate this in your ``*scratch*`` buffer:
 

--- a/README.rst
+++ b/README.rst
@@ -36,7 +36,7 @@ First, install the required Python packages:::
   # and yapf for code formatting
   pip install yapf
 
-One-line install: **sudo pip3 install rope jedi flake8 importmagic autopep8 yapf**
+One-line install: **sudo pip install rope jedi flake8 importmagic autopep8 yapf**
 
 Evaluate this in your ``*scratch*`` buffer:
 

--- a/README.rst
+++ b/README.rst
@@ -36,6 +36,7 @@ First, install the required Python packages:::
   # and yapf for code formatting
   pip install yapf
 
+One-line install: **sudo pip3 install rope jedi flake8 importmagic autopep8 yapf**
 
 Evaluate this in your ``*scratch*`` buffer:
 


### PR DESCRIPTION
When i was installing elpy i was missing this - i find it easier to copy the line than typing it all out or getting the repo and installing via the requirements file :)
Up to you ofc.