### PR TITLE
One-line python requirements install line added

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -36,6 +36,7 @@ First, install the required Python packages:::
   # and yapf for code formatting
   pip install yapf
 
+One-line install: **pip install jedi flake8 importmagic autopep8**
 
 Evaluate this in your ``*scratch*`` buffer:
 


### PR DESCRIPTION
As discussed here: https://github.com/jorgenschaefer/elpy/pull/976
rope and yapf removed - and it is all in one commit.
I could not squash the commits from the other PR because i made it online on GitHub so i did not have a fork :)

Anyways - are you happy with this?