### PR TITLE
Source yapf style file from elpy-project-root or default-directory.

### DIFF
--- a/elpy.el
+++ b/elpy.el
@@ -2283,19 +2283,24 @@ Also sort the imports in the import statement blocks."
 (defun elpy-yapf-fix-code ()
   "Automatically formats Python code with yapf."
   (interactive)
-  (elpy--fix-code-with-formatter "fix_code_with_yapf"))
+  (elpy--fix-code-with-formatter "fix_code_with_yapf"
+                                 (or (expand-file-name (elpy-project-root))
+                                     default-directory)))
 
 (defun elpy-autopep8-fix-code ()
   "Automatically formats Python code to conform to the PEP 8 style guide."
   (interactive)
   (elpy--fix-code-with-formatter "fix_code"))
 
-(defun elpy--fix-code-with-formatter (method)
+(defun elpy--fix-code-with-formatter (method directory)
   "Common routine for formatting python code."
   (let ((line (line-number-at-pos))
         (col (current-column)))
     (if (use-region-p)
-        (let ((new-block (elpy-rpc method (list (elpy-rpc--region-contents))))
+        (let ((new-block (elpy-rpc method
+                                   (if directory
+                                       (list (elpy-rpc--region-contents) directory)
+                                     (list (elpy-rpc--region-contents)))))
               (beg (region-beginning)) (end (region-end)))
           (elpy-buffer--replace-region
            beg end
@@ -2304,7 +2309,10 @@ Also sort the imports in the import statement blocks."
           (deactivate-mark))
       ;; Vector instead of list, json.el in Emacs 24.3 and before
       ;; breaks for single-element lists of alists.
-      (let ((new-block (elpy-rpc method (vector (elpy-rpc--buffer-contents))))
+      (let ((new-block (elpy-rpc method
+                                 (if directory
+                                     (vector (elpy-rpc--buffer-contents) directory)
+                                   (vector (elpy-rpc--buffer-contents)))))
             (beg (point-min)) (end (point-max)))
         (elpy-buffer--replace-region beg end new-block)
         (forward-line (1- line))

--- a/elpy.el
+++ b/elpy.el
@@ -2292,7 +2292,7 @@ Also sort the imports in the import statement blocks."
   (interactive)
   (elpy--fix-code-with-formatter "fix_code"))
 
-(defun elpy--fix-code-with-formatter (method directory)
+(defun elpy--fix-code-with-formatter (method &optional directory)
   "Common routine for formatting python code."
   (let ((line (line-number-at-pos))
         (col (current-column)))

--- a/elpy/server.py
+++ b/elpy/server.py
@@ -255,12 +255,12 @@ class ElpyRPCServer(JSONRPCServer):
         source = get_source(source)
         return fix_code(source)
 
-    def rpc_fix_code_with_yapf(self, source):
+    def rpc_fix_code_with_yapf(self, source, directory):
         """Formats Python code to conform to the PEP 8 style guide.
 
         """
         source = get_source(source)
-        return fix_code_with_yapf(source)
+        return fix_code_with_yapf(source, directory)
 
 
 def get_source(fileobj):

--- a/elpy/yapfutil.py
+++ b/elpy/yapfutil.py
@@ -20,7 +20,7 @@ except ImportError:  # pragma: no cover
     yapf_api = None
 
 
-def fix_code(code, directory):
+def fix_code(code, directory=None):
     """Formats Python code to conform to the PEP 8 style guide.
 
     """

--- a/elpy/yapfutil.py
+++ b/elpy/yapfutil.py
@@ -20,13 +20,13 @@ except ImportError:  # pragma: no cover
     yapf_api = None
 
 
-def fix_code(code):
+def fix_code(code, directory):
     """Formats Python code to conform to the PEP 8 style guide.
 
     """
     if not yapf_api:
         raise Fault('yapf not installed', code=400)
-    style_config = file_resources.GetDefaultStyleForDir(os.getcwd())
+    style_config = file_resources.GetDefaultStyleForDir(directory or os.getcwd())
     try:
         reformatted_source, _ = yapf_api.FormatCode(code,
                                                     filename='<stdin>',


### PR DESCRIPTION
The suggestion is to do this rather than using os.getcwd(), which does not pick up project-specific  yapf style settings, similarly to #971 for importmagic.
