### PR TITLE
Option to run Django tests with manage.py

### DIFF
--- a/docs/ide.rst
+++ b/docs/ide.rst
@@ -291,8 +291,15 @@ advantages this brings.
 
    This changes the current test runner. Elpy supports the standard
    unittest discovery runner, the Django discovery runner, nose and
-   py.test. You can also write your own, as described in
-   :ref:`Writing Test Runners`.
+   py.test. You can also write your own, as described in :ref:`Writing
+   Test Runners`.
+
+   Note on Django runners: by default, elpy runs Django tests with
+   :kbd:`django-admin.py`. You must set the environnement variable
+   :envvar:`DJANGO_SETTINGS_MODULE` accordingly. Alternatively, you can set
+   **elpy-test-django-with-manage** to **t** in order to use your
+   project's :kbd:`manage.py`. You then don't need to set the environnement
+   variable, but change virtual envs (see `virtualenvwrapper.el`_).
 
 This enables a good workflow. You write a test and use :kbd:`C-c C-t`
 to watch it fail. You then go to your implementation file, for example
@@ -305,6 +312,8 @@ For an even more automated way, you can use `tdd.el`_, which will run
 your last compile command whenever you save a file.
 
 .. _tdd.el: https://github.com/jorgenschaefer/emacs-tdd/
+
+.. _virtualenvwrapper.el: https://github.com/porterjamesj/virtualenvwrapper.el
 
 
 Refactoring

--- a/elpy.el
+++ b/elpy.el
@@ -315,6 +315,18 @@ edited instead. Setting this variable to nil disables this feature."
   :type '(repeat string)
   :group 'elpy)
 
+(defcustom elpy-test-django-runner-manage-command '("manage.py" "test"
+                                                    "--noinput")
+  "The command to use for `elpy-test-django-runner' in case we want to use manage.py."
+  :type '(repeat string)
+  :group 'elpy)
+
+(defcustom elpy-test-django-with-manage nil
+  "Set to nil, elpy will use `elpy-test-django-runner-command',
+set to t elpy will use `elpy-test-django-runner-manage-command' and set the project root accordingly."
+  :type 'boolean
+  :group 'elpy)
+
 (defcustom elpy-test-nose-runner-command '("nosetests")
   "The command to use for `elpy-test-nose-runner'."
   :type '(repeat string)
@@ -2050,17 +2062,28 @@ This requires Python 2.7 or later."
 (put 'elpy-test-discover-runner 'elpy-test-runner-p t)
 
 (defun elpy-test-django-runner (top file module test)
-  "Test the project using the Django discover runner.
+  "Test the project using the Django discover runner,
+or with manage.py if elpy-test-django-with-manage is true.
 
 This requires Django 1.6 or the django-discover-runner package."
   (interactive (elpy-test-at-point))
   (if module
       (apply #'elpy-test-run
              top
-             (append elpy-test-django-runner-command
-                     (list (if test
-                               (format "%s.%s" module test)
-                             module))))
+             (append
+              ;; if we want to use manage.py, get the root directory where it is.
+              (if elpy-test-django-with-manage
+                  (append (list (concat (expand-file-name
+                                         (locate-dominating-file
+                                          (elpy-project-root)
+                                          (car elpy-test-django-runner-manage-command)))
+                                        (car elpy-test-django-runner-manage-command)))
+                          (cdr elpy-test-django-runner-manage-command))
+                ;; or the default:
+                elpy-test-django-runner-command)
+              (list (if test
+                        (format "%s.%s" module test)
+                      module))))
     (apply #'elpy-test-run
            top
            elpy-test-django-runner-command)))


### PR DESCRIPTION
_"…setting the project root accordingly,
in order not to set the environnement variable DJANGO_SETTINGS_MODULE
for every project (but instead change of virtual env)."_

This PR does not change elpy's default behavior.

It adds a variable to tell elpy to run django tests with `manage.py` instead of `django-admin.py`. 
The thing is that we can't just set `elpy-test-django-runner-command` to our manage.py command because `elpy-test-at-point` needs to return the project root, not the library root.

Benefits: it allows a user to run tests quicker, with no venv or environment variable configuration. We just have to change of virtual env, which is easily done with other packages ([virtualenvwrapper.el](https://github.com/porterjamesj/virtualenvwrapper.el) and others). 

Because from my experience, I wasn't able to run django tests when I tried elpy. Now, I can and I hope it's easier for others too.

See https://github.com/jorgenschaefer/elpy/issues/931
