### PR TITLE
Add functions to kill shell(s)

### DIFF
--- a/docs/ide.rst
+++ b/docs/ide.rst
@@ -183,6 +183,18 @@ easier to send code snippets over.
    Similar to :kbd:`C-c C-c`, this will send the code of the current
    top level class or function to the interactive Python process.
 
+.. command:: elpy-shell-kill
+   :kbd: C-c C-k
+
+   Kill the current python shell.
+   If ``elpy-dedicated-shells`` is non-nil,
+   kill the current buffer dedicated shell.
+
+.. command:: elpy-shell-kill-all
+   :kbd: C-c C-K
+
+   Kill all active python shells.
+
 .. command:: elpy-use-ipython
 .. command:: elpy-use-cpython
 

--- a/test/elpy-shell-kill-all-should-kill-all-shell-buffers.el
+++ b/test/elpy-shell-kill-all-should-kill-all-shell-buffers.el
@@ -1,0 +1,23 @@
+(ert-deftest elpy-shell-kill-all-should-kill-all-shells ()
+  (elpy-testcase ()
+    (let ((buff1 (generate-new-buffer "buff1"))
+	  (buff2 (generate-new-buffer "buff2"))
+	  (shell-buff1 nil)
+	  (shell-buff2 nil)
+	  (elpy-dedicated-shells t))
+      (with-current-buffer buff1
+	(python-mode)
+	(elpy-mode 1)
+	(setq shell-buff1 (process-buffer (elpy-shell-get-or-create-process))))
+      (with-current-buffer buff2
+	(python-mode)
+	(elpy-mode 1)
+	(setq shell-buff2 (process-buffer (elpy-shell-get-or-create-process))))
+      (defun yes-or-no-p (&rest args)
+	t)
+      (defun y-or-n-p (&rest args)
+	t)
+      (elpy-shell-kill-all t)
+    (should (not (and
+		    (buffer-name shell-buff1)
+		    (buffer-name shell-buff2)))))))

--- a/test/elpy-shell-kill-all-should-kill-all-shells.el
+++ b/test/elpy-shell-kill-all-should-kill-all-shells.el
@@ -1,0 +1,23 @@
+(ert-deftest elpy-shell-kill-all-should-kill-all-shells ()
+  (elpy-testcase ()
+    (let ((buff1 (generate-new-buffer "buff1"))
+	  (buff2 (generate-new-buffer "buff2"))
+	  (shell-buff1 nil)
+	  (shell-buff2 nil)
+	  (elpy-dedicated-shells t))
+      (with-current-buffer buff1
+	(python-mode)
+	(elpy-mode 1)
+	(setq shell-buff1 (process-buffer (elpy-shell-get-or-create-process))))
+      (with-current-buffer buff2
+	(python-mode)
+	(elpy-mode 1)
+	(setq shell-buff2 (process-buffer (elpy-shell-get-or-create-process))))
+      (defun yes-or-no-p (&rest args)
+	t)
+      (defun y-or-n-p (&rest args)
+	t)
+      (elpy-shell-kill-all)
+    (should (not (and
+		    (get-buffer-process shell-buff1)
+		    (get-buffer-process shell-buff2)))))))

--- a/test/elpy-shell-kill-should-kill-shell-buffer.el
+++ b/test/elpy-shell-kill-should-kill-shell-buffer.el
@@ -1,0 +1,7 @@
+(ert-deftest elpy-shell-kill-should-kill-shell-buffer ()
+  (elpy-testcase ()
+    (python-mode)
+    (elpy-mode 1)
+    (let ((shell-buffer (process-buffer (elpy-shell-get-or-create-process))))
+      (elpy-shell-kill t)
+      (should (not (buffer-name shell-buffer))))))

--- a/test/elpy-shell-kill-should-kill-shell.el
+++ b/test/elpy-shell-kill-should-kill-shell.el
@@ -1,0 +1,7 @@
+(ert-deftest elpy-shell-kill-should-kill-shell ()
+  (elpy-testcase ()
+    (python-mode)
+    (elpy-mode 1)
+    (let ((shell-buffer (process-buffer (elpy-shell-get-or-create-process))))
+      (elpy-shell-kill t)
+      (should (not (get-buffer-process shell-buffer))))))


### PR DESCRIPTION
## Motivation
With the use of dedicated shells, I end up having a lot of active python shells (potentially using a lot of memory...). 
As it can be time-consuming to search and kill each python shell, I wrote a function to do it automatically.

## New functions
`elpy-shell-kill` : kill the current python shell (and the python shell buffer, if asked).
`elpy-shell-kill-all` : kill all the dedicated python shells (and their buffers, if asked).