### PR TITLE
Add aliases to elpy importmagic

### DIFF
--- a/elpy/impmagic.py
+++ b/elpy/impmagic.py
@@ -71,15 +71,26 @@ class ImportMagic(object):
     def add_import(self, source, statement):
         imports = importmagic.importer.Imports(self.symbol_index, source)
         if statement.startswith('import '):
-            modname = statement[7:]
-            imports.add_import(modname)
+            sepalias = None
+            alias = None
+            if ' as ' in statement:
+                sepalias = statement.find(' as ')
+                alias = statement[sepalias+4:]
+            modname = statement[7:sepalias]
+            imports.add_import(modname, alias)
             self.favorites.add(modname)
         else:
             sep = statement.find(' import ')
+            sepalias = None
+            alias = None
+            if ' as ' in statement:
+                sepalias = statement.find(' as ')
+                alias = statement[sepalias+4:]
             modname = statement[5:sep]
+            name = statement[sep+8:sepalias]
             if sep > -1:
                 self.favorites.add(modname)
-                imports.add_import_from(statement[5:sep], statement[sep+8:])
+                imports.add_import_from(modname, name, alias)
         start_line, end_line, import_block = imports.get_update()
         return start_line, end_line, import_block
 

--- a/test/elpy-importmagic--add-import-read-args-test.el
+++ b/test/elpy-importmagic--add-import-read-args-test.el
@@ -8,4 +8,4 @@
                (elpy-rpc (call args) '("import mymodule"))
                (completing-read (prompt vals &optional func require-match default history)
                                 "import mymodule"))
-        (should (equal (elpy-importmagic--add-import-read-args) '("import mymodule")))))))
+        (should (equal (elpy-importmagic--add-import-read-args) "import mymodule"))))))


### PR DESCRIPTION
## Motivation
I use a lot a aliases while coding in python.
As importmagic handles aliases, it seems a good idea for the  `elpy-importmagic-*` functions to handle them as well.

## Improvements
- `elpy-importmagic-add-import` with non-nil `ask-for-alias` optional argument now ask for the wanted alias after choosing the import statement.
- `elpy-importmagic-fixup` now gathers unresolved module names (supposed to be aliases), ask for their real names and add import statements in consequence.

## Working (simple) example
```python
HOME = r"/home/ben"

x = np.linspace(0, 1, 1000)
y = x**2
plt.figure()
plt.plot(x, y, marker=markers.TICKDOWN)
plt.title(time.time)
plt.show(block=False)
plt.savefig(join(HOME, "test-elpy/figure.svg"))
```
give, after `elpy-importmagic-fixup` and some prompting: 
```python
import time
from os.path import join

import numpy as np
from matplotlib import markers, pyplot as plt


HOME = r"/home/ben"

x = np.linspace(0, 1, 100)
y = x**2
plt.figure()
plt.plot(x, y, marker=markers.TICKDOWN)
plt.title(time.time)
plt.show(block=False)
plt.savefig(join(HOME, "test-elpy/figure.svg"))

```
## Notes
- `elpy-importmagic--add-import-read-args` now return a string instead of a list of one string (I didn't find any reasons to keep a list of one element).
- Importmagic do not seems to be able to clean modules imported with aliases...
- `elpy-importmagic-fixup`  try to get an import statement for variables if they are not defined.