### PR TITLE
Fix apparition of tabs while removing indentation

### DIFF
--- a/elpy.el
+++ b/elpy.el
@@ -1735,6 +1735,9 @@ If ASK-FOR-EACH-ONE is non-nil, ask before killing each python process.
         (indent-rigidly (point-min)
                         (point-max)
                         (- indent-level))
+        ;; 'indent-rigidly' introduces tabs despite the fact that 'indent-tabs-mode' is nil
+        ;; 'untabify' fix that
+	(untabify (point-min) (point-max))
         (buffer-string)))))
 
 ;;;;;;;;;;;;;;;;;


### PR DESCRIPTION
For some user (see #988), wild tabs seem to appear while sending code parts to python shell. 
This seems to be due (for me) to `indent-rigdly` in `elpy-shell--region-without-indentation`.
Using `untabify` after `indent-rigidly` fix the problem, but I don't think `indent-rigidly` is supposed to add tabs, so this just looks like a workaround...