### PR TITLE
Fix compilation warnings

### DIFF
--- a/elpy-django.el
+++ b/elpy-django.el
@@ -113,10 +113,10 @@ require arguments in order for it to work."
           (with-temp-buffer
             (progn
               (insert help-output)
-              (beginning-of-buffer)
+              (goto-char (point-min))
               (delete-region (point) (search-forward "Available subcommands:" nil nil nil))
               ;; cleanup [auth] and stuff
-              (beginning-of-buffer)
+              (goto-char (point-min))
               (save-excursion
                 (replace-regexp "\\[.*\\]" ""))
               (buffer-string))))


### PR DESCRIPTION
Emacs complains when byte-compiling this file
```
elpy-django.el:126:37:Warning: ‘beginning-of-buffer’ is for interactive use
    only; use ‘(goto-char (point-min))’ instead.
elpy-django.el:117:87:Warning: ‘beginning-of-buffer’ is for interactive use
    only; use ‘(goto-char (point-min))’ instead.
```
This PR should fix it.