### PR TITLE
Fix no-name buffer error when using `elpy-shell-kill-all`

### DIFF
--- a/elpy.el
+++ b/elpy.el
@@ -1670,7 +1670,8 @@ If ASK-FOR-EACH-ONE is non-nil, ask before killing each python process.
   (let ((python-buffer-list ()))
     ;; Get active python shell buffers and kill inactive ones (if asked)
     (loop for buffer being the buffers do
-	  (when (string-match "^\*Python\\\[.*\\]\*$" (buffer-name buffer))
+	  (when (and (buffer-name buffer)
+                     (string-match "^\*Python\\\[.*\\]\*$" (buffer-name buffer)))
 	    (if (get-buffer-process buffer)
 		(push buffer python-buffer-list)
 	      (when kill-buffers


### PR DESCRIPTION
`elpy-shell-kill-all` run into an error  if a buffer have no name (`(buffer-name buffer)` returning `nil`).
This commit just add a preliminary check to ensure we work only with named buffer.
This bug is not easy to reproduce, so I don't know exactly what kind of buffer return no name...