### PR TITLE
Fix bug in elpy-shell-kill-all where it does not find the *Python* bu…

### DIFF
--- a/elpy.el
+++ b/elpy.el
@@ -1681,7 +1681,8 @@ If ASK-FOR-EACH-ONE is non-nil, ask before killing each python process.
     ;; Get active python shell buffers and kill inactive ones (if asked)
     (loop for buffer being the buffers do
 	  (when (and (buffer-name buffer)
-                     (string-match "^\*Python\\\[.*\\]\*$" (buffer-name buffer)))
+		     (string-match (rx bol "*Python" (opt "[" (* (not (any "]"))) "]") "*" eol)
+				   (buffer-name buffer)))
 	    (if (get-buffer-process buffer)
 		(push buffer python-buffer-list)
 	      (when kill-buffers


### PR DESCRIPTION
…ffer(s)

This is a fix for the problem reported in
https://github.com/jorgenschaefer/elpy/issues/1147#issue-238358628

This replaces the original regular-expression for one that does not
mandate that the buffer name contains a square-bracketed
expression. It is unknown why it needed to match the square-bracketed
expression in the first place, since the only buffer names I have seen
in practice being created by elpy are "*Python*". Perhaps in the past
there were allowed to be multiple interactive Python buffers?
Regardless, make it match either with or without the square-bracketed
form of buffer names.