### PR TITLE
cl-generic dependency typo fixup

### DIFF
--- a/Cask
+++ b/Cask
@@ -11,7 +11,7 @@
 (depends-on "pyvenv" "1.2")
 (depends-on "yasnippet" "0.8.0")
 (depends-on "s" "1.11.0")
-(depends-on "cl-generic" "1.0")
+(depends-on "cl-generic" "0.3")
 
 (development
  (depends-on "dash")

--- a/elpy-pkg.el
+++ b/elpy-pkg.el
@@ -6,5 +6,5 @@
                   (pyvenv "1.3")
                   (yasnippet "0.8.0")
                   (s "1.11.0")
-                  (cl-generic "1.0"))
+                  (cl-generic "0.3"))
                 )


### PR DESCRIPTION
Fix due to dependency error while installing elpy.