### PR TITLE
Use project root as shell default directory

### DIFF
--- a/docs/ide.rst
+++ b/docs/ide.rst
@@ -196,6 +196,11 @@ The Shell Buffer
    Switch to buffer with a Python interpreter running, starting one if
    necessary.
 
+   By default, Elpy tries to find the root directory of the current project
+   (git, svn or hg repository, python package or projectile project) and
+   starts the python interpreter here. This behaviour can be suppressed
+   with the option ``elpy-shell-use-project-root``.
+
 .. option:: elpy-dedicated-shells
 
    By default, Elpy only starts a single interactive Python process. This

--- a/elpy-shell.el
+++ b/elpy-shell.el
@@ -89,6 +89,15 @@ in the Python shell."
   :type 'integer
   :group 'elpy)
 
+(defcustom elpy-shell-use-project-root t
+  "Whether to use project root as default directory for python shells.
+
+If nil, the current file directory is used.
+Project root is determined using `elpy-project-root' function."
+  :type 'integer
+  :group 'elpy)
+
+
 ;;;;;;;;;;;;;;;
 ;;; Shell setup
 
@@ -290,7 +299,10 @@ Python process. This allows the process to start up."
     (if elpy-dedicated-shells
         (if dedproc
             dedproc
-          (run-python (python-shell-parse-command) t t)
+          (let ((default-directory (or (and elpy-shell-use-project-root
+                                            (elpy-project-root))
+                                       default-directory)))
+            (run-python (python-shell-parse-command) t t))
           (when sit
             (sit-for sit))
           (get-buffer-process dedbufname))
@@ -298,7 +310,10 @@ Python process. This allows the process to start up."
           dedproc
         (if proc
             proc
-          (run-python (python-shell-parse-command) nil t)
+          (let ((default-directory (or (and elpy-shell-use-project-root
+                                            (elpy-project-root))
+                                       default-directory)))
+            (run-python (python-shell-parse-command) nil t))
           (when sit
             (sit-for sit))
           (get-buffer-process bufname))))))

--- a/elpy-shell.el
+++ b/elpy-shell.el
@@ -90,11 +90,11 @@ in the Python shell."
   :group 'elpy)
 
 (defcustom elpy-shell-use-project-root t
-  "Whether to use project root as default directory for python shells.
+  "Whether to use project root as default directory when starting a Python shells.
 
-If nil, the current file directory is used.
-Project root is determined using `elpy-project-root' function."
-  :type 'integer
+The project root is determined using `elpy-project-root`. If this variable is set to 
+nil, the current directory is used instead."
+  :type 'boolean
   :group 'elpy)
 
 


### PR DESCRIPTION
Fix issue #1178 (related to issue #1170).

New shells can now be started from the project root directory.
This feature is disabled by default to avoid confusing users and can be activated through the new option `elpy-shell-use-project-root`.
