### PR TITLE
Fix dedicated-shells and echo-input conflict

### DIFF
--- a/elpy-shell.el
+++ b/elpy-shell.el
@@ -502,7 +502,7 @@ Prepends a continuation promt if PREPEND-CONT-PROMPT is set."
   (let ((buffer (current-buffer)))
     (set-buffer (process-buffer (elpy-shell-get-or-create-process)))
     (let ((initial-point (point))
-          (mark-point (process-mark (elpy-shell-get-or-create-process))))
+          (mark-point (process-mark (get-buffer-process (current-buffer)))))
       (goto-char mark-point)
       (if prepend-cont-prompt
           (let* ((column (+ (- (point) (progn (forward-line -1) (end-of-line) (point))) 1))


### PR DESCRIPTION
Before that, activating both `elpy-dedicated-shells` and  `elpy-shell-echo-input` options leads to the creation of new python shells at each code evaluation.

Due to the use of `(elpy-shell-get-or-create-process)`, that return a new process when used while in the python shell buffer.

@rgemulla: Do you thing this would break something else ?