### PR TITLE
Avoid the delay of 3 seconds when sending code for the first time.

### DIFF
--- a/elpy-shell.el
+++ b/elpy-shell.el
@@ -309,11 +309,14 @@ Python process. This allows the process to start up."
 If the shell is not running, waits until the first prompt is visible and
 commands can be sent to the shell."
   (with-current-buffer (process-buffer (elpy-shell-get-or-create-process))
-    (let ((inhibit-text-field-motion t))
-      (while (progn
-               (goto-char (point-min))
-               (not (re-search-forward "^>>>" nil t)))
-        (sleep-for .1))))
+    (let ((cumtime 0))
+      (while (and (when (boundp 'python-shell--first-prompt-received)
+                    (not python-shell--first-prompt-received))
+                  (< cumtime 3))
+        (sleep-for 0.1)
+        (setq cumtime (+ cumtime 0.1)))
+      (when (>= cumtime 3)
+        (message "Elpy warning: failed to detect receipt of the first prompt (timeout)"))))
   (elpy-shell-get-or-create-process))
 
 (defun elpy-shell--region-without-indentation (beg end)

--- a/elpy-shell.el
+++ b/elpy-shell.el
@@ -306,10 +306,15 @@ Python process. This allows the process to start up."
 (defun elpy-shell--ensure-shell-running ()
   "Ensure that the Python shell for the current buffer is running.
 
-If the shell is not running, waits a while so that the first
-prompt is visible and commands can be sent to the shell."
-  ;; this should be enough time to start the shell and show the first prompt
-  (elpy-shell-get-or-create-process 3))
+If the shell is not running, waits until the first prompt is visible and
+commands can be sent to the shell."
+  (with-current-buffer (process-buffer (elpy-shell-get-or-create-process))
+    (let ((inhibit-text-field-motion t))
+      (while (progn
+               (goto-char (point-min))
+               (not (re-search-forward "^>>>" nil t)))
+        (sleep-for .1))))
+  (elpy-shell-get-or-create-process))
 
 (defun elpy-shell--region-without-indentation (beg end)
   "Return the current region as a string, but without indentation."

--- a/elpy-shell.el
+++ b/elpy-shell.el
@@ -314,9 +314,7 @@ commands can be sent to the shell."
                     (not python-shell--first-prompt-received))
                   (< cumtime 3))
         (sleep-for 0.1)
-        (setq cumtime (+ cumtime 0.1)))
-      (when (>= cumtime 3)
-        (message "Elpy warning: failed to detect receipt of the first prompt (timeout)"))))
+        (setq cumtime (+ cumtime 0.1)))))
   (elpy-shell-get-or-create-process))
 
 (defun elpy-shell--region-without-indentation (beg end)


### PR DESCRIPTION
There is a hard-coded delay of 3 seconds when sending code for the first time (using `elpy-shell-send-region-or-buffer` for example).
It can be annoying if ones needs to restart the python shell often.
Moreover, 3 seconds may not be enough for slow computer or heavily loaded python startups.

This fix instead detects the display of the first prompt ('>>>') in the python shell buffer.
I couldn't find a better way of doing this (e.g. catch a signal from the python shell ?).

@rgemulla: did I understand this delay correctly ?