### PR TITLE
Add goto assignment function

### DIFF
--- a/elpy.el
+++ b/elpy.el
@@ -1591,6 +1591,14 @@ with a prefix argument)."
         (elpy-goto-location (car location) (cadr location))
       (error "No definition found"))))
 
+(defun elpy-goto-assignment ()
+  "Go to the assignment of the symbol at point, if found."
+  (interactive)
+  (let ((location (elpy-rpc-get-assignment)))
+    (if location
+        (elpy-goto-location (car location) (cadr location))
+      (error "No assignment found"))))
+
 (defun elpy-goto-definition-other-window ()
   "Go to the definition of the symbol at point in other window, if found."
   (interactive)
@@ -1598,6 +1606,14 @@ with a prefix argument)."
     (if location
         (elpy-goto-location (car location) (cadr location) 'other-window)
       (error "No definition found"))))
+
+(defun elpy-goto-assignment-other-window ()
+  "Go to the assignment of the symbol at point in other window, if found."
+  (interactive)
+  (let ((location (elpy-rpc-get-assignment)))
+    (if location
+        (elpy-goto-location (car location) (cadr location) 'other-window)
+      (error "No assignment found"))))
 
 (defun elpy-goto-location (filename offset &optional other-window-p)
   "Show FILENAME at OFFSET to the user.
@@ -3080,6 +3096,17 @@ Returns a list of file name and line number, or nil"
 
 Returns nil or a list of (filename, point)."
   (elpy-rpc "get_definition"
+            (list buffer-file-name
+                  (elpy-rpc--buffer-contents)
+                  (- (point)
+                     (point-min)))
+            success error))
+
+(defun elpy-rpc-get-assignment (&optional success error)
+  "Call the find_assignment API function.
+
+Returns nil or a list of (filename, point)."
+  (elpy-rpc "get_assignment"
             (list buffer-file-name
                   (elpy-rpc--buffer-contents)
                   (- (point)

--- a/elpy/server.py
+++ b/elpy/server.py
@@ -122,6 +122,13 @@ class ElpyRPCServer(JSONRPCServer):
         return self._call_backend("rpc_get_definition", None, filename,
                                   get_source(source), offset)
 
+    def rpc_get_assignment(self, filename, source, offset):
+        """Get the location of the assignment for the symbol at the offset.
+
+        """
+        return self._call_backend("rpc_get_assignment", None, filename,
+                                  get_source(source), offset)
+
     def rpc_get_docstring(self, filename, source, offset):
         """Get the docstring for the symbol at the offset.
 

--- a/elpy/tests/support.py
+++ b/elpy/tests/support.py
@@ -595,6 +595,103 @@ class RPCGetDefinitionTests(GenericRPCTests):
                          (filename, 0))
 
 
+class RPCGetAssignmentTests(GenericRPCTests):
+    METHOD = "rpc_get_assignment"
+
+    def test_should_return_assignment_location_same_file(self):
+        source, offset = source_and_offset("import threading\n"
+                                           "class TestClass(object):\n"
+                                           "    def __init__(self, a, b):\n"
+                                           "        self.a = a\n"
+                                           "        self.b = b\n"
+                                           "\n"
+                                           "testclass = TestClass(2, 4)"
+                                           "\n"
+                                           "testcl_|_ass(\n")
+        filename = self.project_file("test.py", source)
+
+        location = self.backend.rpc_get_assignment(filename,
+                                                   source,
+                                                   offset)
+
+        self.assertEqual(location[0], filename)
+        # On def or on the function name
+        self.assertEqual(location[1], 111)
+
+    def test_should_return_location_in_same_file_if_not_saved(self):
+        source, offset = source_and_offset("import threading\n"
+                                           "class TestClass(object):\n"
+                                           "    def __init__(self, a, b):\n"
+                                           "        self.a = a\n"
+                                           "        self.b = b\n"
+                                           "\n"
+                                           "testclass = TestClass(2, 4)"
+                                           "\n"
+                                           "testcl_|_ass(\n")
+        filename = self.project_file("test.py", "")
+
+        location = self.backend.rpc_get_assignment(filename,
+                                                   source,
+                                                   offset)
+
+        self.assertEqual(location[0], filename)
+        # def or function name
+        self.assertEqual(location[1], 111)
+
+    def test_should_return_location_in_different_file(self):
+        source1 = ("class TestClass(object):\n"
+                   "    def __init__(self, a, b):\n"
+                   "        self.a = a\n"
+                   "        self.b = b\n"
+                   "testclass = TestClass(3, 5)\n")
+        file1 = self.project_file("test1.py", source1)
+        source2, offset = source_and_offset("from test1 import testclass\n"
+                                            "testcl_|_ass.a\n")
+        file2 = self.project_file("test2.py", source2)
+        # First jump goes to import statement
+        assignment = self.backend.rpc_get_assignment(file2,
+                                                     source2,
+                                                     offset)
+        # Second jump goes to test1 file
+        self.assertEqual(assignment[0], file2)
+        assignment = self.backend.rpc_get_assignment(file2,
+                                                     source2,
+                                                     assignment[1])
+
+        self.assertEqual(assignment[0], file1)
+        self.assertEqual(assignment[1], 93)
+
+    def test_should_return_none_if_location_not_found(self):
+        source, offset = source_and_offset("test_f_|_unction()\n")
+        filename = self.project_file("test.py", source)
+
+        assignment = self.backend.rpc_get_assignment(filename,
+                                                     source,
+                                                     offset)
+
+        self.assertIsNone(assignment)
+
+    def test_should_return_none_if_outside_of_symbol(self):
+        source, offset = source_and_offset("testcl(_|_)ass\n")
+        filename = self.project_file("test.py", source)
+
+        assignment = self.backend.rpc_get_assignment(filename,
+                                                     source,
+                                                     offset)
+
+        self.assertIsNone(assignment)
+
+    def test_should_find_variable_assignment(self):
+        source, offset = source_and_offset("SOME_VALUE = 1\n"
+                                           "\n"
+                                           "variable = _|_SOME_VALUE\n")
+        filename = self.project_file("test.py", source)
+        self.assertEqual(self.backend.rpc_get_assignment(filename,
+                                                         source,
+                                                         offset),
+                         (filename, 0))
+
+
 class RPCGetCalltipTests(GenericRPCTests):
     METHOD = "rpc_get_calltip"
 

--- a/elpy/tests/test_jedibackend.py
+++ b/elpy/tests/test_jedibackend.py
@@ -15,6 +15,7 @@ from elpy.tests.support import RPCGetCompletionDocstringTests
 from elpy.tests.support import RPCGetCompletionLocationTests
 from elpy.tests.support import RPCGetDocstringTests
 from elpy.tests.support import RPCGetDefinitionTests
+from elpy.tests.support import RPCGetAssignmentTests
 from elpy.tests.support import RPCGetCalltipTests
 from elpy.tests.support import RPCGetUsagesTests
 from elpy.tests.support import RPCGetNamesTests
@@ -84,6 +85,25 @@ class TestRPCGetDefinition(RPCGetDefinitionTests,
         ]
         script = Script.return_value
         script.goto_definitions.return_value = locations
+        script.goto_assignments.return_value = locations
+
+        location = self.rpc("", "", 0)
+
+        self.assertIsNone(location)
+
+
+class TestRPCGetAssignment(RPCGetAssignmentTests,
+                           JediBackendTestCase):
+    @mock.patch("jedi.Script")
+    def test_should_not_fail_if_module_path_is_none(self, Script):
+        """Do not fail if loc.module_path is None.
+
+        """
+        locations = [
+            mock.Mock(module_path=None)
+        ]
+        script = Script.return_value
+        script.goto_assignments.return_value = locations
         script.goto_assignments.return_value = locations
 
         location = self.rpc("", "", 0)

--- a/elpy/tests/test_server.py
+++ b/elpy/tests/test_server.py
@@ -230,6 +230,16 @@ class TestRPCGetDefinition(BackendCallTestCase):
                                                       "offset"))
 
 
+class TestRPCGetAssignment(BackendCallTestCase):
+    def test_should_call_backend(self):
+        self.assert_calls_backend("rpc_get_assignment")
+
+    def test_should_handle_no_backend(self):
+        self.srv.backend = None
+        self.assertIsNone(self.srv.rpc_get_assignment("filname", "source",
+                                                      "offset"))
+
+
 class TestRPCGetDocstring(BackendCallTestCase):
     def test_should_call_backend(self):
         self.assert_calls_backend("rpc_get_docstring")

--- a/test/elpy-goto-assignment-other-window-test.el
+++ b/test/elpy-goto-assignment-other-window-test.el
@@ -1,0 +1,22 @@
+(ert-deftest elpy-goto-assignment-other-window-should-open-other-window ()
+  (elpy-testcase ()
+                 (mletf* ((elpy-rpc-get-assignment
+                           ()
+                           '(test location t))
+                          (elpy-goto-location
+                           (line column window)
+                           (if window
+                               (split-window-below))))
+
+                         (elpy-goto-assignment-other-window)
+
+                         (should (= (count-windows) 2)))))
+
+
+(ert-deftest elpy-goto-assignment-other-window-should-fail-for-missing-location ()
+  (elpy-testcase ()
+                 (mletf* ((elpy-rpc-get-assignment
+                           ()
+                           nil))
+
+                         (should-error (elpy-goto-assignment-other-window)))))

--- a/test/elpy-goto-assignment-test.el
+++ b/test/elpy-goto-assignment-test.el
@@ -1,0 +1,24 @@
+(ert-deftest elpy-goto-assignment-should-pass-location ()
+  (elpy-testcase ()
+    (mletf* ((elpy-rpc-get-assignment
+              ()
+              '(test location))
+             (goto-location-line nil)
+             (goto-location-col nil)
+             (elpy-goto-location
+              (line column)
+              (setq goto-location-line line
+                    goto-location-col column)))
+
+      (elpy-goto-assignment)
+
+      (should (equal goto-location-line 'test))
+      (should (equal goto-location-col 'location)))))
+
+(ert-deftest elpy-goto-assignment-should-fail-for-missing-location ()
+  (elpy-testcase ()
+    (mletf* ((elpy-rpc-get-assignment
+              ()
+              nil))
+
+      (should-error (elpy-goto-assignment)))))

--- a/test/elpy-rpc-get-assignment-test.el
+++ b/test/elpy-rpc-get-assignment-test.el
@@ -1,0 +1,11 @@
+(ert-deftest elpy-rpc-get-assignment ()
+  (elpy-testcase ()
+    (mletf* ((called-args nil)
+             (elpy-rpc (&rest args) (setq called-args args)))
+
+      (elpy-rpc-get-assignment)
+
+      (should (equal called-args
+                     '("get_assignment"
+                       (nil "" 0)
+                       nil nil))))))


### PR DESCRIPTION
Follow issue #1214.
Add `elpy-goto-assignment` function to benefit from the jedi `get_assignments` feature.

In this situation:
```Python
class TestClass(object):
    def __init__(a, b):
        self.a = a
        self.b = b

testclass = TestClass(2, 4)

testcla|ss.a
```
`elpy-goto-definition` jumps to the class definition:
```Python
|class TestClass(object):
    def __init__(a, b):
        self.a = a
        self.b = b

testclass = TestClass(2, 4)

testclass.a
```
while `elpy-goto-assignment` jumps to the variable assignment:
```Python
class TestClass(object):
    def __init__(a, b):
        self.a = a
        self.b = b

|testclass = TestClass(2, 4)

testclass.a
```