### PR TITLE
Allow better code sending to shell

### DIFF
--- a/docs/ide.rst
+++ b/docs/ide.rst
@@ -241,19 +241,35 @@ The Shell Buffer
    starts the python interpreter here. This behaviour can be suppressed
    with the option ``elpy-shell-use-project-root``.
 
-.. option:: elpy-dedicated-shells
+.. command:: elpy-shell-toggle-dedicated-shell
 
-   By default, Elpy only starts a single interactive Python process. This
-   process will inherit the current virtual env. If you want to start a Python
-   interpreter with a different virtual env, you can either kill the existing
-   one, or rename the buffer. Moreover, if `elpy-dedicated-shells` is set to
-   ``t``, Elpy creates a dedicated shell for each buffer.
+   By default, python buffers are all attached to a same python shell
+   (that lies in the `*Python*` buffer), meaning that all buffers and
+   code fragments will be executed in this shell.
+   `elpy-shell-toggle-dedicated-shell` attaches a dedicated python shell
+   (not shared with the other python buffers) to the current python buffer.
+   To make this the default behavior (like the deprecated option
+   `elpy-dedicated-shells` did), you can use the following snippet:
+
+.. code-block:: lisp
+
+   (add-hook 'elpy-mode-hook (lambda () (elpy-shell-toggle-dedicated-shell 1)))
+
+.. command:: elpy-shell-set-local-shell
+
+   Attach the current python buffer to a specific python shell (whose name is
+   asked with completion).
+   You can use this function, for example, to have one python shell per project,
+   with:
+
+.. code-block:: lisp
+
+   (add-hook 'elpy-mode-hook (lambda () (elpy-shell-set-local-shell elpy-project-root)))
 
 .. command:: elpy-shell-kill
    :kbd: C-c C-k
 
-   Kill the current python shell. If :option:`elpy-dedicated-shells` is non-nil,
-   kill the current buffer dedicated shell.
+   Kill the associated python shell.
 
 .. command:: elpy-shell-kill-all
    :kbd: C-c C-K

--- a/docs/ide.rst
+++ b/docs/ide.rst
@@ -245,11 +245,11 @@ The Shell Buffer
 
    By default, python buffers are all attached to a same python shell
    (that lies in the `*Python*` buffer), meaning that all buffers and
-   code fragments will be executed in this shell.
+   code fragments will be send to this shell.
    `elpy-shell-toggle-dedicated-shell` attaches a dedicated python shell
    (not shared with the other python buffers) to the current python buffer.
    To make this the default behavior (like the deprecated option
-   `elpy-dedicated-shells` did), you can use the following snippet:
+   `elpy-dedicated-shells` did), use the following snippet:
 
 .. code-block:: lisp
 
@@ -259,8 +259,7 @@ The Shell Buffer
 
    Attach the current python buffer to a specific python shell (whose name is
    asked with completion).
-   You can use this function, for example, to have one python shell per project,
-   with:
+   You can use this function to have one python shell per project, with:
 
 .. code-block:: lisp
 

--- a/elpy-shell.el
+++ b/elpy-shell.el
@@ -40,7 +40,7 @@ force the creation of dedicated shells for each buffers."
   :group 'elpy)
 (make-obsolete-variable 'elpy-dedicated-shells
                         "Dedicated shells are no longer supported by Elpy.
-See the documentation to achieve the same behavior with `elpy-shell-toggle-dedicated-shell'."
+You can use `(add-hook 'elpy-mode-hook (lambda () (elpy-shell-toggle-dedicated-shell 1)))' to achieve the same result."
                         "1.17.0")
 
 (defcustom elpy-shell-display-buffer-after-send nil ;
@@ -255,9 +255,9 @@ if ARG is negative or 0, disable the use of a dedicated shell."
 (defun elpy-shell-set-local-shell (&optional shell-name)
   "Associate the current buffer to a specific shell.
 
-This means that the code from the current buffer will be sent to this shell.
+Meaning that the code from the current buffer will be sent to this shell.
 
-If SHELL-NAME is not specified, ask with completion for a name.
+If SHELL-NAME is not specified, ask with completion for a shell name.
 
 If SHELL-NAME is \"Global\", associate the current buffer to the main python
 shell (often \"*Python*\" shell)."

--- a/test/elpy-shell-kill-all-should-kill-all-shell-buffers.el
+++ b/test/elpy-shell-kill-all-should-kill-all-shell-buffers.el
@@ -4,7 +4,7 @@
 	  (buff2 (generate-new-buffer "buff2"))
 	  (shell-buff1 nil)
 	  (shell-buff2 nil)
-	  (elpy-dedicated-shells t))
+	  (add-hook 'elpy-mode-hook (lambda () (elpy-shell-toggle-dedicated-shell 1))))
       (with-current-buffer buff1
 	(python-mode)
 	(elpy-mode 1)

--- a/test/elpy-shell-kill-all-should-kill-all-shells.el
+++ b/test/elpy-shell-kill-all-should-kill-all-shells.el
@@ -4,7 +4,7 @@
 	  (buff2 (generate-new-buffer "buff2"))
 	  (shell-buff1 nil)
 	  (shell-buff2 nil)
-	  (elpy-dedicated-shells t))
+          (add-hook (lambda () (elpy-shell-toggle-dedicated-shell 1))))
       (with-current-buffer buff1
 	(python-mode)
 	(elpy-mode 1)

--- a/test/elpy-shell-set-local-shell-test.el
+++ b/test/elpy-shell-set-local-shell-test.el
@@ -1,0 +1,19 @@
+(ert-deftest elpy-shell-set-local-shell-should-set-a-local-shell ()
+  (elpy-testcase ()
+    (python-mode)
+    (elpy-mode 1)
+    (elpy-shell-set-local-shell "localshell")
+    (save-excursion
+      (elpy-shell-switch-to-shell)
+      (should (string= (buffer-name)
+                       (format "*Python[localshell]*"))))
+    (elpy-shell-set-local-shell "anotherlocalshell")
+    (save-excursion
+      (elpy-shell-switch-to-shell)
+      (should (string= (buffer-name)
+                       (format "*Python[anotherlocalshell]*"))))
+    (elpy-shell-set-local-shell "Global")
+    (save-excursion
+      (elpy-shell-switch-to-shell)
+      (should (string= (buffer-name)
+                       "*Python*")))))

--- a/test/elpy-shell-toggle-dedicated-shell-test.el
+++ b/test/elpy-shell-toggle-dedicated-shell-test.el
@@ -1,0 +1,15 @@
+(ert-deftest elpy-shell-toggle-dedicated-shell-should-give-dedicated-shells ()
+  (elpy-testcase ()
+    (python-mode)
+    (elpy-mode 1)
+    (elpy-shell-toggle-dedicated-shell)
+    (let ((bufname (buffer-name)))
+      (save-excursion
+        (elpy-shell-switch-to-shell)
+        (should (string= (buffer-name)
+                         (format "*Python[%s]*"bufname))))
+      (elpy-shell-toggle-dedicated-shell)
+      (save-excursion
+        (elpy-shell-switch-to-shell)
+        (should (string= (buffer-name)
+                         "*Python*"))))))


### PR DESCRIPTION
Apparently Elpy users have a wide variety of workflows that necessitate different relations between python buffers and interactive shells (see PR #839 and issues #1100 and #1197).
This is an attempt to allow all those different workflows while keeping the code simple.

This PR defines a new option `elpy-shell-code-sending-strategy` which can be used to control to which python shell the code should be sent. 

Available options are:
- **on-shell**: the default behavior of elpy. everything is sent to a main python shell.
- **dedicated-shells**: the old behavior of elpy when `elpy-dedicated-shells` was non-nil. Each buffer send its code to a dedicated python shell. Functionality introduced by PR #839.
- **manual-switching**: the code is sent to a main python shell for all buffers, but you can switch between different main python shells with `elpy-shell-switch-python-shell`. Functionality discussed in #1197.
- **project-shell**: one shell per project (as identified by `elpy-project-root`). Functionality discussed in #1100.
- **ask**: Ask to which buffer the code has to be sent for each buffer (only the first time code is sent).

After implementing and testing it, I am not sure the **ask** option is really useful...

One advantage of this implementation is that code modifications are restrained  in `elpy-shell-get-or-create-process`.

I am waiting for some feedback on this before finalizing (notably updating the tests and the documentation).