### PR TITLE
Add python3.6 to travis ci

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,6 +5,7 @@ python:
   - 3.3
   - 3.4
   - 3.5
+  - 3.6
 env:
   # - EVM_EMACS=emacs-24.1-travis
   # - EVM_EMACS=emacs-24.2-travis


### PR DESCRIPTION
Does anyone know if there is a strong usage of 3.3? From what I've heard most people are on 3.4 or higher if they're doing py3 stuff 