### PR TITLE
fix #1255, `elpy-xref--identifier-at-point` should return a string

### DIFF
--- a/elpy.el
+++ b/elpy.el
@@ -3115,7 +3115,7 @@ Points to file FILE, at position POS."
     "Return identifier at point.
 
 Is a string, formatted as \"LINE_NUMBER: VARIABLE_NAME\"."
-    (let ((symb (substring-no-properties (symbol-name (symbol-at-point))))
+    (let ((symb (thing-at-point 'symbol t))
           (assign (elpy-rpc-get-assignment)))
       (when assign (format "%s: %s"
                         (line-number-at-pos (+ 1 (car (cdr assign))))


### PR DESCRIPTION
This fix the issue #1255 reported by @rksm.

`elpy-xref--identifier-at-point` now return a string instead of a symbol, in agreement with the xref documentation.