### PR TITLE
fix overriding xref keys if xref is installed

### DIFF
--- a/elpy.el
+++ b/elpy.el
@@ -435,12 +435,12 @@ option is `pdb'."
     (define-key map (kbd "<M-left>") 'elpy-nav-indent-shift-left)
     (define-key map (kbd "<M-right>") 'elpy-nav-indent-shift-right)
 
-    (if (not (boundp 'xref-find-definitions))
+    (if (not (fboundp 'xref-find-definitions))
         (define-key map (kbd "M-.") 'elpy-goto-definition))
-    (if (not (boundp 'xref-find-definitions-other-window))
+    (if (not (fboundp 'xref-find-definitions-other-window))
         (define-key map (kbd "C-x 4 M-.") 'elpy-goto-definition-other-window)
       (define-key map (kbd "C-x 4 M-.") 'xref-find-definitions-other-window))
-    (if (boundp 'xref-pop-marker-stack)
+    (if (fboundp 'xref-pop-marker-stack)
       (define-key map (kbd "M-*") 'xref-pop-marker-stack))
 
     (define-key map (kbd "M-TAB") 'elpy-company-backend)


### PR DESCRIPTION
I was reading the elpy documentation and I saw this: "If you use an Emacs version superior to 25, elpy will define the necessary backends for the xref package." I am on Emacs 25.2.2 but `M-.` was still bound to `elpy-goto-definition` instead of `xref-find-definitions`.

Looking at elpy.el, I can see that the check for `xref-find-definitions` is done with `boundp`. I am not very experienced with elisp, but from what I can gather `boundp` is for variables while `fboundp` is for functions. Changing these instances of `boundp` to `fboundp` seems to fix the issue for me.

If this is not the correct solution, or I have misunderstood how this functionality is supposed to work, please do let me know!