### PR TITLE
fix void function call in elpy-django-command

### DIFF
--- a/Cask
+++ b/Cask
@@ -11,6 +11,5 @@
 (depends-on "s" "1.11.0")
 
 (development
- (depends-on "dash")
  (depends-on "f")
  (depends-on "ert-runner"))

--- a/elpy-django.el
+++ b/elpy-django.el
@@ -123,7 +123,7 @@ require arguments in order for it to work."
     ;; get a list of commands from the output of manage.py -h
     ;; What would be the pattern to optimize this ?
     (setq dj-commands-str (split-string dj-commands-str "\n"))
-    (setq dj-commands-str (-remove (lambda (x) (string= x "")) dj-commands-str))
+    (setq dj-commands-str (remove (lambda (x) (string= x "")) dj-commands-str))
     (setq dj-commands-str (mapcar (lambda (x) (s-trim x)) dj-commands-str))
     (sort dj-commands-str 'string-lessp)))
 

--- a/elpy-django.el
+++ b/elpy-django.el
@@ -123,7 +123,7 @@ require arguments in order for it to work."
     ;; get a list of commands from the output of manage.py -h
     ;; What would be the pattern to optimize this ?
     (setq dj-commands-str (split-string dj-commands-str "\n"))
-    (setq dj-commands-str (remove (lambda (x) (string= x "")) dj-commands-str))
+    (setq dj-commands-str (cl-remove-if (lambda (x) (string= x "")) dj-commands-str))
     (setq dj-commands-str (mapcar (lambda (x) (s-trim x)) dj-commands-str))
     (sort dj-commands-str 'string-lessp)))
 


### PR DESCRIPTION
When running `C-c C-x c (elpy-django-command)` I see the following:
`elpy-django--get-commands: Symbol’s function definition is void: -remove`
This change proposal appears to fix the error.

As with my other PR - I'm not very experienced with elisp so it's possible I'm missing something.