### PR TITLE
Fix some compilation warnings

### DIFF
--- a/elpy-django.el
+++ b/elpy-django.el
@@ -118,7 +118,8 @@ require arguments in order for it to work."
               ;; cleanup [auth] and stuff
               (goto-char (point-min))
               (save-excursion
-                (replace-regexp "\\[.*\\]" ""))
+                (while (re-search-forward "\\[.*\\]" nil t)
+                  (replace-match "" nil nil)))
               (buffer-string))))
     ;; get a list of commands from the output of manage.py -h
     ;; What would be the pattern to optimize this ?

--- a/elpy-refactor.el
+++ b/elpy-refactor.el
@@ -130,7 +130,7 @@ Available types:
   boolean      - A boolean question"
   (mapcar (lambda (arg)
             (let ((type (cadr arg))
-                  (prompt (caddr arg)))
+                  (prompt (cl-caddr arg)))
               (cond
                ((equal type "offset")
                 (aref pos 0))

--- a/elpy-shell.el
+++ b/elpy-shell.el
@@ -185,12 +185,11 @@ If KILL-BUFF is non-nil, also kill the associated buffer."
   "Kill all active python shells.
 
 If KILL-BUFFERS is non-nil, also kill the associated buffers.
-If ASK-FOR-EACH-ONE is non-nil, ask before killing each python process.
-"
+If ASK-FOR-EACH-ONE is non-nil, ask before killing each python process."
   (interactive)
   (let ((python-buffer-list ()))
     ;; Get active python shell buffers and kill inactive ones (if asked)
-    (loop for buffer being the buffers do
+    (cl-loop for buffer being the buffers do
 	  (when (and (buffer-name buffer)
 		     (string-match (rx bol "*Python" (opt "[" (* (not (any "]"))) "]") "*" eol)
 				   (buffer-name buffer)))
@@ -201,15 +200,15 @@ If ASK-FOR-EACH-ONE is non-nil, ask before killing each python process.
     (cond
      ;; Ask for each buffers and kill
      ((and python-buffer-list ask-for-each-one)
-      (loop for buffer in python-buffer-list do
-	    (when (y-or-n-p (format "Kill %s ?" buffer))
+      (cl-loop for buffer in python-buffer-list do
+	    (when (y-or-n-p (format "Kill %s ? " buffer))
 		(delete-process buffer)
 		(when kill-buffers
 		  (kill-buffer buffer)))))
      ;; Ask and kill every buffers
      (python-buffer-list
-      (if (y-or-n-p (format "Kill %s python shells ?" (length python-buffer-list)))
-	  (loop for buffer in python-buffer-list do
+      (if (y-or-n-p (format "Kill %s python shells ? " (length python-buffer-list)))
+	  (cl-loop for buffer in python-buffer-list do
 		(delete-process buffer)
 		(when kill-buffers
 		  (kill-buffer buffer)))))
@@ -611,8 +610,7 @@ there."
 Assumes that the point is precisely at the beginning of a
 statement (e.g., after calling
 `elpy-shell--nav-beginning-of-statement')."
-  (let ((indent (current-column))
-        (continue t)
+  (let ((continue t)
         (p))
     (while (and (not (eq p (point)))
                 continue)
@@ -855,7 +853,7 @@ variables `elpy-shell-cell-boundary-regexp' and
                (forward-line)
                (if (re-search-forward elpy-shell-cell-boundary-regexp nil t)
                    (forward-line -1)
-                 (end-of-buffer))
+                 (goto-char (point-max)))
                (end-of-line)
                (point))))
     (if beg

--- a/elpy.el
+++ b/elpy.el
@@ -169,7 +169,9 @@ These will be checked in turn. The first directory found is used."
                      elpy-project-find-svn-root))
   :group 'elpy)
 
-(make-obsolete-variable 'elpy-company-hide-modeline 'elpy-remove-modeline-lighter)
+(make-obsolete-variable 'elpy-company-hide-modeline
+                        'elpy-remove-modeline-lighter
+                        "1.10.0")
 (defcustom elpy-remove-modeline-lighter t
   "Non-nil if Elpy should remove most mode line display.
 
@@ -1744,7 +1746,10 @@ indentation levels."
   (setq elpy-nav-expand--initial-position (point))
   (let ((indentation (current-indentation)))
     (if (= indentation 0)
-        (mark-whole-buffer)
+        (progn
+          (push-mark (point))
+          (push-mark (point-max) nil t)
+          (goto-char (point-min)))
       (while (<= indentation (current-indentation))
         (forward-line -1))
       (forward-line 1)
@@ -2124,8 +2129,8 @@ prefix argument is given, prompt for a symbol from the user."
 (defun elpy-importmagic-fixup ()
   (interactive))
 
-(make-obsolete 'elpy-importmagic-add-import "support for importmagic has been dropped.")
-(make-obsolete 'elpy-importmagic-fixup "support for importmagic has been dropped.")
+(make-obsolete 'elpy-importmagic-add-import "support for importmagic has been dropped." "1.17.0")
+(make-obsolete 'elpy-importmagic-fixup "support for importmagic has been dropped." "1.17.0")
 
 ;;;;;;;;;;;;;;;;;;;;;
 ;;; Code reformatting
@@ -3141,7 +3146,8 @@ Try to find the identifier assignement if it is in the current buffer.
     "Goto the identifier ID in the current buffer.
 This is needed to get information on the identifier with jedi
 \(that work only on the symbol at point\)"
-    (goto-line (elpy-xref--identifier-line id))
+    (goto-char (point-min))
+    (forward-line (1- (elpy-xref--identifier-line id)))
     (search-forward (elpy-xref--identifier-name id))
     (goto-char (match-beginning 0)))
 


### PR DESCRIPTION
Fix some compilation warnings, mainly due to:
- obsolete command
- use of interactive-only commands
- unused variables