### PR TITLE
Fix Xref reference mis-behavior

### DIFF
--- a/docs/ide.rst
+++ b/docs/ide.rst
@@ -167,8 +167,7 @@ necessary backends for the `xref`_ package.
 .. command:: xref-find-references
    :kbd: M-?
 
-   Find references to the identifier at point.
-   With prefix argument, prompt for the identifier.
+   Find references for an identifier of the current buffer.
 
 .. command:: xref-find-apropos
    :kbd: C-M-.


### PR DESCRIPTION
Some bugs were introduced by the last modification of the xref backend (#1258, my bad).
Notable `xref-goto-definition` and `xref-find-reference` now fail when the symbol assignment is in another file.

 This PR fix those bugs.
(also fix the documentation for `xref-find-references`).
