### PR TITLE
Check for yapf and autopep8 modules instead of executables

### DIFF
--- a/elpy.el
+++ b/elpy.el
@@ -949,6 +949,11 @@ item in another window.\n\n")
 
     ))
 
+(defun elpy-config--package-available-p (package)
+  "Check if PACKAGE is installed in the rpc."
+  (equal 0 (call-process elpy-rpc-python-command nil nil nil "-c"
+                         (format "import %s" package))))
+
 (defun elpy-config--get-config ()
   "Return the configuration from `elpy-rpc-python-command'.
 
@@ -2134,9 +2139,9 @@ prefix argument is given, prompt for a symbol from the user."
   "Format code using the available formatter."
   (interactive)
   (cond
-   ((executable-find "yapf")
+   ((elpy-config--package-available-p "yapf")
     (elpy-yapf-fix-code))
-   ((executable-find "autopep8")
+   ((elpy-config--package-available-p "autopep8")
     (elpy-autopep8-fix-code))
    (t
     (message "Install yapf/autopep8 to format code."))))


### PR DESCRIPTION
Following #1275.
Presence of yapf and autopep8 is now checked by verifying the presence of the modules in the RPC instead of verifying the presence of their binaries.

Additionally, is there a good reason for the syntax checker to be specified as an executable instead of as a module ?
Would it not be more coherent to use the module, as for yapf, autopep8, ...