### PR TITLE
Update travis file to include last python and emacs versions

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,6 +5,7 @@ python:
   - 3.3
   - 3.4
   - 3.5
+  - 3.6
 env:
   # - EVM_EMACS=emacs-24.1-travis
   # - EVM_EMACS=emacs-24.2-travis
@@ -13,6 +14,7 @@ env:
   - EVM_EMACS=emacs-24.5-travis
   - EVM_EMACS=emacs-25.1-travis
   - EVM_EMACS=emacs-25.2-travis
+  - EVM_EMACS=emacs-25.3-travis
   # - EVM_EMACS=emacs-git-snapshot
 before_install:
   - curl -fsSkL https://gist.github.com/rejeep/ebcd57c3af83b049833b/raw > travis.sh && source ./travis.sh

--- a/elpy/tests/test_jedibackend.py
+++ b/elpy/tests/test_jedibackend.py
@@ -49,15 +49,21 @@ class TestRPCGetCompletionLocation(RPCGetCompletionLocationTests,
 
 class TestRPCGetDocstring(RPCGetDocstringTests,
                           JediBackendTestCase):
-    JSON_LOADS_DOCSTRING = (
-        'loads(s, encoding=None, cls=None, '
-        'object_hook=None, parse_float=None,'
-    )
 
     def check_docstring(self, docstring):
+        if sys.version_info >= (3, 6):
+            JSON_LOADS_DOCSTRING = (
+                'loads(s, *, encoding=None, cls=None, '
+                'object_hook=None, parse_float=None,'
+            )
+        else:
+            JSON_LOADS_DOCSTRING = (
+                'loads(s, encoding=None, cls=None, '
+                'object_hook=None, parse_float=None,'
+            )
         lines = docstring.splitlines()
         self.assertEqual(lines[0], 'Documentation for json.loads:')
-        self.assertEqual(lines[2], self.JSON_LOADS_DOCSTRING)
+        self.assertEqual(lines[2], JSON_LOADS_DOCSTRING)
 
     @mock.patch("elpy.jedibackend.run_with_debug")
     def test_should_not_return_empty_docstring(self, run_with_debug):


### PR DESCRIPTION
Add python3.6 and emacs25.3 to travis tests.
Also update a failing test (due to a change in json docstring in python3.6).
Should make #1243 obsolete.