### PR TITLE
Add missing dependency, fix #1285

### DIFF
--- a/elpy-shell.el
+++ b/elpy-shell.el
@@ -24,6 +24,8 @@
 ;;
 ;;; Code:
 
+(eval-when-compile (require 'subr-x))
+
 ;;;;;;;;;;;;;;;;;;;;;;
 ;;; User customization
 


### PR DESCRIPTION
Fix Issue #1285.

## Problem
When installing elpy from melpa on a clean emacs, 
compilation raise the following error: 
```
elpy-shell.el:977:1:Error: Symbol's function definition is void: string-remove-suffix
```

## Solution
It is fixed by adding the dependency to `subr-x` in `elpy-shell.el`.

Still, I thought that requiring `subr-x` in `elpy.el` would be enough, 
any ideas why it is not the case ?