### PR TITLE
Auto-update of the documentation buffer

### DIFF
--- a/docs/ide.rst
+++ b/docs/ide.rst
@@ -532,11 +532,13 @@ Elpy provides a single interface to documentation.
    With a prefix argument, Elpy will skip all the guessing and just
    prompt the user for a string to look up in pydoc.
 
+   Documentation buffer will be automatically updated with symbol at
+   point or with the currently selected company candidate.
+
 .. option:: elpy-autodoc-delay
 
-   Delay before which the documentation buffer will be updated using the symbol at point.
-   Documentation will also be updated from company candidate selection.
-   If nil, Elpy won't update the documentation buffer.
+   The idle delay in seconds until documentation is updated automatically.
+   If nil, disable automatic update of the documentation buffer.
 
 
 Testing

--- a/docs/ide.rst
+++ b/docs/ide.rst
@@ -532,6 +532,12 @@ Elpy provides a single interface to documentation.
    With a prefix argument, Elpy will skip all the guessing and just
    prompt the user for a string to look up in pydoc.
 
+.. option:: elpy-autodoc-delay
+
+   Delay before which the documentation buffer will be updated using the symbol at point.
+   Documentation will also be updated from company candidate selection.
+   If nil, Elpy won't update the documentation buffer.
+
 
 Testing
 =======

--- a/docs/ide.rst
+++ b/docs/ide.rst
@@ -532,13 +532,13 @@ Elpy provides a single interface to documentation.
    With a prefix argument, Elpy will skip all the guessing and just
    prompt the user for a string to look up in pydoc.
 
-   Documentation buffer will be automatically updated with symbol at
-   point or with the currently selected company candidate.
+If the `autodoc` module is enabled (not the case by default) the
+documentation is automatically updated with the symbol at point or the
+currently selected company candidate.
 
 .. option:: elpy-autodoc-delay
 
    The idle delay in seconds until documentation is updated automatically.
-   If nil, disable automatic update of the documentation buffer.
 
 
 Testing

--- a/elpy.el
+++ b/elpy.el
@@ -2138,7 +2138,7 @@ If nil, deactivate the documentation automatic refresh."
     (`post-command
      (when elpy-autodoc-delay
        (when elpy-autodoc--timer
-         (cancel-timer elpy-autodoc-timer))
+         (cancel-timer elpy-autodoc--timer))
        (setq elpy-autodoc--timer
              (run-with-timer elpy-autodoc-delay
                              nil

--- a/elpy.el
+++ b/elpy.el
@@ -75,7 +75,6 @@ This can be used to enable minor modes for Python development."
 (defcustom elpy-modules '(elpy-module-sane-defaults
                           elpy-module-company
                           elpy-module-eldoc
-                          elpy-module-autodoc
                           elpy-module-flymake
                           elpy-module-highlight-indentation
                           elpy-module-pyvenv
@@ -3818,11 +3817,8 @@ description."
   "Timer to refresh documentation.")
 
 (defcustom elpy-autodoc-delay .5
-  "The idle delay in seconds until documentation is refreshed automatically.
-
-If nil, deactivate the documentation automatic refresh."
-  :type '(choice (const :tag "never (nil)" nil)
-                 (const :tag "immediate (0)" 0)
+  "The idle delay in seconds until documentation is refreshed automatically."
+  :type '(choice (const :tag "immediate (0)" 0)
                  (number :tag "seconds"))
   :group 'elpy
   :group 'elpy-autodoc)

--- a/elpy.el
+++ b/elpy.el
@@ -3843,7 +3843,12 @@ If nil, deactivate the documentation automatic refresh."
 (defun elpy-autodoc--refresh-doc ()
   "Refresh the doc asynchronously with the symbol at point."
   (when (get-buffer-window "*Python Doc*")
-    (elpy-rpc-get-docstring 'elpy-autodoc--show-doc (lambda (_reason) nil))))
+    (save-excursion
+      (re-search-forward "\\>" (point-max) t)
+      (when (not (looking-at "("))
+        (python-nav-backward-up-list))
+      (elpy-rpc-get-docstring 'elpy-autodoc--show-doc
+                              (lambda (_reason) nil)))))
 
 (defun elpy-autodoc--show-doc (doc)
   "Display DOC (if any) but only if the doc buffer is currently visible."

--- a/elpy.el
+++ b/elpy.el
@@ -3810,7 +3810,7 @@ description."
     (`buffer-stop
      (remove-hook 'pre-command-hook 'elpy-autodoc--pre-command t)
      (remove-hook 'post-command-hook 'elpy-autodoc--post-command t)
-     (setq company-frontends (remove 'elpy-autodoc--frontend 'company-frontends)))))
+     (setq company-frontends (remove 'elpy-autodoc--frontend company-frontends)))))
 
 
 ;; Auto refresh documentation on cursor motion
@@ -3843,12 +3843,8 @@ If nil, deactivate the documentation automatic refresh."
 (defun elpy-autodoc--refresh-doc ()
   "Refresh the doc asynchronously with the symbol at point."
   (when (get-buffer-window "*Python Doc*")
-    (save-excursion
-      (re-search-forward "\\>" (point-max) t)
-      (when (not (looking-at "("))
-        (python-nav-backward-up-list))
-      (elpy-rpc-get-docstring 'elpy-autodoc--show-doc
-                              (lambda (_reason) nil)))))
+    (elpy-rpc-get-docstring 'elpy-autodoc--show-doc
+                            (lambda (_reason) nil))))
 
 (defun elpy-autodoc--show-doc (doc)
   "Display DOC (if any) but only if the doc buffer is currently visible."

--- a/elpy.el
+++ b/elpy.el
@@ -2101,7 +2101,11 @@ prefix argument is given, prompt for a symbol from the user."
 
 (defcustom elpy-autodoc-delay .5
   "Idle delay before which refreshing the documentation.
-If nil, deactivate documentation auto refresh.")
+If nil, deactivate documentation auto refresh."
+  :type '(choice (const :tag "never (nil)" nil)
+                 (const :tag "immediate (0)" 0)
+                 (number :tag "seconds"))
+  :group 'elpy)
 
 (defun elpy-autodoc--pre-command ()
   "Cancel autodoc timer on user action."
@@ -2136,7 +2140,7 @@ If nil, deactivate documentation auto refresh.")
                      (setq elpy-autodoc-timer
                            (run-with-timer elpy-autodoc-delay nil 'elpy-autodoc--refresh-doc-from-company))))
     (`hide
-     (when elpy-autodoc-delay
+     (when elpy-autodoc-timer
        (cancel-timer elpy-autodoc-timer)))))
 
 (defun elpy-autodoc--refresh-doc-from-company ()

--- a/test/elpy-doc--autodoc-test.el
+++ b/test/elpy-doc--autodoc-test.el
@@ -1,0 +1,60 @@
+(defun elpy-doc-test-insert-functions ()
+  (insert
+   "def fun1():
+    \"\"\"
+    fun1 documentation ##9ghtye
+    \"\"\"
+    pass
+def fun2():
+    \"\"\"
+    fun2 documentation #yhe38R
+    \"\"\"
+    pass\n"
+   ))
+
+(ert-deftest elpy-doc-should-be-updated-automatically ()
+  (elpy-testcase ()
+    (python-mode)
+    (elpy-mode)
+    (elpy-doc-test-insert-functions)
+    (insert "fun1")
+    (elpy-doc)
+    (with-current-buffer "*Python Doc*"
+      (should (re-search-forward "fun1 documentation ##9ghtye")))
+    (insert "\nfun2")
+    (run-hooks 'post-command-hook)
+    (sleep-for 2)
+    (with-current-buffer "*Python Doc*"
+      (should (re-search-forward "fun2 documentation #yhe38R")))))
+
+(ert-deftest elpy-doc-should-not-be-updated-if-doc-not-visible ()
+  (elpy-testcase ()
+    (python-mode)
+    (elpy-doc-test-insert-functions)
+    (insert "fun1")
+    (elpy-doc)
+    (with-current-buffer "*Python Doc*"
+      (should (re-search-forward "fun1 documentation ##9ghtye")))
+    (delete-window (get-buffer-window "*Python Doc*"))
+    (insert "\nfun2")
+    (run-hooks 'post-command-hook)
+    (sleep-for 2)
+    (with-current-buffer "*Python Doc*"
+      (should (re-search-forward "fun1 documentation ##9ghtye")))))
+
+(ert-deftest elpy-doc-should-not-be-updated-if-deactivated ()
+  (elpy-testcase ()
+    (python-mode)
+    (elpy-mode)
+    (setq elpy-autodoc-delay nil)
+    (elpy-doc-test-insert-functions)
+    (insert "fun1")
+    (elpy-doc)
+    (with-current-buffer "*Python Doc*"
+      (should (re-search-forward "fun1 documentation ##9ghtye")))
+    (insert "\nfun2")
+    (run-hooks 'post-command-hook)
+    (sleep-for 2)
+    (with-current-buffer "*Python Doc*"
+      (goto-char (point-min))
+      (should (re-search-forward "fun1 documentation ##9ghtye")))))

--- a/test/elpy-module-autodoc-test.el
+++ b/test/elpy-module-autodoc-test.el
@@ -14,6 +14,7 @@ def fun2():
 
 (ert-deftest elpy-doc-should-be-updated-automatically ()
   (elpy-testcase ()
+    (add-to-list 'elpy-modules 'elpy-module-autodoc)
     (python-mode)
     (elpy-mode)
     (elpy-doc-test-insert-functions)
@@ -29,6 +30,7 @@ def fun2():
 
 (ert-deftest elpy-doc-should-not-be-updated-if-doc-not-visible ()
   (elpy-testcase ()
+    (add-to-list 'elpy-modules 'elpy-module-autodoc)
     (python-mode)
     (elpy-doc-test-insert-functions)
     (insert "fun1")
@@ -44,6 +46,7 @@ def fun2():
 
 (ert-deftest elpy-doc-should-not-be-updated-if-deactivated ()
   (elpy-testcase ()
+    (add-to-list 'elpy-modules 'elpy-module-autodoc)
     (python-mode)
     (elpy-mode)
     (setq elpy-autodoc-delay nil)


### PR DESCRIPTION
Following feature request #1276.

## Summary
This PR adds the automatic update of the documentation buffer based on the symbol at point.
Documentation is also updated in company, based on the currently selected candidate.

To avoid documentation poping up unexpectedly, the documentation is only updated when the documentation buffer is visible (i.e. associated to a window).

## Control of the feature
The delay before which updating the documentation is controlled by the option `elpy-autodoc-delay`, that can be set to `nil` to deactivate the feature.
