### PR TITLE
Allow different Django Test Runners

### DIFF
--- a/elpy.el
+++ b/elpy.el
@@ -1967,7 +1967,7 @@ This requires Django 1.6 or the django-discover-runner package."
                 ;; or the default:
                 elpy-test-django-runner-command)
               (list (if test
-                        (format "%s.%s" module test)
+                        (format "%s%s%s" module (elpy-django--get-test-format) test)
                       module))))
     (apply #'elpy-test-run
            top

--- a/test/elpy-module-django-test.el
+++ b/test/elpy-module-django-test.el
@@ -70,3 +70,15 @@ Available subcommands:
     (should (member "clearsessions" (elpy-django--get-commands)))
     (should (member "migrate" (elpy-django--get-commands)))
     (should (member "changepassword" (elpy-django--get-commands)))))
+
+(ert-deftest elpy-module-django-get-test-runner-should-error-if-no-django-settings-module-environment ()
+  (setenv "DJANGO_SETTINGS_MODULE" "")
+  (should-error (elpy-django--get-test-runner)))
+
+(ert-deftest elpy-module-django-get-test-runner-should-error-if-cannot-import-django-settings-module ()
+  (setenv "DJANGO_SETTINGS_MODULE" "popcorn")
+  (should-error (elpy-django--get-test-runner)))
+
+(ert-deftest elpy-module-django-get-test-format-should-error-if-cannot-find-test-runner ()
+  (mletf* ((elpy-django--get-test-runner "math")))
+  (should-error (elpy--get-django-test-format)))

--- a/test/elpy-test-django-runner-test.el
+++ b/test/elpy-test-django-runner-test.el
@@ -36,6 +36,7 @@
   (elpy-testcase ()
     (mletf* ((command nil)
              (top nil)
+             (elpy-django--get-test-format () ".")
              (elpy-test-run (start-dir &rest args) (setq command args
                                                          top start-dir)))
 
@@ -53,6 +54,7 @@
   (elpy-testcase ()
     (mletf* ((command nil)
              (top nil)
+             (elpy-django--get-test-format () ".")
              (elpy-test-run (start-dir &rest args) (setq command args
                                                          top start-dir)))
 


### PR DESCRIPTION
The user can now add test runners into a list if they need to put the correct format
Not sure if this is the right approach but some people do use custom test runners 

Should also probably add this in the docs if it's approved