### PR TITLE
test: Honor existing PYTHONPATH when running tests.

### DIFF
--- a/test/test-helper.el
+++ b/test/test-helper.el
@@ -3,7 +3,9 @@
 (require 'f)
 (let ((elpy-dir (f-parent (f-dirname (f-this-file)))))
   (add-to-list 'load-path elpy-dir)
-  (add-to-list 'process-environment (format "PYTHONPATH=%s" elpy-dir))
+  (add-to-list 'process-environment (format "PYTHONPATH=%s:%s"
+					    elpy-dir
+					    (getenv "PYTHONPATH")))
   (add-to-list 'process-environment "ELPY_TEST=1"))
 (require 'elpy)
 ;; Travis regularly has some lag for some reason.


### PR DESCRIPTION
Before this change, PYTHONPATH was completely overriden to take only
the directory of Elpy's root directory. This caused problems for
platforms such as Guix which uses PYTHONPATH to provide the required
test dependencies.