### PR TITLE
Fix company bug when using completion in the interpreter

### DIFF
--- a/elpy.el
+++ b/elpy.el
@@ -3339,7 +3339,13 @@ If you need your modeline, you can set the variable `elpy-remove-modeline-lighte
      (require 'company)
      (elpy-modules-remove-modeline-lighter 'company-mode)
      (define-key company-active-map (kbd "C-d")
-       'company-show-doc-buffer))
+       'company-show-doc-buffer)
+     ;; Workaround for company bug
+     ;; (https://github.com/company-mode/company-mode/issues/759)
+     (add-hook 'inferior-python-mode-hook
+               (lambda () (setq-local company-transformers
+                                      (remove 'company-sort-by-occurrence
+                                              company-transformers)))))
     (`buffer-init
      ;; We want immediate completions from company.
      (set (make-local-variable 'company-idle-delay)


### PR DESCRIPTION
Follow issue #1297.

## Issue
`company-sort-by-occurence` does not work in inferior-python-mode and can prevent company from showing up (see company-mode/company-mode#759).

## Solution
As proposed in company-mode/company-mode#759, this PR just make sure `company-sort-by-occurence` is deactivated in `inferior-python-mode`.

This workaround will have to be removed when(if) the issue disappear.
