### PR TITLE
Use elpy-django-command more often

### DIFF
--- a/docs/ide.rst
+++ b/docs/ide.rst
@@ -575,12 +575,10 @@ advantages this brings.
    py.test. You can also write your own, as described in :ref:`Writing
    Test Runners`.
 
-   Note on Django runners: by default, elpy runs Django tests with
-   :kbd:`django-admin.py`. You must set the environment variable
-   :envvar:`DJANGO_SETTINGS_MODULE` accordingly. Alternatively, you can set
-   **elpy-test-django-with-manage** to **t** in order to use your
-   project's :kbd:`manage.py`. You then don't need to set the environment
-   variable, but change virtual envs (see `virtualenvwrapper.el`_).
+   Note on Django runners: Elpy tries to find `manage.py` within your project
+   structure. If it's unable to find it, it falls back to `django-admin.py`.
+   You must set the environment variable :envvar:`DJANGO_SETTINGS_MODULE` accordingly.
+
 
 This enables a good workflow. You write a test and use :kbd:`C-c C-t`
 to watch it fail. You then go to your implementation file, for example

--- a/elpy-django.el
+++ b/elpy-django.el
@@ -89,23 +89,32 @@ but the default Django test runner uses '.'"
   :group 'elpy-django)
 (make-variable-buffer-local 'elpy-django-test-runner-formats)
 
-(defcustom elpy-test-django-runner-command '("django-admin.py" "test"
-                                             "--noinput")
-  "The command to use for `elpy-test-django-runner'."
+(defcustom elpy-django-test-runner-args '("test" "--noinput")
+  "Arguments to pass to the test runner when calling tests."
   :type '(repeat string)
   :group 'elpy-django)
+(make-variable-buffer-local 'elpy-django-test-runner-args)
 
-(defcustom elpy-test-django-runner-manage-command '("manage.py" "test"
-                                                    "--noinput")
-  "The command to use for `elpy-test-django-runner' in case we want to use manage.py."
+(defcustom elpy-test-django-runner-command nil
+  "Deprecated. Please define Django command in `elpy-django-command' and
+test arguments in `elpy-django-test-runner-args'"
   :type '(repeat string)
   :group 'elpy-django)
+(make-obsolete-variable 'elpy-test-django-runner-command nil "March 2018")
+
+(defcustom elpy-test-django-runner-manage-command nil
+  "Deprecated. Please define Django command in `elpy-django-command' and
+test arguments in `elpy-django-test-runner-args'."
+  :type '(repeat string)
+  :group 'elpy-django)
+(make-obsolete-variable 'elpy-test-django-runner-manage-command nil "March 2018")
 
 (defcustom elpy-test-django-with-manage nil
-  "Set to nil, elpy will use `elpy-test-django-runner-command',
-set to t elpy will use `elpy-test-django-runner-manage-command' and set the project root accordingly."
+  "Deprecated.  Please define Django command in `elpy-django-command' and
+test arguments in `elpy-django-test-runner-args'."
   :type 'boolean
   :group 'elpy-django)
+(make-obsolete-variable 'elpy-test-django-with-manage nil "March 2018")
 
 ;;;;;;;;;;;;;;;;;;;;;;
 ;; Key map
@@ -130,7 +139,7 @@ set to t elpy will use `elpy-test-django-runner-manage-command' and set the proj
     ;; This only affects the buffer if there's no directory
     ;; variable overwriting it.
     (setq elpy-django-command
-          (concat (locate-dominating-file default-directory "manage.py") "manage.py"))
+          (expand-file-name (concat (locate-dominating-file default-directory "manage.py") "manage.py")))
     (elpy-django 1)))
 
 (defun elpy-django--get-commands ()
@@ -230,34 +239,17 @@ This requires Django 1.6 or the django-discover-runner package."
       (apply #'elpy-test-run
              top
              (append
-              ;; if we want to use manage.py, get the root directory where it is.
-              (if elpy-test-django-with-manage
-                  (append (list (concat (expand-file-name
-                                         (locate-dominating-file
-                                          (elpy-project-root)
-                                          (car elpy-test-django-runner-manage-command)))
-                                        (car elpy-test-django-runner-manage-command)))
-                          (cdr elpy-test-django-runner-manage-command))
-                ;; or the default:
-                elpy-test-django-runner-command)
+              (list elpy-django-command)
+              elpy-django-test-runner-args
               (list (if test
                         (format "%s.%s" module test)
                       module))))
     (apply #'elpy-test-run
            top
            (append
-            (if elpy-test-django-with-manage
-                (append (list (concat (expand-file-name
-                                       (locate-dominating-file
-                                        (if (elpy-project-root)
-                                            (elpy-project-root)
-                                          ".")
-                                        (car elpy-test-django-runner-manage-command)))
-                                      (car elpy-test-django-runner-manage-command)))
-                        (cdr elpy-test-django-runner-manage-command))
-              elpy-test-django-runner-command)))))
+            (list elpy-django-command)
+            elpy-django-test-runner-args))))
 (put 'elpy-test-django-runner 'elpy-test-runner-p t)
-
 
 (define-minor-mode elpy-django
   "Minor mode to for Django commands."

--- a/test/elpy-module-django-test.el
+++ b/test/elpy-module-django-test.el
@@ -22,7 +22,7 @@ the `manage.py' file."
     (elpy-module-django 'buffer-init)
 
     (should elpy-django)
-    (should (string= elpy-django-command (concat default-directory "manage.py")))
+    (should (string= elpy-django-command (expand-file-name (concat default-directory "manage.py"))))
 
     (delete-file (concat default-directory "manage.py"))))
 

--- a/test/elpy-test-django-runner-test.el
+++ b/test/elpy-test-django-runner-test.el
@@ -67,3 +67,17 @@
                      '("django-admin.py" "test" "--noinput"
                        "package.module.TestClass.test_method")))
       (should (equal root "/project/root/")))))
+
+(ert-deftest elpy-test-django-runner-with-manage-path-should-run-all-tests ()
+  (elpy-testcase ()
+    (mletf* ((command nil)
+             (root nil)
+             (elpy-django-command "/project/root/manage.py")
+             (elpy-test-run (start-dir &rest args) (setq command args
+                                                         root start-dir)))
+
+      (elpy-test-django-runner "/project/root/" nil nil nil)
+
+      (should (equal command
+                     '("/project/root/manage.py" "test" "--noinput")))
+      (should (equal root "/project/root/")))))


### PR DESCRIPTION
Instead of recalculating which django command to use, just use the
variable that holds that information already. Also, move test args to
a single place instead of having one for django-admin.py and another
for manage.py