### PR TITLE
Add customizeable python shell root

### DIFF
--- a/elpy-shell.el
+++ b/elpy-shell.el
@@ -104,6 +104,13 @@ nil, the current directory is used instead."
   :type 'boolean
   :group 'elpy)
 
+(defcustom elpy-shell-custom-root nil
+  "Custom directory where a Python shell will *always* start from.
+
+If you wish to use this, then set `elpy-shell-use-project-root' to nil"
+  :type 'string
+  :group 'elpy)
+
 (defcustom elpy-shell-cell-boundary-regexp
   (concat "^\\(?:"
           "##.*" "\\|"
@@ -231,6 +238,7 @@ Python process. This allows the process to start up."
         proc
       (let ((default-directory (or (and elpy-shell-use-project-root
                                         (elpy-project-root))
+                                   elpy-shell-custom-root
                                    default-directory)))
         (run-python (python-shell-parse-command) nil t))
       (when sit (sit-for sit))


### PR DESCRIPTION
So I have started following a certain pattern in python by putting my packages/modules inside a `src` directory (https://blog.ionelmc.ro/2014/05/25/python-packaging/#the-structure)
Example structure of proj:
```
.
├── README.md
├── setup.cfg
├── setup.py
├── src
│   └── main_package
│       ├── __init__.py
│       ├── some_nested_package
├── tests
│   ├── __init__.py
└── tox.ini
```

This puts me in a weird spot where I do want the shell to have the project root in sys.path but I always want it to start inside of the `src` dir. Any arguments for/against?