### PR TITLE
elpy-config fails when using python >= v3.2 compiled with debug mode.

### DIFF
--- a/elpy.el
+++ b/elpy.el
@@ -619,6 +619,10 @@ virtualenv.
 
 (defvar elpy-config--get-config "import json
 import sys
+import warnings
+
+if 'ResourceWarning' in __builtins__.__dict__.keys():
+    warnings.simplefilter('ignore', ResourceWarning)
 
 try:
     import xmlrpclib


### PR DESCRIPTION
If python >= 3.2 is built from source & built in debug mode, it will raise 'ResourceWarning' for unclosed system resources. This will result in a failing of elpy-config. In this fix the ResourceWarning is surpressed.

The code is python2 compliant (tested with python2 & python3)