### PR TITLE
Add github PR and issue templates

### DIFF
--- a/.github/issue_template.md
+++ b/.github/issue_template.md
@@ -1,11 +1,10 @@
 # Summary
 
+Thank you for reporting to Elpy !
 
-# Expected behavior
-
-
-# Actual behavior
-
+Here is a template to help you do it so your issue can be fixed as
+soon as possible. Please replace this paragraph with a summary of
+your issue and fill the next sections.
 
 # Steps to reproduce
 
@@ -13,9 +12,8 @@
 # My configuration
 ## OS
 
-## Emacs version
 
-## Result from `(elpy-config)`
+## Result of `(elpy-config)`
 ```
 # Paste it here
 ```

--- a/.github/issue_template.md
+++ b/.github/issue_template.md
@@ -1,0 +1,26 @@
+# Summary
+
+
+# Expected behavior
+
+
+# Actual behavior
+
+
+# Steps to reproduce
+
+
+# My configuration
+## OS
+
+## Emacs version
+
+## Result from `(elpy-config)`
+```
+# Paste it here
+```
+
+## Elpy configuration in my init.el
+```
+# Paste it here
+```

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,15 @@
+# PR Summary
+
+
+# PR checklist
+
+Please make sure that the following things have been addressed (and check the relevant checkboxes):
+
+- [ ] Commits respect our [guidelines](../CONTRIBUTING.rst)
+- [ ] Tests are passing properly (see [here](https://elpy.readthedocs.io/en/latest/extending.html#running-tests) on how to run Elpy's tests)
+- [ ] Code is not generating new bytecode warnings
+
+## For new features only:
+- [ ] Tests has been added to cover the change
+- [ ] The documentation has been updated
+- [ ] An entry in NEWS.rst has been added


### PR DESCRIPTION
There is a significant potion of the issues that take times to resolve due to lack of information.
In the hope that this will make the process easier, I added an issue template to indicate to the users what kind of information we need.

I also added a PR template, to be sure no one forget about tests, documentation updates and changelog updates (which I forget myself quite often...).