### PR TITLE
Suggest elpy-rpc-restart after setting PATH

### DIFF
--- a/elpy.el
+++ b/elpy.el
@@ -814,7 +814,7 @@ item in another window.\n\n")
        "no active virtualenv, installing Python packages locally will "
        "place executables in that directory, so Emacs won't find them. "
        "If you are missing some commands, do add this directory to your "
-       "PATH.\n\n"))
+       "PATH -- and then do `elpy-rpc-restart'.\n\n"))
 
     ;; Python found, but can't find the elpy module
     (when (and (gethash "python_rpc_executable" config)


### PR DESCRIPTION
# PR Summary

When warning about `~/.local/bin` not being on `PATH`, suggest running `elpy-rpc-restart` to make changes to `PATH` "stick".

I'm skipping the various "pull request" checkboxes because this change is so small.