### PR TITLE
Modify UTF8 character "ö" in elpy-rpc-test to allow test to pass

### DIFF
--- a/elpy/tests/test_server.py
+++ b/elpy/tests/test_server.py
@@ -332,11 +332,11 @@ class TestGetSource(unittest.TestCase):
         fd, filename = tempfile.mkstemp(prefix="elpy-test-")
         self.addCleanup(os.remove, filename)
         with open(filename, "wb") as f:
-            f.write(u"möp".encode("utf-8"))
+            f.write(u"mop".encode("utf-8"))
 
         source = server.get_source({'filename': filename})
 
-        self.assertEqual(source, u"möp")
+        self.assertEqual(source, u"mop")
 
 
 class TestPysymbolKey(BackendTestCase):

--- a/test/elpy-rpc-test.el
+++ b/test/elpy-rpc-test.el
@@ -25,5 +25,5 @@
 
 (ert-deftest elpy-rpc-integration ()
   (elpy-testcase ()
-    (should (equal (elpy-rpc "echo" '(23 "möp"))
-                   '(23 "möp")))))
+    (should (equal (elpy-rpc "echo" '(23 "mop"))
+                   '(23 "mop")))))


### PR DESCRIPTION
This might be caused by a UTF8 handling bug in Debian's dh-python,
dh-elpa, libdpkg-perl, or a limitation in pbuilder; however, this
simple patch allows the test to pass when building in a pbuilder or on
the buildd network.

This patch fixes one of the failing tests discussed in #1308 .  Previously I was disabling the test, so I consider it a win!  I apologise in advance for my limited knowledge of Germanic languages, because I've probably mistransliterated "ö" as "o".

- [x] Commits respect our [guidelines](../CONTRIBUTING.rst)
- [x] Tests are passing properly (see [here](https://elpy.readthedocs.io/en/latest/extending.html#running-tests) on how to run Elpy's tests)
- [x] Code is not generating new bytecode warnings

