### PR TITLE
Don't throw an error when a reference has no associated file

### DIFF
--- a/elpy.el
+++ b/elpy.el
@@ -3136,14 +3136,17 @@ This is needed to get information on the identifier with jedi
          for ref in references
          for file = (alist-get 'filename ref)
          for pos = (+ (alist-get 'offset ref) 1)
-         for line = (with-current-buffer (find-file-noselect file)
-                      (save-excursion
-                        (goto-char (+ pos 1))
-                        (buffer-substring (line-beginning-position) (line-end-position))))
-         for linenumber = (with-current-buffer (find-file-noselect file)
-                            (line-number-at-pos pos))
+         for line = (when file
+                      (with-current-buffer (find-file-noselect file)
+                        (save-excursion
+                          (goto-char (+ pos 1))
+                          (buffer-substring (line-beginning-position) (line-end-position)))))
+         for linenumber = (when file
+                            (with-current-buffer (find-file-noselect file)
+                              (line-number-at-pos pos)))
          for summary = (format elpy-xref--format-references linenumber line)
          for loc = (xref-make-elpy-location file pos)
+         if file
          collect (xref-make summary loc)))))
 
   ;; Completion table (used when calling `xref-find-references`)


### PR DESCRIPTION
# PR Summary
`xref-find-references` stops and throws an error if one of the references obtained through jedi does not have an associated file (for builtins functions for example).

With this PR, those references are just ignored, and `xref-find-references` still show the valid references.

# Example
```Python
import sys
print(sy|s.path)
```
At the moment, using `xref-find-references` with the cursor on `|` throws an error.
With this PR, it will show, as expected:
```
/tmp/test.py
  1:	import sys
  2:	print(sys.path)
```

# PR checklist

Please make sure that the following things have been addressed (and check the relevant checkboxes):

- [x] Commits respect our [guidelines](../CONTRIBUTING.rst)
- [x] Tests are passing properly (see [here](https://elpy.readthedocs.io/en/latest/extending.html#running-tests) on how to run Elpy's tests)
- [x] Code is not generating new bytecode warnings
