### PR TITLE
Raise an error if the interpreter is not in the current virtualenv

### DIFF
--- a/elpy-shell.el
+++ b/elpy-shell.el
@@ -229,6 +229,11 @@ Python process. This allows the process to start up."
          (proc (get-buffer-process bufname)))
     (if proc
         proc
+      (when (and pyvenv-virtual-env
+                 (not (string-prefix-p (expand-file-name pyvenv-virtual-env)
+                                       (executable-find
+                                        python-shell-interpreter))))
+        (error "Intepreter binaries not found in current virtual environnement"))
       (let ((default-directory (or (and elpy-shell-use-project-root
                                         (elpy-project-root))
                                    default-directory)))

--- a/elpy-shell.el
+++ b/elpy-shell.el
@@ -25,6 +25,7 @@
 ;;; Code:
 
 (eval-when-compile (require 'subr-x))
+(require 'pyvenv)
 (require 'python)
 
 ;;;;;;;;;;;;;;;;;;;;;;
@@ -233,7 +234,7 @@ Python process. This allows the process to start up."
                  (not (string-prefix-p (expand-file-name pyvenv-virtual-env)
                                        (executable-find
                                         python-shell-interpreter))))
-        (error "Intepreter binaries not found in current virtual environnement"))
+        (error "Interpreter binaries not found in the current virtual environnement"))
       (let ((default-directory (or (and elpy-shell-use-project-root
                                         (elpy-project-root))
                                    default-directory)))

--- a/test/elpy-shell-get-or-create-process-test.el
+++ b/test/elpy-shell-get-or-create-process-test.el
@@ -7,3 +7,13 @@
     (let ((proc (elpy-shell-get-or-create-process)))
       (with-current-buffer (process-buffer proc)
         (should (eq major-mode 'inferior-python-mode))))))
+
+(ert-deftest elpy-shell-get-or-create-process-should-fail-for-missing-binaries ()
+  (elpy-testcase ()
+    ;; test that it does not fail outside a virtual env
+    (elpy-shell-get-or-create-process)
+    (elpy-shell-kill)
+    ;; Test that it fail for a virtualenv without the wanted interpreter
+    (pyvenv-activate (expand-file-name "./dummy-folder"))
+    (should-error (elpy-shell-get-or-create-process))
+    (pyvenv-deactivate)))


### PR DESCRIPTION
# PR Summary
Following issue #1333.
Elpy now raises an error if the wanted interpreter (set by `python-shell-interpreter`) is not available within the current virtual environnement.
This avoid Elpy to just fall back to the system interpreter binaries, outside of the virtual environment, without the user noticing.

# PR checklist

- [x] Commits respect our [guidelines](../CONTRIBUTING.rst)
- [x] Tests are passing properly (see [here](https://elpy.readthedocs.io/en/latest/extending.html#running-tests) on how to run Elpy's tests)
- [x] Code is not generating new bytecode warnings
