### PR TITLE
Prevent 'expand-file-name' from erroring when project-root is nil

### DIFF
--- a/elpy.el
+++ b/elpy.el
@@ -2118,8 +2118,9 @@ root directory."
   "Common routine for formatting python code."
   (let ((line (line-number-at-pos))
         (col (current-column))
-        (directory (or (expand-file-name (elpy-project-root))
-                              default-directory)))
+        (directory (if (elpy-project-root)
+                       (expand-file-name (elpy-project-root))
+                     default-directory)))
     (if (use-region-p)
         (let ((new-block (elpy-rpc method
                                    (list (elpy-rpc--region-contents)


### PR DESCRIPTION
# PR Summary
Fix issue #1345:
`elpy-format-code` raise an error when the script is outside a project.

# PR checklist

Please make sure that the following things have been addressed (and check the relevant checkboxes):

- [x] Commits respect our [guidelines](../CONTRIBUTING.rst)
- [x] Tests are passing properly (see [here](https://elpy.readthedocs.io/en/latest/extending.html#running-tests) on how to run Elpy's tests)
- [x] Code is not generating new bytecode warnings
