### PR TITLE
Use new convention for python shell name

### DIFF
--- a/elpy-shell.el
+++ b/elpy-shell.el
@@ -256,7 +256,9 @@ if ARG is negative or 0, disable the use of a dedicated shell."
     (if (<= arg 0)
         (kill-local-variable 'python-shell-buffer-name)
       (setq-local python-shell-buffer-name
-                  (format "Python[%s]" (buffer-name))))))
+                  (format "Python[%s]"
+                          (file-name-sans-extension
+                          (buffer-name)))))))
 
 (defun elpy-shell-set-local-shell (&optional shell-name)
   "Associate the current buffer to a specific shell.
@@ -276,12 +278,14 @@ shell (often \"*Python*\" shell)."
                                "Global"))
          (shell-names (cl-loop
                 for buffer in (buffer-list)
-                for buffer-name = (substring-no-properties (buffer-name buffer))
+                for buffer-name = (file-name-sans-extension (substring-no-properties (buffer-name buffer)))
                 if (string-match "\\*Python\\[\\(.*?\\)\\]\\*" buffer-name)
                 collect (match-string 1 buffer-name)))
          (candidates (remove current-shell-name
-                          (delete-dups
-                           (append (list (buffer-name) "Global") shell-names))))
+                           (delete-dups
+                           (append (list (file-name-sans-extension
+                                          (buffer-name)) "Global")
+                                   shell-names))))
          (prompt (format "Shell name (current: %s): " current-shell-name))
          (shell-name (or shell-name (completing-read prompt candidates))))
     (if (string= shell-name "Global")


### PR DESCRIPTION
# PR Summary

The name of the dedicated python shells are now using the buffer name
without extension, for example `*Python[test]*` instead of `*Python[test.py]*`.

This avoid conflicts with the way python.el handles dedicated shells
(see #1328).

# PR checklist

Please make sure that the following things have been addressed (and check the relevant checkboxes):

- [x] Commits respect our [guidelines](../CONTRIBUTING.rst)
- [x] Tests are passing properly (see [here](https://elpy.readthedocs.io/en/latest/extending.html#running-tests) on how to run Elpy's tests)
- [x] Code is not generating new bytecode warnings