### PR TITLE
elpy.el: prepare for flymake in emacs >= 26

### DIFF
--- a/elpy.el
+++ b/elpy.el
@@ -3695,14 +3695,18 @@ description."
 
 (defun elpy-flymake-error-at-point ()
   "Return the flymake error at point, or nil if there is none."
-  (when (boundp 'flymake-err-info)
-    (let* ((lineno (line-number-at-pos))
-           (err-info (car (flymake-find-err-info flymake-err-info
-                                                 lineno))))
-      (when err-info
-        (mapconcat #'flymake-ler-text
-                   err-info
-                   ", ")))))
+  (cond ((boundp 'flymake-err-info)     ; emacs < 26
+         (let* ((lineno (line-number-at-pos))
+                (err-info (car (flymake-find-err-info flymake-err-info
+                                                      lineno))))
+           (when err-info
+             (mapconcat #'flymake-ler-text
+                        err-info
+                        ", "))))
+        ((and (fboundp 'flymake-diagnostic-text)
+              (fboundp 'flymake-diagnostics)) ; emacs >= 26
+         (mapconcat #'flymake-diagnostic-text
+                    (flymake-diagnostics (point)) ", "))))
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;;; Module: Highlight Indentation


### PR DESCRIPTION
flymake-err-info is removed without alias in flymake emacs >= 26.

Related discussions:
https://github.com/jorgenschaefer/elpy/issues/1272
https://github.com/jorgenschaefer/elpy/issues/1357
http://lists.gnu.org/archive/html/bug-gnu-emacs/2018-04/msg00985.html

# PR Summary

Hello Elpy hackers, lets prepare for emacs 26 :)

# PR checklist

Please make sure that the following things have been addressed (and check the relevant checkboxes):

- [ ] Commits respect our [guidelines](../CONTRIBUTING.rst)
- [x] Tests are passing properly (see [here](https://elpy.readthedocs.io/en/latest/extending.html#running-tests) on how to run Elpy's tests)
- [x] Code is not generating new bytecode warnings

## For new features only:
- [ ] Tests has been added to cover the change
- [ ] The documentation has been updated
- [ ] An entry in NEWS.rst has been added

Wrap current code in the first of two cond clauses, add new check for emacs >= 26 in the second clause.

This is a possible refinement of https://github.com/jorgenschaefer/elpy/pull/1360 which I think might fail for emacs < 26 by returning nil. I didn't add or fix any tests for now because I don't feel ready for it, the test frame work is new to me. But tests will need to be updated too I think, the test `elpy-flymake-show-error` is calling `flymake-ler-make-ler` which is gone as well in emacs >= 26.