### PR TITLE
Fix misleading doc on project shells

### DIFF
--- a/docs/ide.rst
+++ b/docs/ide.rst
@@ -266,7 +266,7 @@ The Shell Buffer
 
 .. code-block:: lisp
 
-   (add-hook 'elpy-mode-hook (lambda () (elpy-shell-set-local-shell elpy-project-root)))
+   (add-hook 'elpy-mode-hook (lambda () (elpy-shell-set-local-shell (elpy-project-root))))
 
 .. command:: elpy-shell-kill
    :kbd: C-c C-k


### PR DESCRIPTION
# PR Summary
Quick fix for the documentation on project shells.

The proposed way to use a shell per project was not working.