### PR TITLE
Replace error by warning when interpreter is not in the virtualenv

### DIFF
--- a/elpy-shell.el
+++ b/elpy-shell.el
@@ -230,11 +230,6 @@ Python process. This allows the process to start up."
          (proc (get-buffer-process bufname)))
     (if proc
         proc
-      (when (and pyvenv-virtual-env
-                 (not (string-prefix-p (expand-file-name pyvenv-virtual-env)
-                                       (executable-find
-                                        python-shell-interpreter))))
-        (error "Interpreter binaries not found in the current virtual environnement"))
       (let ((default-directory (or (and elpy-shell-use-project-root
                                         (elpy-project-root))
                                    default-directory)))

--- a/elpy.el
+++ b/elpy.el
@@ -852,6 +852,23 @@ item in another window.\n\n")
               (gethash "error_output" config) "\n"
               "\n"))
 
+    ;; Interactive python interpreter not in the current virtual env
+    (when (and pyvenv-virtual-env
+               (not (string-prefix-p (expand-file-name pyvenv-virtual-env)
+                                     (executable-find
+                                      python-shell-interpreter))))
+      (elpy-insert--para
+       "The python interactive interpreter (" python-shell-interpreter
+       ") is not installed on the current virtualenv ("
+       pyvenv-virtual-env "). The system binary ("
+       (executable-find python-shell-interpreter)
+       ") will be used instead."
+       "\n")
+      (insert "\n")
+      (widget-create 'elpy-insert--pip-button
+                     :package python-shell-interpreter)
+      (insert "\n\n"))
+
     ;; Requested backend unavailable
     (when (and (gethash "python_rpc_executable" config)
                (not (gethash "jedi_version" config)))

--- a/test/elpy-shell-get-or-create-process-test.el
+++ b/test/elpy-shell-get-or-create-process-test.el
@@ -7,13 +7,3 @@
     (let ((proc (elpy-shell-get-or-create-process)))
       (with-current-buffer (process-buffer proc)
         (should (eq major-mode 'inferior-python-mode))))))
-
-(ert-deftest elpy-shell-get-or-create-process-should-fail-for-missing-binaries ()
-  (elpy-testcase ()
-    ;; test that it does not fail outside a virtual env
-    (elpy-shell-get-or-create-process)
-    (elpy-shell-kill)
-    ;; Test that it fail for a virtualenv without the wanted interpreter
-    (pyvenv-activate (expand-file-name "./dummy-folder"))
-    (should-error (elpy-shell-get-or-create-process))
-    (pyvenv-deactivate)))


### PR DESCRIPTION
# PR Summary
Currently, if the wanted interpreter binaries are not in the active virtualenv, `elpy-shell-get-or-create-process` fails with an error.
Some users complained about the impossibility of using the system python binaries from inside a virtualenv (#1370).

This PR removes the error, and adds an entry in `elpy-config` to warn users, in case they just forgot to install their interpreter:
```
Elpy Configuration

Virtualenv........: dummy (/home/glaunay/.virtualenvs/dummy)
RPC Python........: 3.6.5 (/home/glaunay/.virtualenvs/dummy/bin/python3)
Interactive Python: ipython (/usr/bin/ipython)
Emacs.............: 25.3.1
Elpy..............: 1.20.0
Jedi..............: 0.12.0
Rope..............: Not found (0.10.7 available)
Autopep8..........: Not found (1.3.5 available)
Yapf..............: Not found (0.22.0 available)
Syntax checker....: flake8 (/usr/bin/flake8)

The python interactive interpreter (ipython) is not installed on the
current virtualenv (/home/glaunay/.virtualenvs/dummy/). The system
binary (/usr/bin/ipython) will be used instead.

[run] python3 -m pip install ipython

The autopep8 package is not available. Commands using this will not
work.

[run] python3 -m pip install autopep8

The yapf package is not available. Commands using this will not work.

[run] python3 -m pip install yapf

Options

Square brackets indicate buttons; type RET or click mouse-1 on a
button to invoke its action. Invoke [+] to expand a group, and [-] to
collapse an expanded group. Invoke the [Group], [Face], and [Option]
buttons below to edit that item in another window.

[+]-- [Group] Elpy
[+]-- [Group] Python
[+]-- [Group] Virtual Environments (Pyvenv)
[+]-- [Group] Completion (Company)
[+]-- [Group] Call Signatures (ElDoc)
[+]-- [Group] Inline Errors (Flymake)
[+]-- [Group] Snippets (YASnippet)
[+]-- [Group] Directory Grep (rgrep)
[+]-- [Group] Search as You Type (ido)
[+]-- [Group] Django extension
[+]-- [Group] Autodoc extension
```
# PR checklist

Please make sure that the following things have been addressed (and check the relevant checkboxes):

- [x] Commits respect our [guidelines](../CONTRIBUTING.rst)
- [x] Tests are passing properly (see [here](https://elpy.readthedocs.io/en/latest/extending.html#running-tests) on how to run Elpy's tests)
- [x] Code is not generating new bytecode warnings
