### PR TITLE
Add black autoformatter

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -33,7 +33,9 @@ install:
     fi
   - pip install autopep8
   - pip install yapf
-  - pip install black
+  - if [[ "$TRAVIS_PYTHON_VERSION" > 3.6 || "$TRAVIS_PYTHON_VERSION" == 3.6 ]] ; then
+      pip install black ;
+    fi
   - pip install coveralls
 script:
   - nosetests

--- a/.travis.yml
+++ b/.travis.yml
@@ -33,6 +33,7 @@ install:
     fi
   - pip install autopep8
   - pip install yapf
+  - pip install black
   - pip install coveralls
 script:
   - nosetests

--- a/NEWS.rst
+++ b/NEWS.rst
@@ -1,3 +1,8 @@
+New in Elpy development
+=======================
+
+- Elpy now supports Black to format your code.
+
 New in Elpy 1.21.0
 ==================
 
@@ -5,12 +10,6 @@ New in Elpy 1.21.0
 - Elpy now knows how to deal with the flymake in the upcoming Emacs
   release.
 - Some minor improvements in error messages and warnings.
-  
-
-New in Elpy 1.20.0
-==================
-
-- Elpy now supports Black to format your code.
 
 New in Elpy 1.20.0
 ==================

--- a/NEWS.rst
+++ b/NEWS.rst
@@ -10,6 +10,11 @@ New in Elpy 1.21.0
 New in Elpy 1.20.0
 ==================
 
+- Elpy now supports Black to format your code.
+
+New in Elpy 1.20.0
+==================
+
 - No new features, but lots of bugfixes
 
 Thanks again to Gaby Launay for the continued and exceptional work!
@@ -32,7 +37,7 @@ Thanks to Craig MacEachern, Daniel Gopar, Gaby Launay, Maxim
 Cournoyer, Nicholas D. Steeves and Sam Steingold for their help in
 making this release!
 
-  
+
 New in Elpy 1.18.0
 ==================
 
@@ -62,7 +67,7 @@ New in Elpy 1.18.0
 We are happy to report that Elpy now has more maintainers! Daniel
 Gopar, Rainer Gemulla and @galaunay are now helping regularly with
 this project.
-  
+
 Thanks to all the contributors!
 
 

--- a/docs/ide.rst
+++ b/docs/ide.rst
@@ -634,15 +634,16 @@ Elpy supports various forms of refactoring Python code.
 
    Format code using the available formatter.
 
-   This command formats code using `yapf`_ or `autopep8`_ formatter. If a
-   region is selected, only that region is formatted. Otherwise current
-   buffer is formatted.
+   This command formats code using `yapf`_ , `autopep8`_ or `black`_
+   formatter. If a region is selected, only that region is formatted.
+   Otherwise current buffer is formatted.
 
    `yapf`_ and `autopep8`_ can be configured with style files placed in
    the project root directory (determined by ``elpy-project-root``).
 
 .. _autopep8: https://github.com/hhatto/autopep8
 .. _yapf: https://github.com/google/yapf
+.. _black: https://github.com/ambv/black
 
 
 .. command:: elpy-refactor

--- a/elpy.el
+++ b/elpy.el
@@ -690,6 +690,14 @@ except:
     config['yapf_version'] = None
     config['yapf_latest'] = latest('yapf')
 
+try:
+    import black
+    config['black_version'] = black.__version__
+    config['black_latest'] = latest('black', config['black_version'])
+except:
+    config['black_version'] = None
+    config['black_latest'] = latest('black')
+
 json.dump(config, sys.stdout)
 ")
 
@@ -941,6 +949,26 @@ item in another window.\n\n")
                      :package "yapf" :upgrade t)
       (insert "\n\n"))
 
+    ;; No black available
+    (when (not (gethash "black_version" config))
+      (elpy-insert--para
+       "The black package is not available. Commands using this will "
+       "not work.\n")
+      (insert "\n")
+      (widget-create 'elpy-insert--pip-button
+                     :package "black")
+      (insert "\n\n"))
+
+    ;; Newer version of black available
+    (when (and (gethash "black_version" config)
+               (gethash "black_latest" config))
+      (elpy-insert--para
+       "There is a newer version of the black package available.\n")
+      (insert "\n")
+      (widget-create 'elpy-insert--pip-button
+                     :package "black" :upgrade t)
+      (insert "\n\n"))
+
     ;; Syntax checker not available
     (when (not (executable-find elpy-syntax-check-command))
       (elpy-insert--para
@@ -1036,6 +1064,8 @@ virtual_env_short"
         (autopep8-latest (gethash "autopep8_latest" config))
         (yapf-version (gethash "yapf_version" config))
         (yapf-latest (gethash "yapf_latest" config))
+        (black-version (gethash "black_version" config))
+        (black-latest (gethash "black_latest" config))
         (virtual-env (gethash "virtual_env" config))
         (virtual-env-short (gethash "virtual_env_short" config))
         table maxwidth)
@@ -1090,6 +1120,9 @@ virtual_env_short"
             ("Yapf" . ,(elpy-config--package-link "yapf"
                                                   yapf-version
                                                   yapf-latest))
+            ("Black" . ,(elpy-config--package-link "black"
+                                                   black-version
+                                                   black-latest))
             ("Syntax checker" . ,(let ((syntax-checker
                                         (executable-find
                                          elpy-syntax-check-command)))
@@ -2112,6 +2145,8 @@ prefix argument is given, prompt for a symbol from the user."
     (elpy-yapf-fix-code))
    ((elpy-config--package-available-p "autopep8")
     (elpy-autopep8-fix-code))
+   ((elpy-config--package-available-p "black")
+    (elpy-black-fix-code))
    (t
     (message "Install yapf/autopep8 to format code."))))
 
@@ -2130,6 +2165,11 @@ Autopep8 can be configured with a style file placed in the project
 root directory."
   (interactive)
   (elpy--fix-code-with-formatter "fix_code"))
+
+(defun elpy-black-fix-code ()
+  "Automatically formats Python code with black."
+  (interactive)
+  (elpy--fix-code-with-formatter "fix_code_with_black"))
 
 (defun elpy--fix-code-with-formatter (method)
   "Common routine for formatting python code."

--- a/elpy/blackutil.py
+++ b/elpy/blackutil.py
@@ -1,0 +1,37 @@
+"""Glue for the "black" library.
+
+"""
+
+import os
+import sys
+
+from elpy.rpc import Fault
+
+BLACK_NOT_SUPPORTED = sys.version_info < (3, 6)
+
+try:
+    if BLACK_NOT_SUPPORTED:
+        black = None
+    else:
+        import black
+except ImportError:  # pragma: no cover
+    black = None
+
+
+def fix_code(code, directory):
+    """Formats Python code to conform to the PEP 8 style guide.
+
+    """
+    if not black:
+        raise Fault('black not installed', code=400)
+
+    try:
+        reformatted_source = black.format_file_contents(
+            src_contents=code,
+            line_length=black.DEFAULT_LINE_LENGTH,
+            fast=False
+        )
+        return reformatted_source
+    except Exception as e:
+            raise Fault("Error during formatting: {}".format(e),
+                        code=400)

--- a/elpy/server.py
+++ b/elpy/server.py
@@ -13,6 +13,7 @@ from elpy.pydocutils import get_pydoc_completions
 from elpy.rpc import JSONRPCServer, Fault
 from elpy.auto_pep8 import fix_code
 from elpy.yapfutil import fix_code as fix_code_with_yapf
+from elpy.blackutil import fix_code as fix_code_with_black
 
 
 try:
@@ -212,6 +213,13 @@ class ElpyRPCServer(JSONRPCServer):
         """
         source = get_source(source)
         return fix_code_with_yapf(source, directory)
+
+    def rpc_fix_code_with_black(self, source, directory):
+        """Formats Python code to conform to the PEP 8 style guide.
+
+        """
+        source = get_source(source)
+        return fix_code_with_black(source, directory)
 
 
 def get_source(fileobj):

--- a/elpy/tests/test_black.py
+++ b/elpy/tests/test_black.py
@@ -1,0 +1,33 @@
+# coding: utf-8
+"""Tests for the elpy.black module"""
+
+import unittest
+import os
+
+from elpy import blackutil
+from elpy.rpc import Fault
+from elpy.tests.support import BackendTestCase
+
+
+@unittest.skipIf(blackutil.BLACK_NOT_SUPPORTED,
+                 'black not supported for current python version')
+class BLACKTestCase(BackendTestCase):
+    def setUp(self):
+        if blackutil.BLACK_NOT_SUPPORTED:
+            raise unittest.SkipTest
+
+    def test_fix_code_should_throw_error_for_invalid_code(self):
+        src = 'x = '
+        self.assertRaises(Fault, blackutil.fix_code, src, os.getcwd())
+
+    def test_fix_code(self):
+        testdata = [
+            ('x=       123\n', 'x = 123\n'),
+            ('x=1; \ny=2 \n', 'x = 1\ny = 2\n'),
+        ]
+        for src, expected in testdata:
+            self._assert_format(src, expected)
+
+    def _assert_format(self, src, expected):
+        new_block = blackutil.fix_code(src, os.getcwd())
+        self.assertEqual(new_block, expected)

--- a/requirements3.txt
+++ b/requirements3.txt
@@ -3,3 +3,4 @@ jedi==0.11.1
 rope_py3k==0.9.4-1
 autopep8==1.3.5
 yapf==0.21.0
+black==18.5b0

--- a/test/elpy-black-fix-code-test.el
+++ b/test/elpy-black-fix-code-test.el
@@ -1,0 +1,47 @@
+(ert-deftest elpy-black-fix-code-should-retain-line-and-column ()
+  (let* ((pyversion (getenv "TRAVIS_PYTHON_VERSION"))
+         (black-not-supported (string< pyversion "3.6")))
+    (unless black-not-supported
+      (elpy-testcase ()
+                     (set-buffer-string-with-point
+                      "x  =  1"
+                      "y = 2_|_"
+                      )
+
+                     (elpy-black-fix-code)
+                     (should
+                      (buffer-be
+                       "x = 1"
+                       "y = 2_|_"))))))
+
+(ert-deftest elpy-black-fix-code-in-region-should-retain-line-and-column ()
+  (let* ((pyversion (getenv "TRAVIS_PYTHON_VERSION"))
+         (black-not-supported (string< pyversion "3.6")))
+    (unless black-not-supported
+      (elpy-testcase ()
+                     (set-buffer-string-with-point
+                      "_|_y =  2"
+                      "z = 3"
+                      "x = 3"
+                      )
+                     (elpy/mark-region (point) 13)
+
+                     (elpy-black-fix-code)
+
+                     (should (not mark-active))
+                     (should
+                      (buffer-be
+                       "y = 2"
+                       "z = 3"
+                       "_|_x = 3"
+                       ))))))
+
+(ert-deftest elpy-black-fix-code-should-throw-error-for-invalid-code ()
+  (let* ((pyversion (getenv "TRAVIS_PYTHON_VERSION"))
+         (black-not-supported (string< pyversion "3.6")))
+    (unless black-not-supported
+      (elpy-testcase ()
+                     (set-buffer-string-with-point
+                      "x =_|_"
+                      )
+                     (should-error (elpy-black-fix-code))))))


### PR DESCRIPTION
# PR Summary
Add [Black](https://github.com/ambv/black) auto formater support to elpy.
Follow issue #1377.
Try it with `M-x elpy-black-fix-code`.

@jorgenschaefer It was a pretty straightforward implementation, mainly copy and paste from yapf implementation.
Not much work involved, so we can perfectly discard this PR if you think it involve adding too much complexity (and support work in the futur).

# PR checklist

Please make sure that the following things have been addressed (and check the relevant checkboxes):

- [x] Commits respect our [guidelines](../CONTRIBUTING.rst)
- [x] Tests are passing properly (see [here](https://elpy.readthedocs.io/en/latest/extending.html#running-tests) on how to run Elpy's tests)
- [x] Code is not generating new bytecode warnings

## For new features only:
- [x] Tests has been added to cover the change
- [x] The documentation has been updated
- [x] An entry in NEWS.rst has been added