### PR TITLE
Fix #1379: Be sure to start the rpc before checking for jedi

### DIFF
--- a/elpy.el
+++ b/elpy.el
@@ -3066,7 +3066,10 @@ Returns a possible multi-line docstring."
 ;;; Xref backend
 (defun elpy--xref-backend ()
   "Return the name of the elpy xref backend."
-  (if elpy-rpc--jedi-available
+  ;; If no rpc available, start one and assume jedi is available
+  (if (or (and (not (elpy-rpc--process-buffer-p elpy-rpc--buffer))
+               (elpy-rpc--get-rpc-buffer))
+          elpy-rpc--jedi-available)
       'elpy
     nil))
 

--- a/test/elpy-xref--backend-test.el
+++ b/test/elpy-xref--backend-test.el
@@ -1,0 +1,29 @@
+(ert-deftest elpy-xref--backend-should-return-true-when-jedi-available ()
+  (when (featurep 'xref)
+    (elpy-testcase ((:project project-root "test.py"))
+        (find-file (f-join project-root "test.py"))
+        (python-mode)
+        (elpy-mode)
+        (insert "def foo(x, y):\n"
+                "    return x + y\n"
+                "var1 = foo(5, 2)")
+        ;; First start the rpc and assume jedi is available
+        (should (string= (xref-find-backend) "elpy"))
+        ;; Second check if jedi is available
+        (let ((elpy-rpc--jedi-available t))
+          (should (string= (xref-find-backend) "elpy"))))))
+
+(ert-deftest elpy-xref--backend-should-return-false-when-jedi-not-available ()
+  (when (featurep 'xref)
+    (elpy-testcase ((:project project-root "test.py"))
+        (find-file (f-join project-root "test.py"))
+        (python-mode)
+        (elpy-mode)
+        (insert "def foo(x, y):\n"
+                "    return x + y\n"
+                "var1 = foo(5, 2)")
+        ;; First start the rpc and assume jedi is available
+        (should (string= (xref-find-backend) "elpy"))
+        (let ((elpy-rpc--jedi-available nil))
+          ;; Second check if jedi is available
+          (should (not (string= (xref-find-backend) "elpy")))))))


### PR DESCRIPTION
# PR Summary
Fix issue #1379.

Modifications in xref in Emacs 26 highlighted an issue with xref implementation in elpy:
if the rpc is not started for the current buffer, elpy xref backend is not activated and the default backend (etags) is used instead.

This PR makes sure that Elpy starts the rpc before checking if elpy xref should be activated or not.

Also add some tests.

# PR checklist

Please make sure that the following things have been addressed (and check the relevant checkboxes):

- [x] Commits respect our [guidelines](../CONTRIBUTING.rst)
- [x] Tests are passing properly (see [here](https://elpy.readthedocs.io/en/latest/extending.html#running-tests) on how to run Elpy's tests)
- [x] Code is not generating new bytecode warnings
