### PR TITLE
Fix error when try to blacken already formatted code

### DIFF
--- a/elpy/blackutil.py
+++ b/elpy/blackutil.py
@@ -32,6 +32,8 @@ def fix_code(code, directory):
             fast=False
         )
         return reformatted_source
+    except black.NothingChanged:
+        return code
     except Exception as e:
             raise Fault("Error during formatting: {}".format(e),
                         code=400)

--- a/test/elpy-black-fix-code-test.el
+++ b/test/elpy-black-fix-code-test.el
@@ -45,3 +45,28 @@
                       "x =_|_"
                       )
                      (should-error (elpy-black-fix-code))))))
+
+(ert-deftest elpy-black-fix-code-should-do-nothing-if-already-formatted ()
+  (let* ((pyversion (getenv "TRAVIS_PYTHON_VERSION"))
+         (black-not-supported (string< pyversion "3.6")))
+    (unless black-not-supported
+      (elpy-testcase ()
+                     (set-buffer-string-with-point
+                      "_|_y =  2"
+                      "z = 3"
+                      "x = 3"
+                      )
+                     (elpy-black-fix-code)
+                     (should
+                      (buffer-be
+                       "_|_y = 2"
+                       "z = 3"
+                       "x = 3"
+                       ))
+                     (elpy-black-fix-code)
+                     (should
+                      (buffer-be
+                       "_|_y = 2"
+                       "z = 3"
+                       "x = 3"
+                       ))))))


### PR DESCRIPTION
# PR Summary
Fix #1384.
Black raises an error when the code is already formatted correctly.

Elpy now ignore this error, instead or raising an "Elpy error".
Also added some tests to cover this.

# PR checklist

Please make sure that the following things have been addressed (and check the relevant checkboxes):

- [x] Commits respect our [guidelines](../CONTRIBUTING.rst)
- [x] Tests are passing properly (see [here](https://elpy.readthedocs.io/en/latest/extending.html#running-tests) on how to run Elpy's tests)
- [x] Code is not generating new bytecode warnings