### PR TITLE
Prevent flymake to overwrite calltip

### DIFF
--- a/elpy.el
+++ b/elpy.el
@@ -3770,8 +3770,9 @@ description."
                         ", "))))
         ((and (fboundp 'flymake-diagnostic-text)
               (fboundp 'flymake-diagnostics)) ; emacs >= 26
-         (mapconcat #'flymake-diagnostic-text
-                    (flymake-diagnostics (point)) ", "))))
+         (let ((diag (flymake-diagnostics (point))))
+           (when diag
+             (mapconcat #'flymake-diagnostic-text diag ", "))))))
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;;; Module: Highlight Indentation


### PR DESCRIPTION
# PR Summary
`elpy-eldoc-documentation` expects `elpy-flymake-error-at-point` to return nil when no flymake errors at point.
This was not the case for emacs >= 26, for which `elpy-flymake-error-at-point` return an empty string.
This empty string is printed in the minibuffer instead of the desired calltip.

Linked to #1388.

# PR checklist

Please make sure that the following things have been addressed (and check the relevant checkboxes):

- [x] Commits respect our [guidelines](../CONTRIBUTING.rst)
- [x] Tests are passing properly (see [here](https://elpy.readthedocs.io/en/latest/extending.html#running-tests) on how to run Elpy's tests)
- [x] Code is not generating new bytecode warnings
