### PR TITLE
Prevent interferences between eldoc and company

### DIFF
--- a/elpy.el
+++ b/elpy.el
@@ -3633,6 +3633,10 @@ or unless NAME is no callable instance."
      (require 'eldoc)
      (setq eldoc-minor-mode-string nil))
     (`buffer-init
+     ;; avoid interferences between eldoc and company meta frontend
+     (when (member 'elpy-module-company elpy-modules)
+       (set (make-local-variable 'company-frontends)
+            (delq 'company-echo-metadata-frontend company-frontends)))
      (set (make-local-variable 'eldoc-documentation-function)
           'elpy-eldoc-documentation)
      (eldoc-mode 1))


### PR DESCRIPTION
# PR Summary
Follow issue #1389.

When eldoc and company modules are enable, and company activated, the two modules compete for the minibuffer message.
This create flickering and changing minibuffer message.

This PR deactivate company meta frontend, and indicate to eldoc to reprint message after company functions to avoid those issues.

# PR checklist

Please make sure that the following things have been addressed (and check the relevant checkboxes):

- [x] Commits respect our [guidelines](../CONTRIBUTING.rst)
- [x] Tests are passing properly (see [here](https://elpy.readthedocs.io/en/latest/extending.html#running-tests) on how to run Elpy's tests)
- [x] Code is not generating new bytecode warnings
