### PR TITLE
WIP: Getting folding right in Elpy

### DIFF
--- a/docs/ide.rst
+++ b/docs/ide.rst
@@ -541,6 +541,57 @@ fly, so see there for more configuration options.
    not need to install the program in every virtual env separately.
 
 
+Folding
+=======
+
+Elpy offers code folding by enhancing the builtin folding minor mode ``Hideshow``.
+
+When opening a python buffer, Elpy will indicate foldable things with an arrow in the left fringe.
+Clicking on an arrow will fold the corresponding code blocks.
+Folded code blocks can be unfolded by clicking on the `...` button at the end of the line.
+
+If you don't want to use your mouse, you can achieve the same thing with the function
+
+.. command:: elpy-folding-toggle-at-point
+   :kbd: C-c @ C-c
+
+   Toggle folding for the thing at point, it can be a docstring, a comment or a code block.
+
+The display of arrows in the fringe can be disable with the option
+
+.. option:: elpy-folding-fringe-indicators
+
+   If elpy should display folding fringe indicators or not.
+
+Elpy also provides some other useful features:
+
+.. command:: elpy-folding-toggle-docstrings
+   :kbd: C-c @ C-b
+
+   Toggle folding of all python docstrings.
+
+.. command:: elpy-folding-toggle-comments
+   :kbd: C-c @ C-m
+
+   Toggle folding of all comments.
+
+.. command:: elpy-folding-hide-leafs
+   :kbd: C-c @ C-f
+
+   Hide all code leafs, i.e. code blocks that do not contains any other blocks.
+
+The classical keybindings for hideshow are also available, e.g.:
+
+.. command:: hs-show-all
+   :kbd: C-c @ C-a
+
+   Unfold everything.
+
+(see `Hideshow`_ documentation for more information)
+
+.. _Hideshow: https://www.emacswiki.org/emacs/HideShow
+
+
 Documentation
 =============
 

--- a/elpy.el
+++ b/elpy.el
@@ -90,6 +90,8 @@ can be inidividually enabled or disabled."
                      elpy-module-eldoc)
               (const :tag "Highlight syntax errors (Flymake)"
                      elpy-module-flymake)
+              (const :tag "Code folding"
+                     elpy-module-folding)
               (const :tag "Show the virtualenv in the mode line (pyvenv)"
                      elpy-module-pyvenv)
               (const :tag "Display indentation markers (highlight-indentation)"
@@ -3102,6 +3104,419 @@ display the current class and method instead."
       ;; Return the last message until we're done
       eldoc-last-message)))
 
+
+;;;;;;;;;;;;;;;;;;;
+;;; Module: Folding
+
+(defun elpy-module-folding (command &rest _args)
+  "Module allowing code folding in Python."
+  (pcase command
+
+    (`global-init
+     (elpy-modules-remove-modeline-lighter 'hs-minor-mode))
+
+    (`buffer-init
+     (hs-minor-mode 1)
+     (setq-local hs-set-up-overlay 'elpy-folding--display-code-line-counts)
+     (setq-local hs-allow-nesting t)
+     (define-key elpy-mode-map [left-fringe mouse-1]
+       'elpy-folding--click-fringe)
+     (define-key elpy-mode-map (kbd "<mouse-1>") 'elpy-folding--click-text)
+     (elpy-folding--mark-foldable-lines)
+     (add-to-list 'after-change-functions 'elpy-folding--mark-foldable-lines))
+
+    (`buffer-stop
+     (hs-minor-mode -1)
+     (kill-local-variable 'hs-set-up-overlay)
+     (kill-local-variable 'hs-allow-nesting)
+     (define-key elpy-mode-map [left-fringe mouse-1] nil)
+     (define-key elpy-mode-map (kbd "<mouse-1>") nil)
+     (remove 'elpy-folding--mark-foldable-lines after-change-functions)
+     (cl-loop for prop in '(elpy-hs-folded elpy-hs-foldable elpy-hs-fringe)
+              do (remove-overlays (point-min) (point-max) prop t)))))
+
+;; Fringe and folding indicators
+(when (fboundp 'define-fringe-bitmap)
+  (define-fringe-bitmap 'elpy-folding-fringe-marker
+    (vector #b00000000
+            #b00000000
+            #b00000000
+            #b11000011
+            #b11100111
+            #b01111110
+            #b00111100
+            #b00011000))
+
+  (define-fringe-bitmap 'elpy-folding-fringe-foldable-marker
+    (vector #b00100000
+            #b00010000
+            #b00001000
+            #b00000100
+            #b00000100
+            #b00001000
+            #b00010000
+            #b00100000)))
+
+(defcustom elpy-folding-fringe-face 'elpy-folding-fringe-face
+  "Face for folding bitmaps appearing on the fringe."
+  :type 'face
+  :group 'elpy)
+
+(defface elpy-folding-fringe-face
+  '((t (:inherit 'font-lock-comment-face
+                 :box (:line-width 1 :style released-button))))
+  "Face for folding bitmaps appearing on the fringe."
+  :group 'elpy)
+
+(defcustom elpy-folding-face 'elpy-folding-face
+  "Face for the folded region indicator."
+  :type 'face
+  :group 'elpy)
+
+(defface elpy-folding-face
+  '((t (:inherit 'font-lock-comment-face :box t)))
+  "Face for the folded region indicator."
+  :group 'elpy)
+
+(defcustom elpy-folding-fringe-indicators t
+  "Non-nil if Elpy should display folding fringe indicators."
+  :set (lambda (var val)                ;
+         (set-default var val)
+         (dolist (buffer (buffer-list))
+           (when (with-current-buffer buffer elpy-mode)
+             (elpy-folding--mark-foldable-lines)))))
+
+(defvar elpy-folding-docstring-regex "[uU]?[rR]?\"\"\""
+  "Regular expression matching docstrings openings and closings.")
+
+(defvar elpy-docstring-block-start-regexp
+  "^\\s-*[uU]?[rR]?\"\"\"\n?\\s-*"
+  "Version of `hs-block-start-regexp' for docstrings.")
+
+;; Herlpers
+(defun elpy-info-docstring-p (&optional syntax-ppss)
+  "Return non-nil if point is in a docstring."
+  (save-excursion
+    (and (progn (python-nav-beginning-of-statement)
+                (looking-at "\\(\"\\|'\\)"))
+         (progn (forward-line -1)
+                (beginning-of-line)
+                (python-info-looking-at-beginning-of-defun)))))
+;; Indicators
+(defun elpy-folding--display-code-line-counts (ov)
+  "Display a folded region indicator with the number of folded lines.
+
+Meant to be used as `hs-set-up-overlay'."
+  (let* ((marker-string "*fringe-dummy*")
+         (marker-length (length marker-string)))
+    (cond
+     ((eq 'code (overlay-get ov 'hs))
+      (let* ((nmb-line (count-lines (overlay-start ov) (overlay-end ov)))
+             (display-string (format "(%d)..." nmb-line)))
+        ;; fringe indicator
+        (when elpy-folding-fringe-indicators
+          (put-text-property 0 marker-length 'display
+                             (list 'left-fringe 'elpy-folding-fringe-marker
+                                   'elpy-folding-fringe-face)
+                             marker-string)
+          (overlay-put ov 'before-string marker-string)
+          (overlay-put ov 'elpy-hs-fringe t))
+        ;; folding indicator
+        (put-text-property 0 (length display-string)
+                           'face 'elpy-folding-face display-string)
+        (put-text-property 0 (length display-string)
+                           'mouse-face 'highlight display-string)
+        (overlay-put ov 'display display-string)
+        (overlay-put ov 'elpy-hs-folded t)))
+     ;; for docstring and comments, we don't display the number of line
+     ((or (eq 'docstring (overlay-get ov 'hs))
+          (eq 'comment (overlay-get ov 'hs)))
+      (let ((display-string "..."))
+        (put-text-property 0 (length display-string)
+                           'mouse-face 'highlight display-string)
+        (overlay-put ov 'display display-string)
+        (overlay-put ov 'elpy-hs-folded t))))))
+
+(defun elpy-folding--mark-foldable-lines (&optional beg end rm-text-len)
+  "Add a fringe indicator for foldable lines.
+
+Meant to be used as a hook to `after-change-functions'."
+  (when elpy-folding-fringe-indicators
+    (save-excursion
+      (save-restriction
+        (when (and beg end)
+          (narrow-to-region (progn (goto-char beg) (line-beginning-position))
+                            (progn (goto-char end) (line-end-position))))
+        (remove-overlays (point-min) (point-max) 'elpy-hs-foldable t)
+        (goto-char (point-min))
+        (while (re-search-forward python-nav-beginning-of-defun-regexp nil t)
+          (let* ((beg (line-beginning-position))
+                 (end (line-end-position))
+                 (ov (make-overlay beg end))
+                 (marker-string "*fringe-dummy*")
+                 (marker-length (length marker-string)))
+            (when (version<= "25.2" emacs-version)
+              (put-text-property 0 marker-length
+                                 'display
+                                 (list 'left-fringe
+                                       'elpy-folding-fringe-foldable-marker
+                                       'elpy-folding-fringe-face)
+                                 marker-string)
+              (overlay-put ov 'before-string marker-string))
+            (overlay-put ov 'elpy-hs-foldable t)))))))
+
+;; Mouse interaction
+(defun elpy-folding--click-fringe (event)
+  "Hide or show block on fringe click."
+  (interactive "e")
+  (hs-life-goes-on
+   (when elpy-folding-fringe-indicators
+     (mouse-set-point event)
+     (let* ((folded (save-excursion
+                      (end-of-line)
+                      (cl-remove-if-not (lambda (ov)
+                                          (overlay-get ov 'elpy-hs-folded))
+                                        (overlays-at (point)))))
+            (foldable (cl-remove-if-not (lambda (ov)
+                                          (overlay-get ov 'elpy-hs-foldable))
+                                        (overlays-at (point)))))
+       (if folded
+           (hs-show-block)
+         (if foldable
+             (hs-hide-block)))))))
+
+(defun elpy-folding--click-text (event)
+  "Show block on click."
+  (interactive "e")
+  (hs-life-goes-on
+   (save-excursion
+     (let ((window (posn-window (event-end event)))
+           (pos (posn-point (event-end event))))
+       (with-current-buffer (window-buffer window)
+         (goto-char pos)
+         (when (hs-overlay-at (point))
+           (hs-show-block)
+           (deactivate-mark)))))))
+
+;; Hidding docstrings
+(defun elpy-folding--hide-docstring-region (beg end)
+  "Hide a region from BEG to END, marking it as a docstring.
+
+BEG and END have to be respectively on the first and last line
+of the docstring, their values are adapted to hide only the
+docstring body."
+  (hs-life-goes-on
+   ;; do not fold oneliners
+   (when (not (save-excursion
+                (goto-char beg)
+                (beginning-of-line)
+                (re-search-forward
+                 (concat elpy-folding-docstring-regex
+                         ".*"
+                         elpy-folding-docstring-regex)
+                 (line-end-position) t)))
+     ;; get begining position (do not fold first doc line)
+     (save-excursion
+       (goto-char beg)
+       (when (save-excursion
+               (beginning-of-line)
+               (re-search-forward
+                (concat elpy-folding-docstring-regex
+                        "[[:space:]]*$")
+                (line-end-position) t))
+         (forward-line 1))
+       (beginning-of-line)
+       (back-to-indentation)
+       (setq beg (point))
+       (setq ov-beg (line-end-position)))
+     ;; get end position
+     (save-excursion
+       (goto-char end)
+       (setq end (line-beginning-position))
+       (setq ov-end (line-end-position)))
+     (hs-discard-overlays ov-beg ov-end)
+     (hs-make-overlay ov-beg ov-end 'docstring (- beg ov-beg) (- end ov-end))
+     (run-hooks 'hs-hide-hook)
+     (goto-char beg))))
+
+(defun elpy-folding--hide-docstring-at-point ()
+  "Hide the docstring at point."
+  (hs-life-goes-on
+   (let ((hs-block-start-regexp elpy-docstring-block-start-regexp))
+     (when (and (elpy-info-docstring-p) (not (hs-already-hidden-p)))
+       (let (beg end line-beg line-end)
+         ;; Get first doc line
+         (if (not (save-excursion (forward-line -1)
+                                  (elpy-info-docstring-p)))
+             (setq beg (line-beginning-position))
+           (forward-line -1)
+           (end-of-line)
+           (re-search-backward (concat "^[[:space:]]*"
+                                       elpy-folding-docstring-regex)
+                               nil t)
+           (setq beg (line-beginning-position)))
+         ;; Go to docstring opening (to be sure to be inside the docstring)
+         (re-search-forward elpy-folding-docstring-regex nil t)
+         (setq line-beg (line-number-at-pos))
+         ;; Get last line
+         (if (not (save-excursion (forward-line 1)
+                                  (elpy-info-docstring-p)))
+             (progn
+               (setq end (line-end-position))
+               (setq line-end (line-number-at-pos)))
+           (re-search-forward elpy-folding-docstring-regex nil t)
+           (setq end (line-end-position))
+           (setq line-end (line-number-at-pos)))
+         ;; hide the docstring
+         (when (not (= line-end line-beg))
+           (elpy-folding--hide-docstring-region beg end)))))))
+
+(defun elpy-folding--show-docstring-at-point ()
+  "Show docstring at point."
+  (hs-life-goes-on
+   (let ((hs-block-start-regexp elpy-docstring-block-start-regexp))
+     (when (elpy-info-docstring-p)
+       (hs-show-block)))))
+
+(defvar-local elpy-folding-docstrings-hidden nil
+  "If docstrings are globally hidden or not.")
+
+(defun elpy-folding-toggle-docstrings ()
+  "Fold or unfold every docstrings in the current buffer."
+  (interactive)
+  (if (not hs-minor-mode)
+      (message "Please enable the 'Folding module' to use this functionality.")
+    (hs-life-goes-on
+     (save-excursion
+       (goto-char (point-min))
+       (while (python-nav-forward-defun)
+         (search-forward-regexp ")\\s-*:" nil t)
+         (forward-line)
+         (when (and (elpy-info-docstring-p)
+                    (progn
+                      (beginning-of-line)
+                      (search-forward-regexp elpy-folding-docstring-regex
+                                             nil t)))
+           (forward-char 2)
+           (back-to-indentation)
+           ;; be sure not to act on invisible docstrings
+           (unless (and (hs-overlay-at (point))
+                        (not (eq (overlay-get (hs-overlay-at (point)) 'hs)
+                                 'docstring)))
+             (if elpy-folding-docstrings-hidden
+                 (elpy-folding--show-docstring-at-point)
+               (elpy-folding--hide-docstring-at-point)))))))
+    (setq elpy-folding-docstrings-hidden (not elpy-folding-docstrings-hidden))))
+
+;; Hiding comments
+(defvar-local elpy-folding-comments-hidden nil
+  "If comments are globally hidden or not.")
+
+(defun elpy-folding-toggle-comments ()
+  "Fold or unfold every comment blocks in the current buffer."
+  (interactive)
+  (if (not hs-minor-mode)
+      (message "Please enable the 'Folding module' to use this functionality.")
+    (hs-life-goes-on
+     (save-excursion
+       (goto-char (point-min))
+       (while (comment-search-forward (point-max) t)
+         ;; be suse not to act on invisible comments
+         (unless (and (hs-overlay-at (point))
+                      (not (eq (overlay-get (hs-overlay-at (point)) 'hs)
+                               'comment)))
+           (if (not elpy-folding-comments-hidden)
+               ;; be sure to be on a multiline comment
+               (when (save-excursion (forward-line)
+                                     (comment-only-p (line-beginning-position)
+                                                     (line-end-position)))
+                 (hs-hide-block))
+             (hs-show-block)))
+         (python-util-forward-comment (buffer-size))))
+     (setq elpy-folding-comments-hidden (not elpy-folding-comments-hidden)))))
+
+;; Hiding leafs
+;;     taken from https://www.emacswiki.org/emacs/HideShow
+(defun elpy-folding--hide-leafs (beg end)
+  "Hide blocks that do not contain others blocks in region (BEG END)."
+  (hs-life-goes-on
+   (save-excursion
+     (goto-char beg)
+     ;; Find the current block beginning and end
+     (when (hs-find-block-beginning)
+       (setq beg (1+ (point)))
+       (funcall hs-forward-sexp-func 1)
+       (setq end (1- (point))))
+     ;; Show all branches if nesting not allowed
+     (unless hs-allow-nesting
+       (hs-discard-overlays beg end))
+     ;; recursively treat current block leafs
+     (let ((leaf t))
+       (while (progn
+                (forward-comment (buffer-size))
+                (and (< (point) end)
+                     (re-search-forward hs-block-start-regexp end t)))
+         (setq pos (match-beginning hs-block-start-mdata-select))
+         (if (elpy-folding--hide-leafs pos end)
+             (save-excursion
+               (goto-char pos)
+               (hs-hide-block-at-point t)))
+         (setq leaf nil))
+       (goto-char end)
+       (run-hooks 'hs-hide-hook)
+       leaf))))
+
+(defun elpy-folding-hide-leafs ()
+  "Hide all blocks that do not contain other blocks."
+  (interactive)
+  (if (not hs-minor-mode)
+      (message "Please enable the 'Folding module' to use this functionality.")
+    (hs-life-goes-on
+     (let ((beg (save-excursion
+                  (goto-char (if (use-region-p) (region-beginning) (point-min)))
+                  (line-beginning-position)))
+           (end (save-excursion
+                  (goto-char (if (use-region-p) (region-end) (point-max)))
+                  (1+ (line-end-position)))))
+       (elpy-folding--hide-leafs beg end)))))
+
+;; DWIM functions
+(defun elpy-folding--hide-region (beg end)
+  "Hide the region betwwen BEG and END."
+  (hs-life-goes-on
+   (save-excursion
+     (let ((beg-eol (progn (goto-char beg) (line-end-position)))
+           (end-eol (progn (goto-char end) (line-end-position))))
+       (hs-discard-overlays beg-eol end-eol)
+       (hs-make-overlay beg-eol end-eol 'code (- beg beg-eol) (- end end-eol))
+       (run-hooks 'hs-hide-hook)
+       (deactivate-mark)))))
+
+(defun elpy-folding-toggle-at-point ()
+  "Fold/Unfold the block, comment or docstring at point.
+
+If a region is selected, fold that region."
+  (interactive)
+  (if (not hs-minor-mode)
+      (message "Please enable the 'Folding module' to use this functionality.")
+    (hs-life-goes-on
+     ;; Use selected region
+     (if (use-region-p)
+         (elpy-folding--hide-region (region-beginning) (region-end))
+       ;; Adapt starting regexp if on a docstring
+       (let ((hs-block-start-regexp
+              (if (elpy-info-docstring-p)
+                  elpy-docstring-block-start-regexp
+                hs-block-start-regexp)))
+         ;; Hide or fold
+         (cond
+          ((hs-already-hidden-p)
+           (hs-show-block))
+          ((elpy-info-docstring-p)
+           (elpy-folding--hide-docstring-at-point))
+          (t
+           (hs-hide-block))))))))
+
 ;;;;;;;;;;;;;;;;;;;
 ;;; Module: Flymake
 
@@ -3119,6 +3534,11 @@ display the current class and method instead."
                     '("\\.py\\'" elpy-flymake-python-init))))
 
     (`buffer-init
+     ;; Avoid fringes clash between flymake and folding indicators
+     (if (and (member 'elpy-module-folding elpy-modules)
+              elpy-folding-fringe-indicators)
+         (setq-local flymake-fringe-indicator-position 'right-fringe)
+       (setq-local flymake-fringe-indicator-position 'left-fringe))
      ;; Set this for `elpy-check' command
      (setq-local python-check-command elpy-syntax-check-command)
      ;; For emacs > 26.1, python.el natively supports flymake,

--- a/elpy.el
+++ b/elpy.el
@@ -321,6 +321,10 @@ option is `pdb'."
     (define-key map (kbd "C-c C-n") 'elpy-flymake-next-error)
     (define-key map (kbd "C-c C-o") 'elpy-occur-definitions)
     (define-key map (kbd "C-c C-p") 'elpy-flymake-previous-error)
+    (define-key map (kbd "C-c @ C-c") 'elpy-folding-toggle-at-point)
+    (define-key map (kbd "C-c @ C-b") 'elpy-folding-toggle-docstrings)
+    (define-key map (kbd "C-c @ C-m") 'elpy-folding-toggle-comments)
+    (define-key map (kbd "C-c @ C-f") 'elpy-folding-hide-leafs)
     (define-key map (kbd "C-c C-s") 'elpy-rgrep-symbol)
     (define-key map (kbd "C-c C-t") 'elpy-test)
     (define-key map (kbd "C-c C-v") 'elpy-check)
@@ -478,6 +482,15 @@ This option need to bet set through `customize' or `customize-set-variable' to b
       :help "Go to the next inline error, if any"]
      ["Previous Error" elpy-flymake-previous-error
       :help "Go to the previous inline error, if any"])
+    ("Code folding"
+     ["Hide/show at point" elpy-folding-toggle-at-point
+      :help "Hide or show the block or docstring at point"]
+     ["Hide/show all docstrings" elpy-folding-toggle-docstrings
+      :help "Hide or show all the docstrings"]
+     ["Hide/show all comments" elpy-folding-toggle-comments
+      :help "Hide or show all the comments"]
+     ["Hide leafs" elpy-folding-hide-leafs
+      :help "Hide all leaf blocks (blocks not containing other blocks)"])
     ("Indentation Blocks"
      ["Dedent" python-indent-shift-left
       :help "Dedent current block or region"
@@ -572,6 +585,7 @@ virtualenv.
     ("Completion (Company)" company "company-")
     ("Call Signatures (ElDoc)" eldoc "eldoc-")
     ("Inline Errors (Flymake)" flymake "flymake-")
+    ("Code folding (hideshow)" hideshow "hs-")
     ("Snippets (YASnippet)" yasnippet "yas-")
     ("Directory Grep (rgrep)" grep "grep-")
     ("Search as You Type (ido)" ido "ido-")

--- a/test/elpy-folding-fold-all-comments-test.el
+++ b/test/elpy-folding-fold-all-comments-test.el
@@ -1,0 +1,53 @@
+(ert-deftest elpy-fold-all-comments-should-fold-all-comments ()
+  (elpy-testcase ()
+    (add-to-list 'elpy-modules 'elpy-module-folding)
+    (set-buffer-string-with-point
+     "var1 = 45"
+     "# This is a comment to explain nothing"
+     "# about the life and the universe"
+     "class foo(object):"
+     "  def __init__(self, a, b):"
+     "    self.a = a"
+     "    self.b = b"
+     "    # This is a _|_comment"
+     "    # on several lines"
+     "    # to test folding"
+     "  def bar(mess):"
+     "    mess *= 2"
+     "    print(mess)"
+     "    # Another comment here"
+     "    return mess"
+     "# Another comment on"
+     "# two lines !"
+     "var2 = foo(var1, 4)")
+    (python-mode)
+    (elpy-mode)
+    ;; Fold all comments
+    (elpy-folding-toggle-comments)
+    (let* ((overlays (overlays-in (point-min) (point-max)))
+           overlay)
+      (should (= 6 (length overlays)))
+      ;; first two lines comment
+      (setq overlay (nth 5 overlays))
+      (should (eq (overlay-get overlay 'hs) 'comment))
+      (should (= (overlay-start overlay) 49))
+      (should (= (overlay-end overlay) 83))
+      ;; second three lines comment
+      (setq overlay (nth 2 overlays))
+      (should (eq (overlay-get overlay 'hs) 'comment))
+      (should (= (overlay-start overlay) 184))
+      (should (= (overlay-end overlay) 229))
+      ;; third two lines comment
+      (setq overlay (nth 0 overlays))
+      (should (eq (overlay-get overlay 'hs) 'comment))
+      (should (= (overlay-start overlay) 340))
+      (should (= (overlay-end overlay) 354)))
+    ;; point shouldn't move
+    (should (= (point) 177))
+    ;; Unfold all comments
+    (elpy-folding-toggle-comments)
+    (let* ((overlays (overlays-in (point-min) (point-max)))
+           overlay)
+      (should (= 3 (length overlays))))
+    ;; Position
+    (should (= (point) 177))))

--- a/test/elpy-folding-fold-all-docstrings-test.el
+++ b/test/elpy-folding-fold-all-docstrings-test.el
@@ -1,0 +1,55 @@
+(ert-deftest elpy-fold-docstrings-should-fold-all-docstrings ()
+  (elpy-testcase ()
+    (add-to-list 'elpy-modules 'elpy-module-folding)
+    (set-buffer-string-with-point
+     "var1 = 45"
+     ""
+     "class foo(object):"
+     "  def __init__(self, a, b):"
+     "    \"\"\" "
+     "    First docstring spawning "
+     "    several lines."
+     "    \"\"\""
+     "    self.a = a"
+     "    self.b = b"
+     ""
+     "  def bar(mess):"
+     "    \"\"\" This is docstring for BAR"
+     ""
+     "    And here are the pa_|_rameters"
+     ""
+     "    And there the return values"
+     "    \"\"\""
+     "    mess *= 2"
+     "    print(mess)"
+     "    return mess"
+     ""
+     "def bar2(mess):"
+     "    \"\"\" This is a oneline docstring\"\"\""
+     "    print(mess)"
+     ""
+     "var2 = foo(var1, 4)")
+    (python-mode)
+    (elpy-mode)
+    (elpy-folding-toggle-docstrings)
+    (let* ((overlays (overlays-in (point-min) (point-max)))
+           overlay)
+      (should (= 6 (length overlays)))
+      ;; First docstring
+      (setq overlay (nth 3 overlays))
+      (should (eq (overlay-get overlay 'hs) 'docstring))
+      (should (= (overlay-start overlay) 97))
+      (should (= (overlay-end overlay) 124))
+      ;; Second docstring
+      (setq overlay (nth 1 overlays))
+      (should (eq (overlay-get overlay 'hs) 'docstring))
+      (should (= (overlay-start overlay) 206))
+      (should (= (overlay-end overlay) 280)))
+    (should (= (point) 231))
+    ;; Unfold
+    (elpy-folding-toggle-docstrings)
+    (let* ((overlays (overlays-in (point-min) (point-max)))
+           overlay)
+      (should (= 4 (length overlays))))
+    ;; Position
+    (should (= (point) 231))))

--- a/test/elpy-folding-fold-blocks-test.el
+++ b/test/elpy-folding-fold-blocks-test.el
@@ -1,0 +1,173 @@
+(ert-deftest elpy-fold-at-point-should-fold-and-unfold-functions ()
+  (elpy-testcase ()
+    (add-to-list 'elpy-modules 'elpy-module-folding)
+    (set-buffer-string-with-point
+     "var1 = 45"
+     "def foo(_|_a, b):"
+     "  c = a + b"
+     "var2 = foo(var1, 4)")
+    (python-mode)
+    (elpy-mode)
+    (elpy-folding-toggle-at-point)
+    (let* ((overlays (apply 'nconc (overlay-lists)))
+           overlay)
+      (should (= 2 (length overlays)))
+      (setq overlay (nth 0 overlays))
+      (should (eq (overlay-get overlay 'hs) 'code))
+      (should (= (overlay-start overlay) 25))
+      (should (or (= (overlay-end overlay) 37)
+                  (= (overlay-end overlay) 38))))
+    (should (= (point) 14))
+    ;; Unfold
+    (elpy-folding-toggle-at-point)
+    (let* ((overlays (apply 'nconc (overlay-lists)))
+           overlay)
+      (should (= 1 (length overlays))))
+    ;; Position
+    (should (= (point) 14))))
+
+(ert-deftest elpy-fold-at-point-should-fold-and-unfold-functions-from-inside ()
+  (elpy-testcase ()
+    (add-to-list 'elpy-modules 'elpy-module-folding)
+    (set-buffer-string-with-point
+     "var1 = 45"
+     "def foo(a, b):"
+     "  c = _|_a + b"
+     "var2 = foo(var1, 4)")
+    (python-mode)
+    (elpy-mode)
+    (elpy-folding-toggle-at-point)
+    (let* ((overlays (apply 'nconc (overlay-lists)))
+           overlay)
+      (should (= 2 (length overlays)))
+      (setq overlay (nth 0 overlays))
+      (should (eq (overlay-get overlay 'hs) 'code))
+      (should (= (overlay-start overlay) 25))
+      (should (or (= (overlay-end overlay) 37)
+                  (= (overlay-end overlay) 38))))
+    (should (= (point) 14))
+    ;; Unfold
+    (elpy-folding-toggle-at-point)
+    (let* ((overlays (apply 'nconc (overlay-lists)))
+           overlay)
+      (should (= 1 (length overlays))))
+    ;; Position
+    (should (= (point) 14))))
+
+(ert-deftest elpy-fold-at-point-should-NOT-fold-and-unfold-functions-from-after ()
+  (elpy-testcase ()
+    (add-to-list 'elpy-modules 'elpy-module-folding)
+    (set-buffer-string-with-point
+     "var1 = 45"
+     "def foo(a, b):"
+     "  c = a + b"
+     "  return c"
+     "_|_"
+     "var2 = foo(var1, 4)")
+    (python-mode)
+    (elpy-mode)
+    (elpy-folding-toggle-at-point)
+    (let ((overlays (apply 'nconc (overlay-lists))))
+      (should (= 1 (length overlays))))
+    ;; Position
+    (should (= (point) 49))))
+
+(ert-deftest elpy-fold-at-point-should-fold-and-unfold-nested-functions ()
+  (elpy-testcase ()
+    (add-to-list 'elpy-modules 'elpy-module-folding)
+    (set-buffer-string-with-point
+     "var1 = 45"
+     "def foo(a, b):"
+     "  c = a + b"
+     "  def bar(mess):"
+     "    mess *= 2"
+     "    print(mess)"
+     "    return _|_mess"
+     "var2 = foo(var1, 4)")
+    (python-mode)
+    (elpy-mode)
+    (elpy-folding-toggle-at-point)
+    (let* ((overlays (apply 'nconc (overlay-lists)))
+           overlay)
+      (should (= 3 (length overlays)))
+      (setq overlay (nth 0 overlays))
+      (should (eq (overlay-get overlay 'hs) 'code))
+      (should (= (overlay-start overlay) 54))
+      (should (or (= (overlay-end overlay) 100)
+                  (= (overlay-end overlay) 101))))
+    (should (= (point) 43))
+    ;; Unfold
+    (elpy-folding-toggle-at-point)
+    (let* ((overlays (apply 'nconc (overlay-lists)))
+           overlay)
+      (should (= 2 (length overlays))))
+    ;; Position
+    (should (= (point) 43))))
+
+(ert-deftest elpy-fold-at-point-should-fold-and-unfold-methods ()
+  (elpy-testcase ()
+    (add-to-list 'elpy-modules 'elpy-module-folding)
+    (set-buffer-string-with-point
+     "var1 = 45"
+     "class foo(object):"
+     "  def __init__(self, a, b):"
+     "    self.a = a"
+     "    self.b = b"
+     "  def bar(mess):"
+     "    mess *= 2"
+     "    print(mess)"
+     "    return _|_mess"
+     "var2 = foo(var1, 4)")
+    (python-mode)
+    (elpy-mode)
+    (elpy-folding-toggle-at-point)
+    (let* ((overlays (apply 'nconc (overlay-lists)))
+           overlay)
+      (should (= 4 (length overlays)))
+      (setq overlay (nth 0 overlays))
+      (should (eq (overlay-get overlay 'hs) 'code))
+      (should (= (overlay-start overlay) 104))
+      (should (or (= (overlay-end overlay) 150)
+                  (= (overlay-end overlay) 151))))
+    (should (= (point) 93))
+    ;; Unfold
+    (elpy-folding-toggle-at-point)
+    (let* ((overlays (apply 'nconc (overlay-lists)))
+           overlay)
+      (should (= 3 (length overlays))))
+    ;; Position
+    (should (= (point) 93))))
+
+(ert-deftest elpy-fold-at-point-should-fold-and-unfold-classes ()
+  (elpy-testcase ()
+    (add-to-list 'elpy-modules 'elpy-module-folding)
+    (set-buffer-string-with-point
+     "var1 = 45"
+     "class foo_|_(object):"
+     "  def __init__(self, a, b):"
+     "    self.a = a"
+     "    self.b = b"
+     "  def bar(mess):"
+     "    mess *= 2"
+     "    print(mess)"
+     "    return mess"
+     "var2 = foo(var1, 4)")
+    (python-mode)
+    (elpy-mode)
+    (elpy-folding-toggle-at-point)
+    (let* ((overlays (apply 'nconc (overlay-lists)))
+           overlay)
+      (should (= 4 (length overlays)))
+      (setq overlay (nth 0 overlays))
+      (should (eq (overlay-get overlay 'hs) 'code))
+      (should (= (overlay-start overlay) 29))
+      (should (or (= (overlay-end overlay) 150)
+                  (= (overlay-end overlay) 151))))
+    (should (= (point) 16))
+    ;; Unfold
+    (elpy-folding-toggle-at-point)
+    (let* ((overlays (apply 'nconc (overlay-lists)))
+           overlay)
+      (should (= 3 (length overlays))))
+    ;; Position
+    (should (= (point) 16))))

--- a/test/elpy-folding-fold-comments-test.el
+++ b/test/elpy-folding-fold-comments-test.el
@@ -1,0 +1,58 @@
+(ert-deftest elpy-fold-at-point-should-fold-and-unfold-comments ()
+  (elpy-testcase ()
+    (add-to-list 'elpy-modules 'elpy-module-folding)
+    (set-buffer-string-with-point
+     "var1 = 45"
+     "class foo(object):"
+     "  def __init__(self, a, b):"
+     "    self.a = a"
+     "    self.b = b"
+     "    # This is a _|_comment"
+     "    # on several lines"
+     "    # to test folding"
+     "  def bar(mess):"
+     "    mess *= 2"
+     "    print(mess)"
+     "    return mess"
+     "var2 = foo(var1, 4)")
+    (python-mode)
+    (elpy-mode)
+    (elpy-folding-toggle-at-point)
+    (let* ((overlays (overlays-in (point-min) (point-max)))
+           overlay)
+      (should (= 4 (length overlays)))
+      (setq overlay (nth 1 overlays))
+      (should (eq (overlay-get overlay 'hs) 'comment))
+      (should (= (overlay-start overlay) 111))
+      (should (= (overlay-end overlay) 156)))
+    (should (= (point) 92))
+    ;; Unfold
+    (elpy-folding-toggle-at-point)
+    (let* ((overlays (overlays-in (point-min) (point-max)))
+           overlay)
+      (should (= 3 (length overlays))))
+    ;; Position
+    (should (= (point) 92))))
+
+(ert-deftest elpy-fold-at-point-should-NOT-fold-and-unfold-oneline-comments ()
+  (elpy-testcase ()
+    (add-to-list 'elpy-modules 'elpy-module-folding)
+    (set-buffer-string-with-point
+     "var1 = 45"
+     "class foo(object):"
+     "  def __init__(self, a, b):"
+     "    self.a = a"
+     "    self.b = b"
+     "    # This is a oneline _|_comment"
+     "  def bar(mess):"
+     "    mess *= 2"
+     "    print(mess)"
+     "    return mess"
+     "var2 = foo(var1, 4)")
+    (python-mode)
+    (elpy-mode)
+    (elpy-folding-toggle-at-point)
+    (let* ((overlays (overlays-in (point-min) (point-max)))
+           overlay)
+      (should (= 3 (length overlays))))
+    (should (= (point) 112))))

--- a/test/elpy-folding-fold-docstrings-test.el
+++ b/test/elpy-folding-fold-docstrings-test.el
@@ -1,0 +1,211 @@
+(ert-deftest elpy-fold-at-point-should-fold-multiline-docstrings ()
+  (elpy-testcase ()
+    (add-to-list 'elpy-modules 'elpy-module-folding)
+    (set-buffer-string-with-point
+     "var1 = 45"
+     "class foo(object):"
+     "  def __init__(self, a, b):"
+     "    self.a = a"
+     "    self.b = b"
+     "  def bar(mess):"
+     "    \"\"\" This is docstring for BAR"
+     ""
+     "    And here are the pa_|_rameters"
+     ""
+     "    And there the return values"
+     "    \"\"\""
+     "    mess *= 2"
+     "    print(mess)"
+     "    return mess"
+     "var2 = foo(var1, 4)")
+    (python-mode)
+    (elpy-mode)
+    (elpy-folding-toggle-at-point)
+    (let* ((overlays (overlays-in (point-min) (point-max)))
+           overlay)
+      ;; (dolist (overlay overlays)
+      ;;   (message "overlay from %s to %s on: %s"
+      ;;            (overlay-start overlay)
+      ;;            (overlay-end overlay)
+      ;;            (buffer-substring (overlay-start overlay)
+      ;;                              (overlay-end overlay))))
+      (should (= 4 (length overlays)))
+      (setq overlay (nth 0 overlays))
+      (should (eq (overlay-get overlay 'hs) 'docstring))
+      (should (= (overlay-start overlay) 138))
+      (should (= (overlay-end overlay) 212)))
+    (should (= (point) 109))
+    ;; Unfold
+    (elpy-folding-toggle-at-point)
+    (let* ((overlays (overlays-in (point-min) (point-max)))
+           overlay)
+      (should (= 3 (length overlays))))
+    ;; Position
+    (should (= (point) 109))))
+
+(ert-deftest elpy-fold-at-point-should-fold-multiline-docstrings-2 ()
+  (elpy-testcase ()
+    (add-to-list 'elpy-modules 'elpy-module-folding)
+    (set-buffer-string-with-point
+     "var1 = 45"
+     "class foo(object):"
+     "  def __init__(self, a, b):"
+     "    self.a = a"
+     "    self.b = b"
+     "  def bar(mess):"
+     "    \"\"\""
+     "    This is docstring for BAR"
+     ""
+     "    And here are the pa_|_rameters"
+     ""
+     "    And there the return values"
+     "    \"\"\""
+     "    mess *= 2"
+     "    print(mess)"
+     "    return mess"
+     "var2 = foo(var1, 4)")
+    (python-mode)
+    (elpy-mode)
+    (elpy-folding-toggle-at-point)
+    (let* ((overlays (overlays-in (point-min) (point-max)))
+           overlay)
+      (should (= 4 (length overlays)))
+      (setq overlay (nth 0 overlays))
+      (should (eq (overlay-get overlay 'hs) 'docstring))
+      (should (= (overlay-start overlay) 142))
+      (should (= (overlay-end overlay) 216)))
+    (should (= (point) 117))
+    ;; Unfold
+    (elpy-folding-toggle-at-point)
+    (let* ((overlays (overlays-in (point-min) (point-max)))
+           overlay)
+      (should (= 3 (length overlays))))
+    ;; Position
+    (should (= (point) 117))))
+
+(ert-deftest elpy-fold-at-point-should-NOT-fold-oneline-docstrings ()
+  (elpy-testcase ()
+    (add-to-list 'elpy-modules 'elpy-module-folding)
+    (set-buffer-string-with-point
+     "var1 = 45"
+     "class foo(object):"
+     "  def __init__(self, a, b):"
+     "    self.a = a"
+     "    self.b = b"
+     "  def bar(mess):"
+     "    \"\"\" This is do_|_cstring for BAR \"\"\""
+     "    mess *= 2"
+     "    print(mess)"
+     "    return mess"
+     "var2 = foo(var1, 4)")
+    (python-mode)
+    (elpy-mode)
+    (elpy-folding-toggle-at-point)
+    (let* ((overlays (overlays-in (point-min) (point-max)))
+           overlay)
+      (should (= 3 (length overlays))))))
+
+(ert-deftest elpy-fold-at-point-should-NOT-fold-strings ()
+  (elpy-testcase ()
+    (set-buffer-string-with-point
+     "var1 = 45"
+     "class foo(object):"
+     "  def __init__(self, a, b):"
+     "    self.a = a"
+     "    self.b = b"
+     "  def bar(mess):"
+     "    \" This is just _|_a string\""
+     "    mess *= 2"
+     "    print(mess)"
+     "    return mess"
+     "var2 = foo(var1, 4)")
+    (python-mode)
+    (elpy-mode)
+    (elpy-folding-toggle-at-point)
+    (let* ((overlays (overlays-in (point-min) (point-max)))
+           overlay)
+      (should (= 3 (length overlays))))))
+
+(ert-deftest elpy-fold-at-point-should-NOT-fold-strings-2 ()
+  (elpy-testcase ()
+    (add-to-list 'elpy-modules 'elpy-module-folding)
+    (set-buffer-string-with-point
+     "var1 = 45"
+     "class foo(object):"
+     "  def __init__(self, a, b):"
+     "    self.a = a"
+     "    self.b = b"
+     "  def bar(mess):"
+     "    mess *= 2"
+     "    \" This is just _|_a string\""
+     "    print(mess)"
+     "    return mess"
+     "var2 = foo(var1, 4)")
+    (python-mode)
+    (elpy-mode)
+    (elpy-folding-toggle-at-point)
+    (let* ((overlays (overlays-in (point-min) (point-max)))
+           overlay)
+      (should (= 4 (length overlays)))
+      (dolist (overlay overlays)
+        (should-not (eq (overlay-get overlay 'hs) 'docstring))))))
+
+(ert-deftest elpy-fold-at-point-should-NOT-fold-strings-3 ()
+  (elpy-testcase ()
+    (add-to-list 'elpy-modules 'elpy-module-folding)
+    (set-buffer-string-with-point
+     "var1 = 45"
+     "class foo(object):"
+     "  def __init__(self, a, b):"
+     "    self.a = a"
+     "    self.b = b"
+     "  def bar(mess):"
+     "    mess *= 2"
+     "    mess = \"\"\" This is just _|_a string\"\"\""
+     "    print(mess)"
+     "    return mess"
+     "var2 = foo(var1, 4)")
+    (python-mode)
+    (elpy-mode)
+    (elpy-folding-toggle-at-point)
+    (let* ((overlays (overlays-in (point-min) (point-max)))
+           overlay)
+      (should (= 4 (length overlays)))
+      (setq overlay (nth 0 overlays))
+      (should (eq (overlay-get overlay 'hs) 'code))
+      (should (= (overlay-start overlay) 104))
+      (should (or (= (overlay-end overlay) 190)
+                  (= (overlay-end overlay) 191))))
+    (should (= (point) 93))))
+
+(ert-deftest elpy-fold-at-point-should-NOT-fold-strings-4 ()
+  (elpy-testcase ()
+    (add-to-list 'elpy-modules 'elpy-module-folding)
+    (set-buffer-string-with-point
+     "var1 = 45"
+     "class foo(object):"
+     "  def __init__(self, a, b):"
+     "    self.a = a"
+     "    self.b = b"
+     "  def bar(mess):"
+     "    mess *= 2"
+     "    mess = \"\"\""
+     "    This is just _|_a string"
+     ""
+     "    Even if it is multinline"
+     "    \"\"\""
+     "    print(mess)"
+     "    return mess"
+     "var2 = foo(var1, 4)")
+    (python-mode)
+    (elpy-mode)
+    (elpy-folding-toggle-at-point)
+    (let* ((overlays (overlays-in (point-min) (point-max)))
+           overlay)
+      (should (= 4 (length overlays)))
+      (setq overlay (nth 0 overlays))
+      (should (eq (overlay-get overlay 'hs) 'code))
+      (should (= (overlay-start overlay) 104))
+      (should (or (= (overlay-end overlay) 229)
+                  (= (overlay-end overlay) 230))))
+    (should (= (point) 93))))

--- a/test/elpy-folding-fold-leafs-test.el
+++ b/test/elpy-folding-fold-leafs-test.el
@@ -1,0 +1,41 @@
+
+(ert-deftest elpy-fold-leafs-should-fold-them ()
+  (elpy-testcase ()
+    (add-to-list 'elpy-modules 'elpy-module-folding)
+    (set-buffer-string-with-point
+     "var1 = 45"
+     "class foo(object):"
+     "  def __init__(self, a, b):"
+     "    self.a = a"
+     "    self.b = b"
+     "  def bar(mess):"
+     "    mess *= 2"
+     "    def bar2(mess):"
+     "      print(_|_mess)"
+     "    return mess"
+     "var2 = foo(var1, 4)")
+    (python-mode)
+    (elpy-mode)
+    (elpy-folding-hide-leafs)
+    (let* ((overlays (overlays-in (point-min) (point-max)))
+           overlay)
+      (should (= 6 (length overlays)))
+      (setq overlay (nth 3 overlays))
+      (should (eq (overlay-get overlay 'hs) 'code))
+      (should (= (overlay-start overlay) 57))
+      (should (or (= (overlay-end overlay) 87)
+                  (= (overlay-end overlay) 88)))
+      (setq overlay (nth 0 overlays))
+      (should (eq (overlay-get overlay 'hs) 'code))
+      (should (= (overlay-start overlay) 138))
+      (should (or (= (overlay-end overlay) 156)
+                  (= (overlay-end overlay) 157))))
+
+    (should (= (point) 151))
+    ;; Unfold
+    (hs-show-all)
+    (let* ((overlays (overlays-in (point-min) (point-max)))
+           overlay)
+      (should (= 4 (length overlays))))
+    ;; Position
+    (should (= (point) 151))))

--- a/test/elpy-folding-fold-on-click-test.el
+++ b/test/elpy-folding-fold-on-click-test.el
@@ -1,0 +1,62 @@
+(ert-deftest elpy-fold-at-point-should-fold-and-unfold-on-fringe-click ()
+  (elpy-testcase ()
+    (add-to-list 'elpy-modules 'elpy-module-folding)
+    (set-buffer-string-with-point
+     "var1 = 45"
+     "def foo(_|_a, b):"
+     "  c = a + b"
+     "var2 = foo(var1, 4)")
+    (python-mode)
+    (elpy-mode)
+    (mletf* ((mouse-set-point (event) (goto-char (point))))
+      (elpy-folding--click-fringe nil))
+    (let* ((overlays (apply 'nconc (overlay-lists)))
+           overlay)
+      (should (= 2 (length overlays)))
+      (setq overlay (nth 0 overlays))
+      (should (eq (overlay-get overlay 'hs) 'code))
+      (should (= (overlay-start overlay) 25))
+      (should (or (= (overlay-end overlay) 37)
+                  (= (overlay-end overlay) 38))))
+    (should (= (point) 14))
+    ;; Unfold
+    (mletf* ((mouse-set-point (event) (goto-char (point))))
+      (elpy-folding--click-fringe nil))
+    (let* ((overlays (apply 'nconc (overlay-lists)))
+           overlay)
+      (should (= 1 (length overlays))))
+    ;; Position
+    (should (= (point) 14))))
+
+(ert-deftest elpy-fold-at-point-should-unfold-on-indicator-click ()
+  (elpy-testcase ()
+    (add-to-list 'elpy-modules 'elpy-module-folding)
+    (set-buffer-string-with-point
+     "var1 = 45"
+     "def foo(_|_a, b):"
+     "  c = a + b"
+     "var2 = foo(var1, 4)")
+    (python-mode)
+    (elpy-mode)
+    (mletf* ((mouse-set-point (event) (goto-char (point))))
+      (elpy-folding--click-fringe nil))
+    (let* ((overlays (apply 'nconc (overlay-lists)))
+           overlay)
+      (should (= 2 (length overlays)))
+      (setq overlay (nth 0 overlays))
+      (should (eq (overlay-get overlay 'hs) 'code))
+      (should (= (overlay-start overlay) 25))
+      (should (or (= (overlay-end overlay) 37)
+                  (= (overlay-end overlay) 38))))
+    (should (= (point) 14))
+    ;; Unfold
+    (end-of-line)
+    (mletf* ((posn-window (position) (get-buffer-window))
+             (posn-point (position) (point))
+             (window-buffer (window) (current-buffer)))
+      (elpy-folding--click-text nil))
+    (let* ((overlays (apply 'nconc (overlay-lists)))
+           overlay)
+      (should (= 1 (length overlays))))
+    ;; Position
+    (should (= (point) 25))))

--- a/test/elpy-folding-should-mark-foldable-lines-test.el
+++ b/test/elpy-folding-should-mark-foldable-lines-test.el
@@ -1,0 +1,40 @@
+(ert-deftest elpy-folding-module-should-mark-foldable-lines ()
+  (elpy-testcase ()
+    (add-to-list 'elpy-modules 'elpy-module-folding)
+    (set-buffer-string-with-point
+     "var1 = 45"
+     "class foo(object):"
+     "  def __init__(self, a, b):"
+     "    self.a = a"
+     "    self.b = b"
+     "  def bar(mess):"
+     "    \"\"\" This is docstring for BAR"
+     ""
+     "    And here are the pa_|_rameters"
+     ""
+     "    And there the return values"
+     "    \"\"\""
+     "    mess *= 2"
+     "    print(mess)"
+     "    return mess"
+     "var2 = foo(var1, 4)")
+    (python-mode)
+    (elpy-mode)
+    (let* ((overlays (overlays-in (point-min) (point-max)))
+           overlay)
+      (should (= 3 (length overlays)))
+      ;; Second mark
+      (setq overlay (nth 2 overlays))
+      (should (eq (overlay-get overlay 'hs) nil))
+      (should (= (overlay-start overlay) 11))
+      (should (= (overlay-end overlay) 29))
+      ;; Second mark
+      (setq overlay (nth 1 overlays))
+      (should (eq (overlay-get overlay 'hs) nil))
+      (should (= (overlay-start overlay) 30))
+      (should (= (overlay-end overlay) 57))
+      ;; Third mark
+      (setq overlay (nth 0 overlays))
+      (should (eq (overlay-get overlay 'hs) nil))
+      (should (= (overlay-start overlay) 88))
+      (should (= (overlay-end overlay) 104)))))


### PR DESCRIPTION
# PR Summary
Follow (old) feature request #240.

This is an attempt to get nice folding functionalities in Elpy.
It is currently based on `hs-minor-mode` and heavily inspired from [hideshowvis](https://www.emacswiki.org/emacs/hideshowvis.el).

Any idea is welcome.

# Todo list
## Nice folding
- [x] Add an overlay indicating the number of folded lines.
- [x] Add a fringe indicator for folded code.
- [x] Make fringe indicators clickable 
- [x] Make folding indicators clickable
- [x] Add fringe indicators to mark the beginning of foldable regions.
- [ ] Add fringe indicator for dosctrings ?
## Folding docstrings
- [x] Add `elpy-folding-toggle-docstrings` to hide all the docstrings in the buffer.
- [x] Add `elpy-folding-hide-docstring-at-point` functions to hide the docstring at point.
- [x] Find a way to show the first docstring line when folding docstring.
## Folding comments
- [x] Add a function to hide all comments
## DWIM
- [x] Add a function to toggle folding dor the thing (block, docstring, region or comment) at point
## Selective folding
- [x] Add `elpy-folding-hide-leafs` to hide blocks not containing other blocks.
## Keybindings
- [x] Add `elpy-folding-fold-at-point` to fold the active region, the docstring,  or the block at point.
- [x] Bind `elpy-folding-toggle-at-point` (to `C-c @ p`).
- [x] Bind `elpy-folding-toggle-all-docstrings` (to `C-c @ b`).
- [x] Bind `elpy-folding-hide-leafs` (to `C-c @ f`).
## Other modules incompatibilities
- [x] Put flymake fringe indicators on the right fringe when folding module is activated to avoid fringe indicator overlap.
## Others
- [x] Clean and reorganize properly
- [x] Write tests
- [x] Update the documentation