### PR TITLE
Use `elpy-syntax-check-command` for emacs > 26.1

### DIFF
--- a/elpy.el
+++ b/elpy.el
@@ -3688,15 +3688,19 @@ display the current class and method instead."
      (require 'flymake)
      (elpy-modules-remove-modeline-lighter 'flymake-mode)
      ;; Add our initializer function.
-     ;; For emacs > 26.1, python.el natively supports flymake,
-     ;; so we just tell python.el to use flake8
-     (if (version<= "26.1" emacs-version)
-         (setq python-flymake-command '("flake8" "-"))
+     (when (not (version<= "26.1" emacs-version))
        (setq python-check-command elpy-syntax-check-command)
        (add-to-list 'flymake-allowed-file-name-masks
                     '("\\.py\\'" elpy-flymake-python-init))))
 
     (`buffer-init
+     ;; For emacs > 26.1, python.el natively supports flymake,
+     ;; so we just tell python.el to use the wanted syntax checker
+     (when (version<= "26.1" emacs-version)
+       (setq-local python-flymake-command
+                   (if (string= elpy-syntax-check-command "pyflakes")
+                       '("pyflakes")
+                     `(,elpy-syntax-check-command "-"))))
      ;; `flymake-no-changes-timeout': The original value of 0.5 is too
      ;; short for Python code, as that will result in the current line
      ;; to be highlighted most of the time, and that's annoying. This

--- a/elpy.el
+++ b/elpy.el
@@ -3689,11 +3689,12 @@ display the current class and method instead."
      (elpy-modules-remove-modeline-lighter 'flymake-mode)
      ;; Add our initializer function.
      (when (not (version<= "26.1" emacs-version))
-       (setq python-check-command elpy-syntax-check-command)
        (add-to-list 'flymake-allowed-file-name-masks
                     '("\\.py\\'" elpy-flymake-python-init))))
 
     (`buffer-init
+     ;; Set this for `elpy-check' command
+     (setq-local python-check-command elpy-syntax-check-command)
      ;; For emacs > 26.1, python.el natively supports flymake,
      ;; so we just tell python.el to use the wanted syntax checker
      (when (version<= "26.1" emacs-version)

--- a/test/elpy-flymake-next-error-test.el
+++ b/test/elpy-flymake-next-error-test.el
@@ -4,4 +4,6 @@
 
 (ert-deftest elpy-flymake-next-error ()
   (elpy-testcase ()
+    (elpy-module-flymake 'global-init)
+    (elpy-module-flymake 'buffer-init)
     (elpy-flymake-next-error)))

--- a/test/elpy-module-flymake-test.el
+++ b/test/elpy-module-flymake-test.el
@@ -2,10 +2,10 @@
   (elpy-testcase ()
     (mletf* ((executable-find (name) (equal name "flake8")))
       (elpy-module-flymake 'global-init)
-
-      (if (version< emacs-version "26.1")
-          (should (equal python-check-command "flake8"))
-      (should (equal python-flymake-command '("flake8" "-")))))))
+      (elpy-module-flymake 'buffer-init)
+      (should (equal python-check-command "flake8"))
+      (if (version<= "26.1" emacs-version)
+          (should (equal python-flymake-command '("flake8" "-")))))))
 
 (ert-deftest elpy-module-flymake-global-init ()
   (elpy-testcase ()


### PR DESCRIPTION

# PR Summary
Following issue #1406.

For Emacs > 26.1, Elpy now uses `elpy-syntax-check-command` to determine which syntax checker to use, instead of always using "flake8".

Also, the syntax checker is now set locally in elpy buffers.


# PR checklist

Please make sure that the following things have been addressed (and check the relevant checkboxes):

- [x] Commits respect our [guidelines](../CONTRIBUTING.rst)
- [ ] Tests are passing properly (see [here](https://elpy.readthedocs.io/en/latest/extending.html#running-tests) on how to run Elpy's tests)
- [x] Code is not generating new bytecode warnings

