### PR TITLE
Silent FutureWarning preventing correct parsing for elpy-config

### DIFF
--- a/elpy.el
+++ b/elpy.el
@@ -619,6 +619,9 @@ virtualenv.
 
 (defvar elpy-config--get-config "import json
 import sys
+import warnings
+
+warnings.filterwarnings('ignore', category=FutureWarning)
 
 try:
     import xmlrpclib


### PR DESCRIPTION
# PR Summary
Following issue #1410 (see details there).

# PR checklist
- [x] Commits respect our [guidelines](../CONTRIBUTING.rst)
- [x] Tests are passing properly (see [here](https://elpy.readthedocs.io/en/latest/extending.html#running-tests) on how to run Elpy's tests)
- [x] Code is not generating new bytecode warnings
