### PR TITLE
Male eldoc message shorter and truncate them if too long

### DIFF
--- a/elpy.el
+++ b/elpy.el
@@ -3670,6 +3670,7 @@ display the current class and method instead."
            ((stringp calltip)
             calltip)
            (t
+            (message "OK1")
             (let ((name (cdr (assq 'name calltip)))
                   (index (cdr (assq 'index calltip)))
                   ;; Strip 'param' added by jedi at the beggining of
@@ -3677,15 +3678,19 @@ display the current class and method instead."
                   (params (mapcar (lambda (param)
                                     (car (split-string param "^param " t)))
                                   (cdr (assq 'params calltip)))))
+              (message "OK2")
               (when index
                 (setf (nth index params)
                       (propertize (nth index params)
                                   'face
                                   'eldoc-highlight-function-argument)))
+              (message "OK3")
               (let ((prefix (propertize name 'face
                                         'font-lock-function-name-face))
                     (args (format "(%s)" (mapconcat #'identity params ", "))))
+                (message "OK4")
                 (eldoc-docstring-format-sym-doc prefix args))))))))
+                (message "OK5")
       ;; Return the last message until we're done
       eldoc-last-message)))
 

--- a/elpy.el
+++ b/elpy.el
@@ -3672,8 +3672,10 @@ display the current class and method instead."
            (t
             (let ((name (cdr (assq 'name calltip)))
                   (index (cdr (assq 'index calltip)))
+                  ;; Strip 'param' added by jedi at the beggining of
+                  ;; parameter names. Should be unecessary for jedi > 0.13.0
                   (params (mapcar (lambda (param)
-                                    (string-trim-left param "param "))
+                                    (car (split-string param "^param " t)))
                                   (cdr (assq 'params calltip)))))
               (when index
                 (setf (nth index params)

--- a/elpy.el
+++ b/elpy.el
@@ -3672,16 +3672,18 @@ display the current class and method instead."
            (t
             (let ((name (cdr (assq 'name calltip)))
                   (index (cdr (assq 'index calltip)))
-                  (params (cdr (assq 'params calltip))))
+                  (params (mapcar (lambda (param)
+                                    (string-trim-left param "param "))
+                                  (cdr (assq 'params calltip)))))
               (when index
                 (setf (nth index params)
                       (propertize (nth index params)
                                   'face
                                   'eldoc-highlight-function-argument)))
-              (format "%s(%s)"
-                      name
-                      (mapconcat #'identity params ", "))
-              ))))))
+              (let ((prefix (propertize name 'face
+                                        'font-lock-function-name-face))
+                    (args (format "(%s)" (mapconcat #'identity params ", "))))
+                (eldoc-docstring-format-sym-doc prefix args))))))))
       ;; Return the last message until we're done
       eldoc-last-message)))
 

--- a/elpy.el
+++ b/elpy.el
@@ -3685,7 +3685,10 @@ display the current class and method instead."
               (let ((prefix (propertize name 'face
                                         'font-lock-function-name-face))
                     (args (format "(%s)" (mapconcat #'identity params ", "))))
-                (eldoc-docstring-format-sym-doc prefix args))))))))
+                ;; for emacs < 25, eldoc function do not accept string
+                (if (version<= emacs-version "25")
+                    (format "%s%s" prefix args)
+                (eldoc-docstring-format-sym-doc prefix args nil)))))))))
       ;; Return the last message until we're done
       eldoc-last-message)))
 

--- a/elpy.el
+++ b/elpy.el
@@ -3670,7 +3670,6 @@ display the current class and method instead."
            ((stringp calltip)
             calltip)
            (t
-            (message "OK1")
             (let ((name (cdr (assq 'name calltip)))
                   (index (cdr (assq 'index calltip)))
                   ;; Strip 'param' added by jedi at the beggining of
@@ -3678,19 +3677,15 @@ display the current class and method instead."
                   (params (mapcar (lambda (param)
                                     (car (split-string param "^param " t)))
                                   (cdr (assq 'params calltip)))))
-              (message "OK2")
               (when index
                 (setf (nth index params)
                       (propertize (nth index params)
                                   'face
                                   'eldoc-highlight-function-argument)))
-              (message "OK3")
               (let ((prefix (propertize name 'face
                                         'font-lock-function-name-face))
                     (args (format "(%s)" (mapconcat #'identity params ", "))))
-                (message "OK4")
                 (eldoc-docstring-format-sym-doc prefix args))))))))
-                (message "OK5")
       ;; Return the last message until we're done
       eldoc-last-message)))
 

--- a/test/elpy-eldoc-documentation-test.el
+++ b/test/elpy-eldoc-documentation-test.el
@@ -81,7 +81,7 @@
              (calltip nil)
              ;; without UI, the minibuffer width is only 9,
              ;; leading to truncated eldoc messages
-             (window-width (window pixelwise) 100)
+             (window-width (window &optional pixelwise) 100)
              (eldoc-message (tip) (setq calltip tip)))
 
       (elpy-eldoc-documentation)

--- a/test/elpy-eldoc-documentation-test.el
+++ b/test/elpy-eldoc-documentation-test.el
@@ -79,6 +79,9 @@
                                   (index . nil)
                                   (params . nil))))
              (calltip nil)
+             ;; without UI, the minibuffer width is only 9,
+             ;; leading to truncated eldoc messages
+             (window-width (window) 100)
              (eldoc-message (tip) (setq calltip tip)))
 
       (elpy-eldoc-documentation)

--- a/test/elpy-eldoc-documentation-test.el
+++ b/test/elpy-eldoc-documentation-test.el
@@ -81,7 +81,7 @@
              (calltip nil)
              ;; without UI, the minibuffer width is only 9,
              ;; leading to truncated eldoc messages
-             (window-width (window) 100)
+             (window-width (window pixelwise) 100)
              (eldoc-message (tip) (setq calltip tip)))
 
       (elpy-eldoc-documentation)


### PR DESCRIPTION
# PR Summary
Follow #1416: 

- Elpy eldoc messages are now truncated to fit in the minibuffer if `eldoc-echo-area-use-multiline-p` is `nil`.

- Eldoc messages are now shorter, removing the useless `param ` strings returned by the jedi backend.

# PR checklist

Please make sure that the following things have been addressed (and check the relevant checkboxes):

- [x] Commits respect our [guidelines](../CONTRIBUTING.rst)
- [x] Tests are passing properly (see [here](https://elpy.readthedocs.io/en/latest/extending.html#running-tests) on how to run Elpy's tests)
- [x] Code is not generating new bytecode warnings
