### PR TITLE
Fix echoing output in the minibuffer

### DIFF
--- a/elpy-shell.el
+++ b/elpy-shell.el
@@ -464,7 +464,9 @@ complete). Otherwise, does nothing."
         (if (string-empty-p output)
             (message "No output was produced.")
           (message "%s" (replace-regexp-in-string "\n\\'" "" output))))
-      (setq-local elpy-shell--captured-output nil)))
+      (setq-local elpy-shell--captured-output nil)
+      ;; Stop capturing the outputs then
+      (setq-local elpy-shell--capture-output nil)))
 
   ;; return input unmodified
   string)


### PR DESCRIPTION
# PR Summary
Follow discussion in #1424.

When `elpy-shell-echo-output` is `t`, the output is always echoed in the minibuffer, even when inputs are directly entered into the shell buffer.

This is due to the variable `elpy-shell--capture-output`, that is set to `t` by commands needing to echo the output, but never set back to `nil`.
Consequently, the output filter grabs and echoes all outputs.

This is fixed here by reseting `elpy-shell--capture-output` to `nil` after having echoed an output.

WIP: need to be tested properly.

# PR checklist

Please make sure that the following things have been addressed (and check the relevant checkboxes):

- [x] Commits respect our [guidelines](../CONTRIBUTING.rst)
- [x] Tests are passing properly (see [here](https://elpy.readthedocs.io/en/latest/extending.html#running-tests) on how to run Elpy's tests)
- [x] Code is not generating new bytecode warnings