### PR TITLE
Make xref faster

### DIFF
--- a/test/elpy-xref--get-completion-table-test.el
+++ b/test/elpy-xref--get-completion-table-test.el
@@ -7,4 +7,5 @@
                 "    return x + y\n"
                 "var1 = foo(5, 2)")
         (let ((identifiers (elpy-xref--get-completion-table)))
-        (should (equal identifiers (list "1: x" "1: y" "3: var1" "1: foo")))))))
+        (should (equal identifiers
+       (list "3: foo" "3: var1" "2: y" "2: x" "1: y" "1: x" "1: foo")))))))

--- a/test/elpy-xref--identifier-at-point-test.el
+++ b/test/elpy-xref--identifier-at-point-test.el
@@ -9,7 +9,7 @@
                 "var1 = foo(5, 2)")
         (goto-char 41)
         (let ((id (elpy-xref--identifier-at-point)))
-          (should (string-match "1: foo" id)))
+          (should (string-match "3: foo" id)))
         (goto-char 33)
         (let ((id (elpy-xref--identifier-at-point)))
           (should (string-match "3: var1" id)))


### PR DESCRIPTION

# PR Summary
Follow #1426.

In xref, do not check for candidate assignments anymore.

This feature was present to prevents redondant candidates,
but is too slow to be decently usable.


# PR checklist

Please make sure that the following things have been addressed (and check the relevant checkboxes):

- [x] Commits respect our [guidelines](../CONTRIBUTING.rst)
- [x] Tests are passing properly (see [here](https://elpy.readthedocs.io/en/latest/extending.html#running-tests) on how to run Elpy's tests)
- [x] Code is not generating new bytecode warnings
