### PR TITLE
Do not remove flymake from the modeline for emacs > 26.1

### DIFF
--- a/elpy.el
+++ b/elpy.el
@@ -3700,7 +3700,9 @@ display the current class and method instead."
   (pcase command
     (`global-init
      (require 'flymake)
-     (elpy-modules-remove-modeline-lighter 'flymake-mode)
+     ;; flymake modeline is quite useful for emacs > 26.1
+     (when (version< emacs-version "26.1")
+       (elpy-modules-remove-modeline-lighter 'flymake-mode))
      ;; Add our initializer function.
      (when (not (version<= "26.1" emacs-version))
        (add-to-list 'flymake-allowed-file-name-masks


### PR DESCRIPTION
# PR Summary
Follow issue #1422.
From emacs 26.1, flymake modeline indicator provides useful informations.
It is no longer required to hide it.

# PR checklist

Please make sure that the following things have been addressed (and check the relevant checkboxes):

- [x] Commits respect our [guidelines](../CONTRIBUTING.rst)
- [x] Tests are passing properly (see [here](https://elpy.readthedocs.io/en/latest/extending.html#running-tests) on how to run Elpy's tests)
- [x] Code is not generating new bytecode warnings
