### PR TITLE
Strip jedi prefix in python instead of in elisp

### DIFF
--- a/elpy.el
+++ b/elpy.el
@@ -3672,11 +3672,7 @@ display the current class and method instead."
            (t
             (let ((name (cdr (assq 'name calltip)))
                   (index (cdr (assq 'index calltip)))
-                  ;; Strip 'param' added by jedi at the beggining of
-                  ;; parameter names. Should be unecessary for jedi > 0.13.0
-                  (params (mapcar (lambda (param)
-                                    (car (split-string param "^param " t)))
-                                  (cdr (assq 'params calltip)))))
+                  (params (cdr (assq 'params calltip))))
               (when index
                 (setf (nth index params)
                       (propertize (nth index params)

--- a/elpy/jedibackend.py
+++ b/elpy/jedibackend.py
@@ -8,6 +8,7 @@ https://github.com/davidhalter/jedi
 
 import sys
 import traceback
+import re
 
 import jedi
 
@@ -143,9 +144,13 @@ class JediBackend(object):
             call = None
         if not call:
             return None
+        # Strip 'param' added by jedi at the beggining of
+        # parameter names. Should be unecessary for jedi > 0.13.0
+        params = [re.sub("^param ", '', param.description)
+                  for param in call.params]
         return {"name": call.name,
                 "index": call.index,
-                "params": [param.description for param in call.params]}
+                "params": params}
 
     def rpc_get_usages(self, filename, source, offset):
         """Return the uses of the symbol at offset.

--- a/elpy/tests/test_jedibackend.py
+++ b/elpy/tests/test_jedibackend.py
@@ -120,13 +120,13 @@ class TestRPCGetAssignment(RPCGetAssignmentTests,
 class TestRPCGetCalltip(RPCGetCalltipTests,
                         JediBackendTestCase):
     KEYS_CALLTIP = {'index': 0,
-                    'params': ['param '],
+                    'params': [''],
                     'name': u'keys'}
     RADIX_CALLTIP = {'index': None,
                      'params': [],
                      'name': u'radix'}
     ADD_CALLTIP = {'index': 0,
-                   'params': [u'param a', u'param b'],
+                   'params': [u'a', u'b'],
                    'name': u'add'}
     if compat.PYTHON3:
         THREAD_CALLTIP = {"name": "Thread",
@@ -139,12 +139,12 @@ class TestRPCGetCalltip(RPCGetCalltipTests,
                           "index": 0}
     else:
         THREAD_CALLTIP = {"name": "Thread",
-                          "params": ["param group=None",
-                                     "param target=None",
-                                     "param name=None",
-                                     "param args=()",
-                                     "param kwargs=None",
-                                     "param verbose=None"],
+                          "params": ["group=None",
+                                     "target=None",
+                                     "name=None",
+                                     "args=()",
+                                     "kwargs=None",
+                                     "verbose=None"],
                           "index": 0}
 
     def test_should_not_fail_with_get_subscope_by_name(self):


### PR DESCRIPTION
# PR Summary
Follow #1435.

Stripping of the `param` prefixes are now done in `jedibackend.py` instead of in `elpy.el`.
This fixes the error described in #1435.

# PR checklist

Please make sure that the following things have been addressed (and check the relevant checkboxes):

- [x] Commits respect our [guidelines](../CONTRIBUTING.rst)
- [x] Tests are passing properly (see [here](https://elpy.readthedocs.io/en/latest/extending.html#running-tests) on how to run Elpy's tests)
- [x] Code is not generating new bytecode warnings

