### PR TITLE
Allow pip-related tests to pass with python3 or /usr/bin/python3

### DIFF
--- a/test/elpy-config-test.el
+++ b/test/elpy-config-test.el
@@ -21,4 +21,4 @@
                                          (elpy/wait-for-output "Only")
                                          (buffer-string))))
                            (should (equal python-check-command "/foo/bar/flake8"))
-                           (should (string-match "python -m pip install.*flake8" output))))))
+                           (should (string-match ".*python.* -m pip install.*flake8" output))))))

--- a/test/elpy-config-test.el
+++ b/test/elpy-config-test.el
@@ -21,4 +21,4 @@
                                          (elpy/wait-for-output "Only")
                                          (buffer-string))))
                            (should (equal python-check-command "/foo/bar/flake8"))
-                           (should (string-match ".*python.* -m pip install.*flake8" output))))))
+                           (should (string-match "python.*\ -m pip install.*flake8" output))))))

--- a/test/elpy-insert--pip-button-value-create-test.el
+++ b/test/elpy-insert--pip-button-value-create-test.el
@@ -17,8 +17,8 @@
               (program &optional infile destination display &rest args)
               0)
              (widget (widget-create 'elpy-insert--pip-button "test-module")))
-      (should (string-match ".*python.* -m pip" (widget-get widget :command)))
-      (should (string-match ".*python.* -m pip" (buffer-string))))))
+      (should (string-match "python.*\ -m pip" (widget-get widget :command)))
+      (should (string-match "python.*\ -m pip" (buffer-string))))))
 
 (ert-deftest elpy-insert--pip-button-value-create-should-use-easy_install ()
   (elpy-testcase ()

--- a/test/elpy-insert--pip-button-value-create-test.el
+++ b/test/elpy-insert--pip-button-value-create-test.el
@@ -17,8 +17,8 @@
               (program &optional infile destination display &rest args)
               0)
              (widget (widget-create 'elpy-insert--pip-button "test-module")))
-      (should (string-match "python -m pip" (widget-get widget :command)))
-      (should (string-match "python -m pip" (buffer-string))))))
+      (should (string-match ".*python.* -m pip" (widget-get widget :command)))
+      (should (string-match ".*python.* -m pip" (buffer-string))))))
 
 (ert-deftest elpy-insert--pip-button-value-create-should-use-easy_install ()
   (elpy-testcase ()


### PR DESCRIPTION
# PR Summary
I believe this is closely related to #1274, and further changes may be required, because this patch only affects the self tests.  This patch is needed to prevent the following failing tests when building on a Debian 10 (buster, though technically I'm building for sid) where /usr/bin/python3 is the only Python.
```
2 unexpected results:
   FAILED  elpy-config-should-show-flake8-pip-button-when-no-syntax-checker-available
   FAILED  elpy-insert--pip-button-value-create-should-use-pip
```
Here is how I added preliminary configuration to default to system-installed Python 3 in the Debian (and inherently the future Ubuntu) package:
https://salsa.debian.org/emacsen-team/elpy/blob/master/debian/debian-config.el
https://salsa.debian.org/emacsen-team/elpy/blob/master/debian/elpa-test
# PR checklist

- [x] Commits respect our [guidelines](../CONTRIBUTING.rst)
- [x] Tests are passing properly (see [here](https://elpy.readthedocs.io/en/latest/extending.html#running-tests) on how to run Elpy's tests)
- [x] Code is not generating new bytecode warnings
