### PR TITLE
Add support for emacs 24.3

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,7 +9,7 @@ python:
 env:
   # - EVM_EMACS=emacs-24.1-travis
   # - EVM_EMACS=emacs-24.2-travis
-  # - EVM_EMACS=emacs-24.3-travis
+  - EVM_EMACS=emacs-24.3-travis
   - EVM_EMACS=emacs-24.4-travis
   - EVM_EMACS=emacs-24.5-travis
   - EVM_EMACS=emacs-25.1-travis

--- a/docs/ide.rst
+++ b/docs/ide.rst
@@ -192,7 +192,7 @@ Interpreter Setup
 Elpy uses the Python interpreter setup from the Emacs ``python`` package. This
 section briefly summarizes some common setups; add the one you need to your
 ``.emacs`` file. Note that the code below (and Elpy in general) require at least
-Emacs 24.4.
+Emacs 24.3.
 
 Use the Python standard interpreter (default):
 

--- a/elpy-backport-24.3.el
+++ b/elpy-backport-24.3.el
@@ -26,6 +26,13 @@
   (defsubst string-empty-p (string)
     "Check whether STRING is empty."
     (string= string ""))
+  (defsubst string-suffix-p (str1 str2 &optional ignore-case)
+    (let ((begin2 (- (length str2) (length str1)))
+          (end2 (length str2)))
+      (when (< begin2 0) (setq begin2 0))
+      (eq t (compare-strings str1 nil nil
+                             str2 begin2 end2
+                             ignore-case))))
   (defsubst string-remove-suffix (suffix string)
     "Remove SUFFIX from STRING if present."
     (if (string-suffix-p suffix string)

--- a/elpy-backport-24.3.el
+++ b/elpy-backport-24.3.el
@@ -1,0 +1,36 @@
+;;; elpy-backport-24.3.el --- provides subr-x for pre 24.4 emacsen
+
+;;; Commentary:
+;;  backport of subr-x -- see https://github.com/vijaykiran/spacemacs/commit/0776a66fab8cb5ad51570c3f0f0d5397b27ffb4a
+
+;;; Code:
+
+(unless (featurep 'subr-x)
+  ;; `subr-x' function for Emacs 24.3 and below
+  (defsubst string-join (strings &optional separator)
+    "Join all STRINGS using SEPARATOR."
+    (mapconcat 'identity strings separator))
+  (defsubst string-trim-left (string)
+    "Remove leading whitespace from STRING."
+    (if (string-match "\\`[ \t\n\r]+" string)
+        (replace-match "" t t string)
+      string))
+  (defsubst string-trim-right (string)
+    "Remove trailing whitespace from STRING."
+    (if (string-match "[ \t\n\r]+\\'" string)
+        (replace-match "" t t string)
+      string))
+  (defsubst string-trim (string)
+    "Remove leading and trailing whitespace from STRING."
+    (string-trim-left (string-trim-right string)))
+  (defsubst string-empty-p (string)
+    "Check whether STRING is empty."
+    (string= string ""))
+  (defsubst string-remove-suffix (suffix string)
+    "Remove SUFFIX from STRING if present."
+    (if (string-suffix-p suffix string)
+        (substring string 0 (- (length string) (length suffix)))
+      string)))
+
+(provide 'elpy-backport-24.3)
+;;; elpy-backport-24.3.el ends here

--- a/elpy-pkg.el
+++ b/elpy-pkg.el
@@ -1,7 +1,7 @@
 (define-package "elpy" "1.23.0"
                 "Emacs Python Development Environment"
                 '((company "0.9.2")
-                  (emacs "24.4")
+                  (emacs "24.3")
                   (find-file-in-project "3.3")
                   (highlight-indentation "0.5.0")
                   (pyvenv "1.3")

--- a/elpy-profile.el
+++ b/elpy-profile.el
@@ -25,87 +25,88 @@
 ;;; Code:
 
 
+(when (version< "24.3" emacs-version)
 ;;;;;;;;;;;;;;;;;;;;;;
 ;;; User customization
 
-(defcustom elpy-profile-visualizer "snakeviz"
-  "Visualizer for elpy profile results."
-  :type 'str
-  :group 'elpy)
+  (defcustom elpy-profile-visualizer "snakeviz"
+    "Visualizer for elpy profile results."
+    :type 'str
+    :group 'elpy)
 
 ;;;;;;;;;;;;;;;;;;;;;;
 ;;; Helper Functions
 
-(defun elpy-profile--display-profiling (file)
-  "Display the profile result FILE using `elpy-profile-visualizer'."
-  (let ((exec (car (split-string elpy-profile-visualizer " " t)))
-        (args (append (cdr (split-string elpy-profile-visualizer " " t)) (list file))))
-    (if (executable-find exec)
-        (apply 'call-process exec nil 0 nil args)
-      (message "Elpy profile visualizer '%s' not found" exec))))
+  (defun elpy-profile--display-profiling (file)
+    "Display the profile result FILE using `elpy-profile-visualizer'."
+    (let ((exec (car (split-string elpy-profile-visualizer " " t)))
+          (args (append (cdr (split-string elpy-profile-visualizer " " t)) (list file))))
+      (if (executable-find exec)
+          (apply 'call-process exec nil 0 nil args)
+        (message "Elpy profile visualizer '%s' not found" exec))))
 
-(defun elpy-profile--sentinel (process string)
-  "Elpy profile sentinel."
-  (let ((filename (file-name-nondirectory (process-get process 'file)))
-        (prof-file (process-get process 'prof-file))
-        (dont-display (process-get process 'dont-display)))
-    (with-current-buffer "*elpy-profile-log*"
-      (view-mode))
-    (if (not (string-equal string "finished\n"))
-        (progn
-          (message  "[%s] Profiling failed" filename)
-          (display-buffer  "*elpy-profile-log*"))
-      (message  "[%s] Profiling succeeded" filename)
-      (when (not dont-display)
-        (elpy-profile--display-profiling prof-file)))))
+  (defun elpy-profile--sentinel (process string)
+    "Elpy profile sentinel."
+    (let ((filename (file-name-nondirectory (process-get process 'file)))
+          (prof-file (process-get process 'prof-file))
+          (dont-display (process-get process 'dont-display)))
+      (with-current-buffer "*elpy-profile-log*"
+        (view-mode))
+      (if (not (string-equal string "finished\n"))
+          (progn
+            (message  "[%s] Profiling failed" filename)
+            (display-buffer  "*elpy-profile-log*"))
+        (message  "[%s] Profiling succeeded" filename)
+        (when (not dont-display)
+          (elpy-profile--display-profiling prof-file)))))
 
-(defun elpy-profile--file (file &optional in-dir dont-display)
-  "Profile asynchronously FILE and display the result using
+  (defun elpy-profile--file (file &optional in-dir dont-display)
+    "Profile asynchronously FILE and display the result using
 `elpy-profile-visualizer'.
 
 If IN-DIR is non nil, profile result is saved in the same
 directory as the script.
 If DONT-DISPLAY is non nil, don't display the profile results."
-  (ignore-errors (kill-buffer "*elpy-profile-log*"))
-  (let* ((prof-file (if in-dir
-                        (concat (file-name-sans-extension file) ".profile")
-                      (concat (make-temp-file "elpy-profile-" nil ".profile"))))
-         (proc-name (format "elpy-profile-%s" file))
-         (proc-cmd (list python-shell-interpreter "-m" "cProfile" "-o" prof-file file))
-         (proc (make-process :name proc-name
-                             :buffer "*elpy-profile-log*"
-                             :sentinel 'elpy-profile--sentinel
-                             :command proc-cmd)))
-    (message "[%s] Profiling ..." (file-name-nondirectory file))
-    (process-put proc 'prof-file prof-file)
-    (process-put proc 'file file)
-    (process-put proc 'dont-display dont-display)
-    prof-file))
+    (ignore-errors (kill-buffer "*elpy-profile-log*"))
+    (let* ((prof-file (if in-dir
+                          (concat (file-name-sans-extension file) ".profile")
+                        (concat (make-temp-file "elpy-profile-" nil ".profile"))))
+           (proc-name (format "elpy-profile-%s" file))
+           (proc-cmd (list python-shell-interpreter "-m" "cProfile" "-o" prof-file file))
+           (proc (make-process :name proc-name
+                               :buffer "*elpy-profile-log*"
+                               :sentinel 'elpy-profile--sentinel
+                               :command proc-cmd)))
+      (message "[%s] Profiling ..." (file-name-nondirectory file))
+      (process-put proc 'prof-file prof-file)
+      (process-put proc 'file file)
+      (process-put proc 'dont-display dont-display)
+      prof-file))
 
 ;;;;;;;;;;;;;;;;;;;;;;
 ;;; User Functions
 
-(defun elpy-profile-buffer-or-region (&optional in-dir dont-display)
-  "Profile asynchronously the active region or the current buffer
+  (defun elpy-profile-buffer-or-region (&optional in-dir dont-display)
+    "Profile asynchronously the active region or the current buffer
 and display the result using `elpy-profile-visualizer'.
 
 If IN-DIR is non nil, profile result is saved in the same
 directory as the script.
 If DONT-DISPLAY is non nil, don't display the profile results."
-  (interactive "P")
-  (let* ((file-name (buffer-name))
-         (file-dir (file-name-directory (buffer-file-name)))
-         (beg (if (region-active-p) (region-beginning) (point-min)))
-         (end (if (region-active-p) (region-end) (point-max)))
-         (tmp-file-prefix (if (region-active-p) "_region_" ""))
-         (tmp-file (if in-dir
-                       (concat file-dir "/" tmp-file-prefix file-name)
-                     (concat (make-temp-file "elpy-profile-" t)  "/" tmp-file-prefix file-name)))
-         (region (elpy-shell--region-without-indentation beg end)))
-    (with-temp-buffer
-      (insert region)
-      (write-region (point-min) (point-max) tmp-file nil t))
-    (elpy-profile--file tmp-file t dont-display)))
-
+    (interactive "P")
+    (let* ((file-name (buffer-name))
+           (file-dir (file-name-directory (buffer-file-name)))
+           (beg (if (region-active-p) (region-beginning) (point-min)))
+           (end (if (region-active-p) (region-end) (point-max)))
+           (tmp-file-prefix (if (region-active-p) "_region_" ""))
+           (tmp-file (if in-dir
+                         (concat file-dir "/" tmp-file-prefix file-name)
+                       (concat (make-temp-file "elpy-profile-" t)  "/" tmp-file-prefix file-name)))
+           (region (elpy-shell--region-without-indentation beg end)))
+      (with-temp-buffer
+        (insert region)
+        (write-region (point-min) (point-max) tmp-file nil t))
+      (elpy-profile--file tmp-file t dont-display)))
+  )
 (provide 'elpy-profile)
 ;;; elpy-profile.el ends here

--- a/elpy-shell.el
+++ b/elpy-shell.el
@@ -24,7 +24,8 @@
 ;;
 ;;; Code:
 
-(eval-when-compile (require 'subr-x))
+(eval-when-compile (require 'subr-x nil t))
+(require 'elpy-backport-24.3)
 (require 'pyvenv)
 (require 'python)
 

--- a/elpy.el
+++ b/elpy.el
@@ -6,7 +6,7 @@
 ;; URL: https://github.com/jorgenschaefer/elpy
 ;; Version: 1.23.0
 ;; Keywords: Python, IDE, Languages, Tools
-;; Package-Requires: ((company "0.9.2") (emacs "24.4") (find-file-in-project "3.3")  (highlight-indentation "0.5.0") (pyvenv "1.3") (yasnippet "0.8.0") (s "1.11.0"))
+;; Package-Requires: ((company "0.9.2") (emacs "24.3") (find-file-in-project "3.3")  (highlight-indentation "0.5.0") (pyvenv "1.3") (yasnippet "0.8.0") (s "1.11.0"))
 
 ;; This program is free software; you can redistribute it and/or
 ;; modify it under the terms of the GNU General Public License
@@ -42,7 +42,8 @@
 (require 'ido)
 (require 'json)
 (require 'python)
-(require 'subr-x)
+(require 'subr-x nil t)
+(require 'elpy-backport-24.3)
 (require 'xref nil t)
 (require 'cl-lib)   ; for `cl-every', `cl-copy-list', `cl-delete-if-not'
 


### PR DESCRIPTION
# PR Summary
Follow #1431.

Add back support for Emacs 24.3, as proposed by @CdeMills.

@jorgenschaefer I don't like the idea of complexifying the code either, but this is apparently useful for some users.
Let to discuss if we want to merge this into the main branch, or instead to make a backport branch.

# PR checklist

Please make sure that the following things have been addressed (and check the relevant checkboxes):

- [x] Commits respect our [guidelines](../CONTRIBUTING.rst)
- [ ] Tests are passing properly (see [here](https://elpy.readthedocs.io/en/latest/extending.html#running-tests) on how to run Elpy's tests)
- [x] Code is not generating new bytecode warnings
