### PR TITLE
Fix gathering completion candidates from interpreter

### DIFF
--- a/elpy.el
+++ b/elpy.el
@@ -3535,7 +3535,11 @@ and return the list.
   python.el provides completion based on what is currently loaded in the
 python shell interpreter."
   (let* ((completion-at-point-functions '(python-completion-complete-at-point))
-         (pytel-candidates (company-capf 'candidates (company-capf 'prefix)))
+         (pytel-candidates
+          (condition-case nil
+              ;; Sometimes, python.el completion raise an error...
+              (company-capf 'candidates (company-capf 'prefix))
+            (error '())))
          (candidates-name (cl-loop
                            for cand in candidates
                            collect (cdr (assoc 'name cand)))))


### PR DESCRIPTION
# PR Summary
python.el sometimes raises an error when asked for completion.

This fix ensures that the error is ignored and does not interrupt the current
completion.

# PR checklist

Please make sure that the following things have been addressed (and check the relevant checkboxes):

- [x] Commits respect our [guidelines](../CONTRIBUTING.rst)
- [x] Tests are passing properly (see [here](https://elpy.readthedocs.io/en/latest/extending.html#running-tests) on how to run Elpy's tests)
- [x] Code is not generating new bytecode warnings
