### PR TITLE
fix completion with no python process

### DIFF
--- a/elpy.el
+++ b/elpy.el
@@ -3538,7 +3538,8 @@ python shell interpreter."
          (start (nth 0 new-candidates))
          (end (nth 1 new-candidates))
          (completion-list (nth 2 new-candidates)))
-    (when (and start end)
+    (if (not (and start end))
+        candidates
       (let ((candidates-name (all-completions (buffer-substring start end)
                                               completion-list)))
         (cl-loop


### PR DESCRIPTION
Completion coming from rpc are intended to merged with completions from python.el.

`python-completion-complete-at-point` returns nil when there is no python shell
process, `elpy-company--add-interpreter-completions-candidates` returns nil in
this case and this shadows completion coming from rpc.

# PR Summary


# PR checklist

Please make sure that the following things have been addressed (and check the relevant checkboxes):

- [x] Commits respect our [guidelines](../CONTRIBUTING.rst)
- [x] Tests are passing properly (see [here](https://elpy.readthedocs.io/en/latest/extending.html#running-tests) on how to run Elpy's tests)
- [x] Code is not generating new bytecode warnings

## For new features only:
- [ ] Tests has been added to cover the change
- [ ] The documentation has been updated
- [ ] An entry in NEWS.rst has been added