### PR TITLE
Default to "." format for django test format

### DIFF
--- a/elpy-django.el
+++ b/elpy-django.el
@@ -78,12 +78,11 @@ require arguments in order for it to work."
   :group 'elpy-django)
 (make-variable-buffer-local 'elpy-django-commands-with-req-arg)
 
-(defcustom elpy-django-test-runner-formats '(("django_nose.NoseTestSuiteRunner" . ":")
-                                             ("django.test.runner.DiscoverRunner" . "."))
+(defcustom elpy-django-test-runner-formats '(("django_nose.NoseTestSuiteRunner" . ":"))
   "List of test runners and their format for calling tests.
 
-Some tests runners are called differently. For example, Nose requires a ':' when calling specific tests,
-but the default Django test runner uses '.'"
+Some tests runners are called differently. For example, Nose requires a ':' when calling specific tests.
+If the runner is not found in this list the default of '.' - like standard Django runner - will be used."
   :type 'list
   :safe 'listp
   :group 'elpy-django)
@@ -193,7 +192,7 @@ Return the correct string format here."
     (if pair
         ;; Return the associated test format
         (cdr pair)
-      (error (format "Unable to find test format for `%s'" (elpy--get-django-test-runner))))))
+      ".")))
 
 ;;;;;;;;;;;;;;;;;;;;;;
 ;;; User Functions

--- a/test/elpy-module-django-test.el
+++ b/test/elpy-module-django-test.el
@@ -79,6 +79,13 @@ Available subcommands:
   (setenv "DJANGO_SETTINGS_MODULE" "popcorn")
   (should-error (elpy-django--get-test-runner)))
 
-(ert-deftest elpy-module-django-get-test-format-should-error-if-cannot-find-test-runner ()
-  (mletf* ((elpy-django--get-test-runner "math")))
-  (should-error (elpy--get-django-test-format)))
+(ert-deftest elpy-module-django-get-test-format-defaults-to-standard-django-runner-format ()
+  (mletf*
+   ((elpy-django--get-test-runner () "my.custom.TestRunner"))
+   (should (string= "." (elpy-django--get-test-format)))))
+
+(ert-deftest elpy-module-django-get-test-format-applies-test-runner-formats-config ()
+  (mletf*
+   ((elpy-django--get-test-runner () "my.custom.TestRunner")
+    (elpy-django-test-runner-formats '(("my.custom.TestRunner" . "~"))))
+   (should (string= "~" (elpy-django--get-test-format)))))


### PR DESCRIPTION
This allows to run out-of-the-box in a project where a custom runner is in use
but it is simply a subclass of standard django.test.runner.DiscoverRunner

# PR Summary
In my experience, often the runner in a django project is overridden with a custom runner simply inheriting from `DiscoverRunner`. In this case case it seems an overkill to require the configuration of `elpy-django-test-runner-formats` for every project.
This PR simply let `"."` separator be the default when running django tests

# PR checklist

Please make sure that the following things have been addressed (and check the relevant checkboxes):

- [x] Commits respect our [guidelines](../CONTRIBUTING.rst)
- [x] Tests are passing properly (see [here](https://elpy.readthedocs.io/en/latest/extending.html#running-tests) on how to run Elpy's tests)
- [x] Code is not generating new bytecode warnings

## For new features only:
- [ ] Tests has been added to cover the change
- [ ] The documentation has been updated
- [ ] An entry in NEWS.rst has been added