### PR TITLE
Check for prompt availability before gathering candidates from shell

### DIFF
--- a/elpy.el
+++ b/elpy.el
@@ -3544,7 +3544,17 @@ and return the list.
 
   python.el provides completion based on what is currently loaded in the
 python shell interpreter."
-  (if (not elpy-company-add-completion-from-shell)
+  ;; check if prompt available
+  (if (or (not elpy-company-add-completion-from-shell)
+          (not (python-shell-get-process))
+          (with-current-buffer (process-buffer (python-shell-get-process))
+            (save-excursion
+              (goto-char (point-max))
+              (let ((inhibit-field-text-motion t))
+                (beginning-of-line)
+                (not (search-forward-regexp
+                      python-shell--prompt-calculated-input-regexp
+                      nil t))))))
       candidates
     (let* ((new-candidates (python-completion-complete-at-point))
            (start (nth 0 new-candidates))


### PR DESCRIPTION
# PR Summary
If the shell prompt is not available, trying to gather completion candidates from the python shell will result in emacs hanging (waiting for the shell to be available).

To avoid freezing emacs, elpy now checks for prompt availability before trying to fetch completion candidates.

# PR checklist

Please make sure that the following things have been addressed (and check the relevant checkboxes):

- [x] Commits respect our [guidelines](../CONTRIBUTING.rst)
- [x] Tests are passing properly (see [here](https://elpy.readthedocs.io/en/latest/extending.html#running-tests) on how to run Elpy's tests)
- [x] Code is not generating new bytecode warnings
