### PR TITLE
make elpy-occur-definitions work for async methods

### DIFF
--- a/elpy.el
+++ b/elpy.el
@@ -2420,7 +2420,7 @@ name."
 Also, switch to that buffer."
   (interactive)
   (let ((list-matching-lines-face nil))
-    (occur "^ *\\(def\\|class\\) "))
+    (occur "^\s*\\(\\(async\s\\|\\)def\\|class\\)\s"))
   (let ((window (get-buffer-window "*Occur*")))
     (if window
         (select-window window)


### PR DESCRIPTION
# PR Summary

With asyncio, a def may be preceded by the keyword 'async'.  This makes
elpy-occur-definitions work for these methods.

Apologies I have not completed the checklist - this is just a regex edit.  Do with this what you will...

# PR checklist

Please make sure that the following things have been addressed (and check the relevant checkboxes):

- [x] Commits respect our [guidelines](../CONTRIBUTING.rst)
- [x] Tests are passing properly (see [here](https://elpy.readthedocs.io/en/latest/extending.html#running-tests) on how to run Elpy's tests)
- [x] Code is not generating new bytecode warnings

## For new features only:
- [ ] Tests has been added to cover the change
- [ ] The documentation has been updated
- [ ] An entry in NEWS.rst has been added