### PR TITLE
Handle sphinx warnings linked to indexnode

### DIFF
--- a/docs/elispdomain.py
+++ b/docs/elispdomain.py
@@ -34,7 +34,7 @@ class ELispMarkup(ObjectDescription):
         indextext = self.get_index_text(self.objtype, name)
         if indextext:
             self.indexnode['entries'].append(('single', indextext,
-                                              targetname, ''))
+                                              targetname, '', None))
 
 
 class ELispFunction(ELispMarkup):

--- a/docs/extending.rst
+++ b/docs/extending.rst
@@ -62,7 +62,7 @@ You can set up a working environment for Elpy using ``pip`` and
 ``cask``. After installing Cask_, create a new virtual environment
 and run the ``setup`` script in it:
 
-.. code-block::
+.. code-block:: sh
 
    virtualenv ~/.virtualenvs/elpy
    source ~/.virtualenvs/elpy/bin/activate


### PR DESCRIPTION
# PR Summary
Following #1470.

Will remove warnings in sphinx (linked to sphinx issue [#2673](https://github.com/sphinx-doc/sphinx/issues/2673)).

Fix is inspired from javasphinx fix (commit [67e175](https://github.com/bronto/javasphinx/commit/67e1756d6edcb8c54d89ca5e567cef17db1be453)) and will ne need to drop sphinx < 1.4 support.



# PR checklist

Please make sure that the following things have been addressed (and check the relevant checkboxes):

- [x] Commits respect our [guidelines](../CONTRIBUTING.rst)
- [x] Tests are passing properly (see [here](https://elpy.readthedocs.io/en/latest/extending.html#running-tests) on how to run Elpy's tests)
- [x] Code is not generating new bytecode warnings
