### PR TITLE
Django check settings module by testing exit code instead of output

### DIFF
--- a/elpy-django.el
+++ b/elpy-django.el
@@ -176,11 +176,13 @@ Needs `DJANGO_SETTINGS_MODULE' to be set in order to work."
     (when (not django-settings-env)
       (error "Please set environment variable `DJANGO_SETTINGS_MODULE' if you'd like to run the test runner"))
 
-    ;; We have to be able to import the DJANGO_SETTINGS_MODULE otherwise it will also break
-    ;; If we get a traceback when import django settings, then warn the user that settings is not valid
-    (when (not (string= "" (shell-command-to-string
-                            (format "%s -c 'import %s'" elpy-rpc-python-command django-settings-env))))
-      (error (format "Unable to import DJANGO_SETTINGS_MODULE: '%s'" django-settings-env)))
+    ;; We have to be able to import the DJANGO_SETTINGS_MODULE to detect test
+    ;; runner; if python process importing settings exits with error,
+    ;; then warn the user that settings is not valid
+    (unless (= 0 (call-process elpy-rpc-python-command nil nil nil
+                               "-c" (format "import %s" django-settings-env)))
+      (error (format "Unable to import DJANGO_SETTINGS_MODULE: '%s'"
+                     django-settings-env)))
 
     ;; Return test runner
     (s-trim (shell-command-to-string

--- a/test/elpy-module-django-test.el
+++ b/test/elpy-module-django-test.el
@@ -72,7 +72,7 @@ Available subcommands:
     (should (member "changepassword" (elpy-django--get-commands)))))
 
 (ert-deftest elpy-module-django-get-test-runner-should-error-if-no-django-settings-module-environment ()
-  (setenv "DJANGO_SETTINGS_MODULE" "")
+  (setenv "DJANGO_SETTINGS_MODULE" nil)
   (should-error (elpy-django--get-test-runner)))
 
 (ert-deftest elpy-module-django-get-test-runner-should-error-if-cannot-import-django-settings-module ()


### PR DESCRIPTION
Check for correctness of DJANGO_SETTINGS_MODULE env var was made by ensuring
that python importing wasn't generating any output/error.
This is not safe since during import the settings module can cause logging and
other forms of output.
Checking that python exits 0 status code is more robust and semantically
correct.

# PR Summary


# PR checklist

Please make sure that the following things have been addressed (and check the relevant checkboxes):

- [x] Commits respect our [guidelines](../CONTRIBUTING.rst)
- [x] Tests are passing properly (see [here](https://elpy.readthedocs.io/en/latest/extending.html#running-tests) on how to run Elpy's tests)
- [x] Code is not generating new bytecode warnings

## For new features only:
- [ ] Tests has been added to cover the change
- [ ] The documentation has been updated
- [ ] An entry in NEWS.rst has been added