### PR TITLE
Eldoc docstring

### DIFF
--- a/elpy.el
+++ b/elpy.el
@@ -3756,10 +3756,11 @@ display the current class and method instead."
                    (let ((prefix (propertize (format "%s: " name)
                                              'face
                                              'font-lock-function-name-face)))
+                     (eldoc-message
                      (if (version<= emacs-version "25")
-                         (format "%s: %s" prefix doc)
+                         (format "%s%s" prefix doc)
                        (let ((eldoc-echo-area-use-multiline-p nil))
-                         (eldoc-message (eldoc-docstring-format-sym-doc
+                         (eldoc-docstring-format-sym-doc
                                          prefix doc nil)))
                      ))))
                ;; Give the current definition

--- a/elpy/jedibackend.py
+++ b/elpy/jedibackend.py
@@ -177,7 +177,9 @@ class JediBackend(object):
                     onelinedoc += [doc[i]]
             onelinedoc = " ".join(onelinedoc)
             name = definition.name
-            if definition.type in ["function", "class"]:
+            if definition.type in ['instance']:
+                return None
+            elif definition.type in ["function", "class"]:
                 name += '()'
             else:
                 name += " {}".format(definition.type)

--- a/elpy/jedibackend.py
+++ b/elpy/jedibackend.py
@@ -181,6 +181,7 @@ class JediBackend(object):
                     lines = []
                     if call != paragraph[0:len(call)]:
                         break
+                    paragraph = ""
                     continue
                 lines.append(doc[i])
             # Keep only the first sentence

--- a/elpy/server.py
+++ b/elpy/server.py
@@ -71,6 +71,13 @@ class ElpyRPCServer(JSONRPCServer):
         return self._call_backend("rpc_get_calltip", None, filename,
                                   get_source(source), offset)
 
+    def rpc_get_oneline_docstring(self, filename, source, offset):
+        """Get a oneline docstring for the symbol at the offset.
+
+        """
+        return self._call_backend("rpc_get_oneline_docstring", None, filename,
+                                  get_source(source), offset)
+
     def rpc_get_completions(self, filename, source, offset):
         """Get a list of completion candidates for the symbol at offset.
 

--- a/test/elpy-eldoc-documentation-test.el
+++ b/test/elpy-eldoc-documentation-test.el
@@ -6,40 +6,7 @@
       (should (equal (elpy-eldoc-documentation)
                      "last message")))))
 
-(ert-deftest elpy-eldoc-documentation-should-use-current-defun-if-no-calltip ()
-  (elpy-testcase ()
-    (mletf* ((elpy-rpc-get-calltip (callback) (funcall callback nil))
-             (calltip nil)
-             (eldoc-message (tip) (setq calltip tip))
-             (python-info-current-defun () "FooClass.method"))
-
-      (elpy-eldoc-documentation)
-
-      (should (equal calltip "In: FooClass.method()")))))
-
-(ert-deftest elpy-eldoc-documentation-should-not-display-current-defun-if-no-calltip-and-show-defun-disabled ()
-  (elpy-testcase ()
-    (mletf* ((elpy-rpc-get-calltip (callback) (funcall callback nil))
-             (calltip nil)
-             (eldoc-message (tip) (setq calltip tip))
-             (python-info-current-defun () "FooClass.method")
-             (elpy-eldoc-show-current-function nil))
-
-      (elpy-eldoc-documentation)
-
-      (should (null calltip)))))
-
-(ert-deftest elpy-eldoc-documentation-should-return-nil-without-defun ()
-  (elpy-testcase ()
-    (mletf* ((elpy-rpc-get-calltip (callback) (funcall callback nil))
-             (calltip 'nothing-set)
-             (eldoc-message (tip) (setq calltip tip))
-             (python-info-current-defun () nil))
-
-      (elpy-eldoc-documentation)
-
-      (should (equal calltip nil)))))
-
+;; Calltip available
 (ert-deftest elpy-eldoc-documentation-should-show-string-calltip ()
   (elpy-testcase ()
     (mletf* ((elpy-rpc-get-calltip
@@ -87,3 +54,56 @@
       (elpy-eldoc-documentation)
 
       (should (equal calltip "cancel_join_thread()")))))
+
+
+;; No calltip: display current edited function
+(ert-deftest elpy-eldoc-documentation-should-use-current-defun-if-no-calltip ()
+  (elpy-testcase ()
+    (mletf* ((elpy-rpc-get-calltip (callback) (funcall callback nil))
+             (elpy-eldoc-info 'current-function)
+             (calltip nil)
+             (eldoc-message (tip) (setq calltip tip))
+             (python-info-current-defun () "FooClass.method"))
+
+      (elpy-eldoc-documentation)
+
+      (should (equal calltip "In: FooClass.method()")))))
+
+(ert-deftest elpy-eldoc-documentation-should-return-nil-without-defun ()
+  (elpy-testcase ()
+    (mletf* ((elpy-rpc-get-calltip (callback) (funcall callback nil))
+             (calltip nil)
+             (elpy-eldoc-info 'current-function)
+             (eldoc-message (tip) (setq calltip tip))
+             (python-info-current-defun () nil))
+
+      (elpy-eldoc-documentation)
+
+      (should (equal calltip nil)))))
+
+;; No calltip: display oneline docstring
+(ert-deftest elpy-eldoc-documentation-should-use-oneline-docstring-if-no-calltip ()
+  (elpy-testcase ()
+    (mletf* ((elpy-rpc-get-calltip (callback) (funcall callback "method(): do something"))
+             (elpy-eldoc-info 'docstring)
+             (calltip nil)
+             (eldoc-message (tip) (setq calltip tip)))
+
+      (elpy-eldoc-documentation)
+
+      (should (equal calltip "method(): do something")))))
+
+
+;; No calltip: display nothing
+(ert-deftest elpy-eldoc-documentation-should-not-display-anything-if-no-calltip ()
+  (elpy-testcase ()
+    (mletf* ((elpy-rpc-get-calltip (callback) (funcall callback nil))
+             (elpy-eldoc-info nil)
+             (calltip nil)
+             (eldoc-message (tip) (setq calltip tip))
+             (python-info-current-defun () "FooClass.method")
+             (elpy-eldoc-show-current-function nil))
+
+      (elpy-eldoc-documentation)
+
+      (should (null calltip)))))


### PR DESCRIPTION
# PR Summary
Add the possibility to display a oneline docstring for the symbol at point in eldoc.
Works for modules, classes and functions.

Here is an example of how eldoc works with this feature:
![1538825648](https://user-images.githubusercontent.com/6860164/46570965-c8f1c300-c964-11e8-9e3e-b329a460953f.png)
![1538825653](https://user-images.githubusercontent.com/6860164/46570966-c8f1c300-c964-11e8-8ac0-d6903a2b7458.png)
![1538825657](https://user-images.githubusercontent.com/6860164/46570967-c8f1c300-c964-11e8-9d6a-c0fa57cfeb19.png)

The option `elpy-eldoc-info` replaces `elpy-eldoc-show-current-function` to allow to customize this feature.

# PR checklist

Please make sure that the following things have been addressed (and check the relevant checkboxes):

- [x] Commits respect our [guidelines](../CONTRIBUTING.rst)
- [x] Tests are passing properly (see [here](https://elpy.readthedocs.io/en/latest/extending.html#running-tests) on how to run Elpy's tests)
- [x] Code is not generating new bytecode warnings

## For new features only:
- [x] Tests has been added to cover the change
- [x] The documentation has been updated
- [x] An entry in NEWS.rst has been added