### PR TITLE
Allow to specify arguments to syntax checker

### DIFF
--- a/elpy.el
+++ b/elpy.el
@@ -3796,9 +3796,12 @@ display the current class and method instead."
      ;; so we just tell python.el to use the wanted syntax checker
      (when (version<= "26.1" emacs-version)
        (setq-local python-flymake-command
-                   (if (string= elpy-syntax-check-command "pyflakes")
-                       '("pyflakes")
-                     `(,elpy-syntax-check-command "-"))))
+                   (let ((command (split-string elpy-syntax-check-command)))
+                     (if (string= (file-name-nondirectory (car command))
+                                  "flake8")
+                         (append command '("-"))
+                       command))))
+
      ;; `flymake-no-changes-timeout': The original value of 0.5 is too
      ;; short for Python code, as that will result in the current line
      ;; to be highlighted most of the time, and that's annoying. This


### PR DESCRIPTION
# PR Summary
Follow #1493.

Until now, Elpy only accepts `elpy-syntax-check-command` to be single a command (`flake8` or `pyflakes` for example).

With this PR, it is now possible to specify arguments, like:
 - `(setq elpy-syntax-check-command "flake8 --config=~/.flake8/flakerc")` to specify a given configuration file, or
- `(setq elpy-syntax-check-command "flake8 --ignore=E402,E401")`  to ignore some errors and warnings.



# PR checklist

- [x] Commits respect our [guidelines](../CONTRIBUTING.rst)
- [x] Tests are passing properly (see [here](https://elpy.readthedocs.io/en/latest/extending.html#running-tests) on how to run Elpy's tests)