### PR TITLE
Update documentation

### DIFF
--- a/docs/ide.rst
+++ b/docs/ide.rst
@@ -106,11 +106,12 @@ documentation is a good place for further information.
 
 .. option:: elpy-company-add-completion-from-shell
 
-    If t, add completion candidates gathered from the current python shell.
-    Normally elpy provides completion using static code analysis (from jedi).
-    With this option set to t, elpy will add the completion candidates from the
-    associated python shell. This allow to have decent completion candidates
-    when the static code analysis fails.
+    If t, use the shell to gather docstrings and completions. Normally elpy
+    provides completion and documentation using static code analysis (from
+    jedi). With this option set to t, elpy will add the completion candidates
+    and the docstrings from the associated python shell. This allows to have
+    decent completion candidates and documentation when the static code analysis
+    fails. the static code analysis fails.
 
 
 Navigation

--- a/docs/ide.rst
+++ b/docs/ide.rst
@@ -104,7 +104,7 @@ documentation is a good place for further information.
 
 .. _Company Mode: https://company-mode.github.io/
 
-.. option:: elpy-company-add-completion-from-shell
+.. option:: elpy-get-info-from-shell
 
     If t, use the shell to gather docstrings and completions. Normally elpy
     provides completion and documentation using static code analysis (from


### PR DESCRIPTION
# PR Summary

The option `elpy-company-add-completion-from-shell` was changed to `elpy-get-info-from-shell` but the documentation was not updated. I just copy-pasted the docstring of `elpy-get-info-from-shell` in the elpy.el file to the docs/ide.rst file.

The issue was mentioned on #1515.

I did not run any tests since I only changed the documentation. I hope that's ok.

# PR checklist

Please make sure that the following things have been addressed (and check the relevant checkboxes):

- [x] Commits respect our [guidelines](../CONTRIBUTING.rst)
- [ ] Tests are passing properly (see [here](https://elpy.readthedocs.io/en/latest/extending.html#running-tests) on how to run Elpy's tests)

## For new features only:
- [ ] Tests has been added to cover the change
- [ ] The documentation has been updated
