### PR TITLE
Nicer display of inputs echoing

### DIFF
--- a/docs/ide.rst
+++ b/docs/ide.rst
@@ -477,14 +477,6 @@ evaluation command, thereby providing visual feedback.
    value). Then, no window is needed to display the shell (thereby saving screen
    real estate), but the outputs can still be seen in the echo area.
 
-.. option:: elpy-shell-capture-last-multiline-output
-
-   When a multiple statements are sent to the shell simultaneously (e.g., via
-   :command:`elpy-shell-send-group-and-step`), Elpy by default captures the
-   value of the last Python statement (if is an expression) and shows it in the
-   shell buffer. This variable can be used to turn off this behavior (then shell
-   won't show any output, except for single-line statements).
-
 .. option:: elpy-shell-display-buffer-after-send
 
    Whether to display the Python shell after sending something to it (default

--- a/elpy-shell.el
+++ b/elpy-shell.el
@@ -68,6 +68,9 @@ You can use `(add-hook 'elpy-mode-hook (lambda () (elpy-shell-toggle-dedicated-s
   captures its output so that it is echoed in the shell."
   :type 'boolean
   :group 'elpy)
+(make-obsolete-variable 'elpy-shell-capture-last-multiline-output
+                        "The last multiline output is now always captured."
+                        "February 2019")
 
 (defcustom elpy-shell-echo-input t
   "Whether to echo input sent to the Python shell as input in the
@@ -441,11 +444,9 @@ Return non-nil is the shell is running and not busy, nil otherwise."
   "Current captured output of the Python shell.")
 
 (defmacro elpy-shell--with-maybe-echo-output (body)
-  "Run BODY and grab shell output according to `elpy-shell-echo-output' and `elpy-shell-capture-last-multiline-output'."
+  "Run BODY and grab shell output according to `elpy-shell-echo-output'."
   `(cl-letf (((symbol-function 'python-shell-send-file)
-              (if elpy-shell-capture-last-multiline-output
-                  (symbol-function 'elpy-shell-send-file)
-                (symbol-function 'python-shell-send-file))))
+              (symbol-function 'elpy-shell-send-file)))
      (let* ((process (elpy-shell--ensure-shell-running))
             (process-buf (process-buffer process))
             (shell-visible (or elpy-shell-display-buffer-after-send

--- a/elpy-shell.el
+++ b/elpy-shell.el
@@ -625,9 +625,10 @@ print) the output of the last expression."
        (when (and delete temp-file-name)
          (format "os.remove('''%s''');" temp-file-name))
        "__block = ast.parse(__code, '''%s''', mode='exec');"
+       "__block.body = __block.body if not isinstance(__block.body[0], ast.If) else __block.body if not isinstance(__block.body[0].test, ast.NameConstant) else __block.body if not __block.body[0].test.value is True else __block.body[0].body;"  ;; remove "if True:" wrapping when sending regions
        "__last = __block.body[-1];" ;; the last statement
        "__isexpr = isinstance(__last,ast.Expr);" ;; is it an expression?
-       "__block.body.pop() if __isexpr else None;" ;; if so, remove it
+       "_ = __block.body.pop() if __isexpr else None;" ;; if so, remove it
        "exec(compile(__block, '''%s''', mode='exec'));" ;; execute everything else
        "eval(compile(ast.Expression(__last.value), '''%s''', mode='eval')) if __isexpr else None" ;; if it was an expression, it has been removed; now evaluate it
        )

--- a/elpy-shell.el
+++ b/elpy-shell.el
@@ -421,9 +421,13 @@ Return non-nil is the shell is running and not busy, nil otherwise."
 ;; Echoing
 
 (defmacro elpy-shell--with-maybe-echo (body)
-  `(elpy-shell--with-maybe-echo-output
-    (elpy-shell--with-maybe-echo-input
-     ,body)))
+  ;; Echoing is apparently buggy for emacs < 25...
+  (if (<= 25 emacs-major-version)
+      `(elpy-shell--with-maybe-echo-output
+        (elpy-shell--with-maybe-echo-input
+         ,body))
+    body))
+
 
 (defmacro elpy-shell--with-maybe-echo-input (body)
   "Run BODY so that it adheres `elpy-shell-echo-input' and `elpy-shell-display-buffer'."

--- a/elpy-shell.el
+++ b/elpy-shell.el
@@ -493,6 +493,7 @@ complete). Otherwise, does nothing."
 
 Unless NO-FONT-LOCK is set, formats STRING as shell input.
 Prepends a continuation promt if PREPEND-CONT-PROMPT is set."
+  (when (not (string-empty-p string))
   (let* ((process (elpy-shell-get-or-create-process))
          (process-buf (process-buffer process))
          (mark-point (process-mark process)))
@@ -506,19 +507,19 @@ Prepends a continuation promt if PREPEND-CONT-PROMPT is set."
               (goto-char mark-point)
               (elpy-shell--insert-and-font-lock
                (car lines) 'comint-highlight-input no-font-lock)
-              (if (cdr lines)
+              (when (cdr lines)
                   ;; no additional newline at end for multiline
                   (dolist (line (cdr lines))
                     (insert "\n")
                     (elpy-shell--insert-and-font-lock
                      prompt 'comint-highlight-prompt no-font-lock)
                     (elpy-shell--insert-and-font-lock
-                     line 'comint-highlight-input no-font-lock))
+                     line 'comint-highlight-input no-font-lock)))
                 ;; but put one for single line
-                (insert "\n")))
+                (insert "\n"))
           (elpy-shell--insert-and-font-lock
            string 'comint-highlight-input no-font-lock))
-        (set-marker (process-mark process) (point))))))
+        (set-marker (process-mark process) (point)))))))
 
 (defun elpy-shell--string-head-lines (string n)
   "Extract the first N lines from STRING."

--- a/test/elpy-shell-echo-inputs-and-outputs-test.el
+++ b/test/elpy-shell-echo-inputs-and-outputs-test.el
@@ -4,7 +4,6 @@
     (elpy-mode)
     (setq elpy-shell-echo-input nil)
     (setq elpy-shell-echo-output nil)
-    (setq elpy-shell-capture-last-multiline-output nil)
     (insert "def foo():
     1+1
     for i in range(10):
@@ -30,7 +29,6 @@
     (elpy-mode)
     (setq elpy-shell-echo-input t)
     (setq elpy-shell-echo-output nil)
-    (setq elpy-shell-capture-last-multiline-output nil)
     (insert "def foo():
     1+1
     for i in range(10):
@@ -81,7 +79,6 @@
     (elpy-mode)
     (setq elpy-shell-echo-input nil)
     (setq elpy-shell-echo-output t)
-    (setq elpy-shell-capture-last-multiline-output t)
     (insert "def foo():\n    1+1\n    for i in range(10):\n        a = 2+2\n        4+3\n        b = a+i\n")
 
     ;; on "1+1"

--- a/test/elpy-shell-echo-inputs-and-outputs-test.el
+++ b/test/elpy-shell-echo-inputs-and-outputs-test.el
@@ -1,4 +1,5 @@
 (ert-deftest elpy-shell-should-not-echo-inputs-when-deactivated ()
+  (when (<= 25 emacs-major-version)
   (elpy-testcase ()
     (python-mode)
     (elpy-mode)
@@ -21,9 +22,10 @@
                                (with-current-buffer "*Python*"
                                  (elpy/wait-for-output "OK" 30)
                                  (buffer-string)))))
-    ))
+    )))
 
 (ert-deftest elpy-shell-should-echo-inputs ()
+  (when (<= 25 emacs-major-version)
   (elpy-testcase ()
     (python-mode)
     (elpy-mode)
@@ -72,40 +74,40 @@
       (should (string-match "...: 4\\+3"
                             (with-current-buffer "*Python*"
                               (buffer-string))))
-      )))
+      ))))
 
 (ert-deftest elpy-shell-should-echo-outputs ()
+  (when (<= 25 emacs-major-version)
   (elpy-testcase ()
     (python-mode)
     (elpy-mode)
+    (setq python-shell-interpreter "python2")
     (setq elpy-shell-echo-input nil)
     (setq elpy-shell-echo-output t)
-    (insert "def foo():\n    1+1\n    for i in range(10):\n        a = 2+2\n        4+3\n        b = a+i\n")
+    (insert "def foo():
+    1+1
+    for i in range(10):
+        a = 2+2
+        4+3
+        b = a+i
+")
 
     ;; on "1+1"
     (goto-char 18)
     (elpy-shell-kill t)
     (elpy-shell-send-statement)
     (python-shell-send-string "print('OK')\n")
-    (if (<= emacs-major-version 24)
-        (should (string-match ">>> 2" (with-current-buffer "*Python*"
-                                         (elpy/wait-for-output "OK" 30)
-                                         (buffer-string))))
-      (should (string-match "^2" (with-current-buffer "*Python*"
-                                   (elpy/wait-for-output "OK" 30)
-                                   (buffer-string)))))
+    (should (string-match "^2" (with-current-buffer "*Python*"
+                                 (elpy/wait-for-output "OK" 30)
+                                 (buffer-string))))
     ;; on "4+3"
-    (goto-char 69)
+    (goto-char 70)
     (elpy-shell-kill t)
     (elpy-shell-send-statement)
     (python-shell-send-string "print('OK')\n")
-    (if (<= emacs-major-version 24)
-        (should (string-match ">>> 7" (with-current-buffer "*Python*"
-                                         (elpy/wait-for-output "OK" 30)
-                                         (buffer-string))))
-      (should (string-match "^7" (with-current-buffer "*Python*"
-                                   (elpy/wait-for-output "OK" 30)
-                                   (buffer-string)))))
+    (should (string-match "^7" (with-current-buffer "*Python*"
+                                 (elpy/wait-for-output "OK" 30)
+                                 (buffer-string))))
     ;; on "a = 2+2" and "4+3" lines
     (set-mark 52)
     (goto-char 72)
@@ -114,11 +116,7 @@
     (message "use-region: %s" (use-region-p))
     (elpy-shell-send-region-or-buffer)
     (python-shell-send-string "print('OK')\n")
-    (if (<= emacs-major-version 24)
-        (should (string-match ">>> 7" (with-current-buffer "*Python*"
-                                         (elpy/wait-for-output "OK" 30)
-                                         (buffer-string))))
-      (should (string-match "^7" (with-current-buffer "*Python*"
-                                   (elpy/wait-for-output "OK" 30)
-                                   (buffer-string)))))
-    ))
+    (should (string-match "^7" (with-current-buffer "*Python*"
+                                 (elpy/wait-for-output "OK" 30)
+                                 (buffer-string))))
+    )))

--- a/test/elpy-shell-echo-inputs-and-outputs-test.el
+++ b/test/elpy-shell-echo-inputs-and-outputs-test.el
@@ -58,20 +58,21 @@
                             (elpy/wait-for-output "OK" 30)
                             (buffer-string))))
     ;; on "a = 2+2" and "4+3" lines
-    (set-mark 52)
-    (goto-char 72)
-    (activate-mark)
-    (elpy-shell-kill t)
-    (elpy-shell-send-region-or-buffer)
-    (python-shell-send-string "print('OK')\n")
-    (should (string-match ">>> a = 2\\+2"
-                          (with-current-buffer "*Python*"
-                            (elpy/wait-for-output "OK" 30)
-                            (buffer-string))))
-    (should (string-match "...: 4\\+3"
-                          (with-current-buffer "*Python*"
-                            (buffer-string))))
-    ))
+    (when (version< "3.0.0" (elpy-shell-get-python-version))
+      (set-mark 52)
+      (goto-char 72)
+      (activate-mark)
+      (elpy-shell-kill t)
+      (elpy-shell-send-region-or-buffer)
+      (python-shell-send-string "print('OK')\n")
+      (should (string-match ">>> a = 2\\+2"
+                            (with-current-buffer "*Python*"
+                              (elpy/wait-for-output "OK" 30)
+                              (buffer-string))))
+      (should (string-match "...: 4\\+3"
+                            (with-current-buffer "*Python*"
+                              (buffer-string))))
+      )))
 
 (ert-deftest elpy-shell-should-echo-outputs ()
   (elpy-testcase ()
@@ -87,7 +88,7 @@
     (elpy-shell-send-statement)
     (python-shell-send-string "print('OK')\n")
     (if (<= emacs-major-version 24)
-        (should (string-match "^>>> 2" (with-current-buffer "*Python*"
+        (should (string-match ">>> 2" (with-current-buffer "*Python*"
                                          (elpy/wait-for-output "OK" 30)
                                          (buffer-string))))
       (should (string-match "^2" (with-current-buffer "*Python*"
@@ -99,7 +100,7 @@
     (elpy-shell-send-statement)
     (python-shell-send-string "print('OK')\n")
     (if (<= emacs-major-version 24)
-        (should (string-match "^>>> 7" (with-current-buffer "*Python*"
+        (should (string-match ">>> 7" (with-current-buffer "*Python*"
                                          (elpy/wait-for-output "OK" 30)
                                          (buffer-string))))
       (should (string-match "^7" (with-current-buffer "*Python*"
@@ -114,7 +115,7 @@
     (elpy-shell-send-region-or-buffer)
     (python-shell-send-string "print('OK')\n")
     (if (<= emacs-major-version 24)
-        (should (string-match "^>>> 7" (with-current-buffer "*Python*"
+        (should (string-match ">>> 7" (with-current-buffer "*Python*"
                                          (elpy/wait-for-output "OK" 30)
                                          (buffer-string))))
       (should (string-match "^7" (with-current-buffer "*Python*"

--- a/test/elpy-shell-echo-inputs-and-outputs-test.el
+++ b/test/elpy-shell-echo-inputs-and-outputs-test.el
@@ -1,0 +1,126 @@
+(ert-deftest elpy-shell-should-not-echo-inputs-when-deactivated ()
+  (elpy-testcase ()
+    (python-mode)
+    (elpy-mode)
+    (setq elpy-shell-echo-input nil)
+    (setq elpy-shell-echo-output nil)
+    (setq elpy-shell-capture-last-multiline-output nil)
+    (insert "def foo():
+    1+1
+    for i in range(10):
+        a = 2+2
+        4+3
+        b = a+i
+")
+
+    ;; on "for i in range(10):"
+    (goto-char 30)
+    (elpy-shell-kill t)
+    (elpy-shell-send-statement)
+    (python-shell-send-string "print('OK')\n")
+    (should (not (string-match ">>> for i in range(10):"
+                               (with-current-buffer "*Python*"
+                                 (elpy/wait-for-output "OK" 30)
+                                 (buffer-string)))))
+    ))
+
+(ert-deftest elpy-shell-should-echo-inputs ()
+  (elpy-testcase ()
+    (python-mode)
+    (elpy-mode)
+    (setq elpy-shell-echo-input t)
+    (setq elpy-shell-echo-output nil)
+    (setq elpy-shell-capture-last-multiline-output nil)
+    (insert "def foo():
+    1+1
+    for i in range(10):
+        a = 2+2
+        4+3
+        b = a+i
+")
+    ;; on "for i in range(10):"
+    (goto-char 30)
+    (elpy-shell-kill t)
+    (elpy-shell-send-statement)
+    (python-shell-send-string "print('OK')\n")
+    (should (string-match ">>> for i in range(10):"
+                          (with-current-buffer "*Python*"
+                            (elpy/wait-for-output "OK" 30)
+                            (buffer-string))))
+    (should (string-match "...:     a = 2\\+2"
+                          (with-current-buffer "*Python*"
+                            (buffer-string))))
+    ;; on "a = 2+2"
+    (goto-char 52)
+    (elpy-shell-kill t)
+    (elpy-shell-send-statement)
+    (python-shell-send-string "print('OK')\n")
+    (should (string-match ">>> a = 2\\+2"
+                          (with-current-buffer "*Python*"
+                            (elpy/wait-for-output "OK" 30)
+                            (buffer-string))))
+    ;; on "a = 2+2" and "4+3" lines
+    (set-mark 52)
+    (goto-char 72)
+    (activate-mark)
+    (elpy-shell-kill t)
+    (elpy-shell-send-region-or-buffer)
+    (python-shell-send-string "print('OK')\n")
+    (should (string-match ">>> a = 2\\+2"
+                          (with-current-buffer "*Python*"
+                            (elpy/wait-for-output "OK" 30)
+                            (buffer-string))))
+    (should (string-match "...: 4\\+3"
+                          (with-current-buffer "*Python*"
+                            (buffer-string))))
+    ))
+
+(ert-deftest elpy-shell-should-echo-outputs ()
+  (elpy-testcase ()
+    (python-mode)
+    (elpy-mode)
+    (setq elpy-shell-echo-input nil)
+    (setq elpy-shell-echo-output t)
+    (setq elpy-shell-capture-last-multiline-output t)
+    (insert "def foo():\n    1+1\n    for i in range(10):\n        a = 2+2\n        4+3\n        b = a+i\n")
+
+    ;; on "1+1"
+    (goto-char 18)
+    (elpy-shell-kill t)
+    (elpy-shell-send-statement)
+    (python-shell-send-string "print('OK')\n")
+    (if (<= emacs-major-version 24)
+        (should (string-match "^>>> 2" (with-current-buffer "*Python*"
+                                         (elpy/wait-for-output "OK" 30)
+                                         (buffer-string))))
+      (should (string-match "^2" (with-current-buffer "*Python*"
+                                   (elpy/wait-for-output "OK" 30)
+                                   (buffer-string)))))
+    ;; on "4+3"
+    (goto-char 69)
+    (elpy-shell-kill t)
+    (elpy-shell-send-statement)
+    (python-shell-send-string "print('OK')\n")
+    (if (<= emacs-major-version 24)
+        (should (string-match "^>>> 7" (with-current-buffer "*Python*"
+                                         (elpy/wait-for-output "OK" 30)
+                                         (buffer-string))))
+      (should (string-match "^7" (with-current-buffer "*Python*"
+                                   (elpy/wait-for-output "OK" 30)
+                                   (buffer-string)))))
+    ;; on "a = 2+2" and "4+3" lines
+    (set-mark 52)
+    (goto-char 72)
+    (activate-mark)
+    (elpy-shell-kill t)
+    (message "use-region: %s" (use-region-p))
+    (elpy-shell-send-region-or-buffer)
+    (python-shell-send-string "print('OK')\n")
+    (if (<= emacs-major-version 24)
+        (should (string-match "^>>> 7" (with-current-buffer "*Python*"
+                                         (elpy/wait-for-output "OK" 30)
+                                         (buffer-string))))
+      (should (string-match "^7" (with-current-buffer "*Python*"
+                                   (elpy/wait-for-output "OK" 30)
+                                   (buffer-string)))))
+    ))

--- a/test/elpy-shell-send-statement-test.el
+++ b/test/elpy-shell-send-statement-test.el
@@ -4,7 +4,6 @@
     (elpy-mode)
     (setq elpy-shell-echo-input nil)
     (setq elpy-shell-echo-output nil)
-    (setq elpy-shell-capture-last-multiline-output nil)
     (insert "def foo():
     1+1
     for i in range(10):

--- a/test/elpy-shell-send-statement-test.el
+++ b/test/elpy-shell-send-statement-test.el
@@ -1,0 +1,48 @@
+(ert-deftest elpy-shell-send-statement-should-send-statement-at-point ()
+  (elpy-testcase ()
+    (python-mode)
+    (elpy-mode)
+    (setq elpy-shell-echo-input nil)
+    (setq elpy-shell-echo-output nil)
+    (setq elpy-shell-capture-last-multiline-output nil)
+    (insert "def foo():
+    1+1
+    for i in range(10):
+        a = 2+2
+        4+3
+        b = a+i
+    print(b)
+")
+
+    ;; on "a = 2+2"
+    (goto-char 52)
+    (elpy-shell-kill t)
+    (elpy-shell-send-statement)
+    (python-shell-send-string "print(a)\n")
+    (python-shell-send-string "print('OK')\n")
+    (should (string-match ">>> 4"
+                          (with-current-buffer "*Python*"
+                            (elpy/wait-for-output "OK" 30)
+                            (buffer-string))))
+    ;; on "for i in range(10):"
+    (goto-char 30)
+    (elpy-shell-kill t)
+    (elpy-shell-send-statement)
+    (python-shell-send-string "print(b)\n")
+    (python-shell-send-string "print('OK')\n")
+    (should (string-match ">>> 13"
+                          (with-current-buffer "*Python*"
+                            (elpy/wait-for-output "OK" 30)
+                            (buffer-string))))
+    (python-shell-send-string "del b")
+    ;; on "def foo():"
+    (goto-char 6)
+    (elpy-shell-kill t)
+    (elpy-shell-send-statement)
+    (python-shell-send-string "foo()\n")
+    (python-shell-send-string "print('OK')\n")
+    (should (string-match ">>> 13"
+                          (with-current-buffer "*Python*"
+                            (elpy/wait-for-output "OK" 30)
+                            (buffer-string))))
+    ))


### PR DESCRIPTION
# PR Summary
Follow second discussion in #1505.

## Problem
For this given code:
```Python
def foo():
      1+1
      while True:
               2+2   # <- cursor here
```
Following commit #1520, using `elpy-shell-send-statement-and-step` would lead to the following result in the shell buffer:
```python
In [7]: if True:
   ...: 
   ...: 
   ...: 
   ...: 
   ...:             2+2
In [8]: 
```
which is quite ugly and doesn't echo the excepted output value `4`.

## Solution
Filtering the `if True:` and removing the indentation on the region lead to the much nicer echo.
Slightly modifying the function `elpy-shell-send-file` allows to get the output back
```Python
In [7]: 2+2  
Out[7]: 4     
In [8]: 
```

## 

# PR checklist

Please make sure that the following things have been addressed (and check the relevant checkboxes):

- [x] Commits respect our [guidelines](../CONTRIBUTING.rst)
- [x] Tests are passing properly (see [here](https://elpy.readthedocs.io/en/latest/extending.html#running-tests) on how to run Elpy's tests)
