### PR TITLE
Bump version of library 's'

### DIFF
--- a/elpy.el
+++ b/elpy.el
@@ -6,7 +6,7 @@
 ;; URL: https://github.com/jorgenschaefer/elpy
 ;; Version: 1.28.0
 ;; Keywords: Python, IDE, Languages, Tools
-;; Package-Requires: ((company "0.9.2") (emacs "24.4") (find-file-in-project "3.3")  (highlight-indentation "0.5.0") (pyvenv "1.3") (yasnippet "0.8.0") (s "1.11.0"))
+;; Package-Requires: ((company "0.9.2") (emacs "24.4") (find-file-in-project "3.3")  (highlight-indentation "0.5.0") (pyvenv "1.3") (yasnippet "0.8.0") (s "1.12.0"))
 
 ;; This program is free software; you can redistribute it and/or
 ;; modify it under the terms of the GNU General Public License


### PR DESCRIPTION
For some reason melpa stable doesn't have a version 1.11.0 of `s`.
Bump version so that it won't break in the future

# PR checklist

Please make sure that the following things have been addressed (and check the relevant checkboxes):

- [ x ] Commits respect our [guidelines](../CONTRIBUTING.rst)
- [ x ] Tests are passing properly (see [here](https://elpy.readthedocs.io/en/latest/extending.html#running-tests) on how to run Elpy's tests)

## For new features only:
- [ ] Tests has been added to cover the change
- [ ] The documentation has been updated
