### PR TITLE
Don't echo outputs when exception occurs

### DIFF
--- a/elpy-shell.el
+++ b/elpy-shell.el
@@ -485,10 +485,12 @@ complete). Otherwise, does nothing."
                      elpy-shell--captured-output
                      0 (match-beginning 0)))
             (message-log-max))
-        (if (string-empty-p output)
-            (message "No output was produced.")
-          (message "%s" (replace-regexp-in-string "\n\\'" "" output))))
-      (setq-local elpy-shell--captured-output nil)))
+        (if (string-match-p "Traceback (most recent call last):" output)
+            (message "Exception during evaluation.")
+          (if (string-empty-p output)
+              (message "No output was produced.")
+            (message "%s" (replace-regexp-in-string "\n\\'" "" output))))
+        (setq-local elpy-shell--captured-output nil))))
 
   ;; return input unmodified
   string)


### PR DESCRIPTION
# PR Summary
When `elpy-shell-echo-output` is non-nil and the code sent to the interpreter raise an exception, elpy tries to display the exception description in the echo area, which is annoying.

This PR fixes this.

# PR checklist

Please make sure that the following things have been addressed (and check the relevant checkboxes):

- [x] Commits respect our [guidelines](../CONTRIBUTING.rst)
- [x] Tests are passing properly (see [here](https://elpy.readthedocs.io/en/latest/extending.html#running-tests) on how to run Elpy's tests)