### PR TITLE
Note warnings as such for emacs > 26.1

### DIFF
--- a/elpy.el
+++ b/elpy.el
@@ -3821,7 +3821,10 @@ display the current class and method instead."
      ;; Useless for emacs >= 26.1, as warning are handled fine
      ;; COMPAT: Obsolete variable as of 24.4
      (cond
-      ((version<= "26.1" emacs-version) t)
+      ((version<= "26.1" emacs-version)
+       (setq-default python-flymake-msg-alist
+                     '(("^W[0-9]+" . :warning)
+                       ("^E[0-9]+" . :error))))
       ((boundp 'flymake-warning-predicate)
        (set (make-local-variable 'flymake-warning-predicate) "^W[0-9]"))
       (t


### PR DESCRIPTION
# PR Summary
For Emacs > 26.1, all flake8 notices are labeled as error.

This PR labels error codes beginning by "W" as warnings.


# PR checklist

Please make sure that the following things have been addressed (and check the relevant checkboxes):

- [x] Commits respect our [guidelines](../CONTRIBUTING.rst)
- [x] Tests are passing properly (see [here](https://elpy.readthedocs.io/en/latest/extending.html#running-tests) on how to run Elpy's tests)