### PR TITLE
More robust python version detection

### DIFF
--- a/elpy-shell.el
+++ b/elpy-shell.el
@@ -149,11 +149,13 @@ the code cell beginnings defined here."
 
 (defun elpy-shell-get-python-version ()
   "Return the python interpreter version"
-  (string-trim
-   (replace-regexp-in-string "Python" ""
-                             (shell-command-to-string
-                              (format "%s --version"
-                                      python-shell-interpreter)))))
+  (let ((version
+         (shell-command-to-string
+          (format "%s --version"
+                  python-shell-interpreter))))
+    (string-match "[0-9]\\.[0-9]\\.[0-9]" version)
+    (match-string 0 version)))
+
 
 (defun elpy-shell-display-buffer ()
   "Display inferior Python process buffer."


### PR DESCRIPTION
# PR Summary
Follow and fix #1542.

Elpy should now be able to detect python version for any implementations.

# PR checklist

Please make sure that the following things have been addressed (and check the relevant checkboxes):

- [x] Commits respect our [guidelines](../CONTRIBUTING.rst)
- [x] Tests are passing properly (see [here](https://elpy.readthedocs.io/en/latest/extending.html#running-tests) on how to run Elpy's tests)
