### PR TITLE
Fix code evaluation slowdown following commit 464e9f8

### DIFF
--- a/test/elpy-shell-echo-inputs-and-outputs-test.el
+++ b/test/elpy-shell-echo-inputs-and-outputs-test.el
@@ -60,21 +60,20 @@
                             (elpy/wait-for-output "OK" 30)
                             (buffer-string))))
     ;; on "a = 2+2" and "4+3" lines
-    (when (version< "3.0.0" (elpy-shell-get-python-version))
-      (set-mark 52)
-      (goto-char 72)
-      (activate-mark)
-      (elpy-shell-kill t)
-      (elpy-shell-send-region-or-buffer)
-      (python-shell-send-string "print('OK')\n")
-      (should (string-match ">>> a = 2\\+2"
-                            (with-current-buffer "*Python*"
-                              (elpy/wait-for-output "OK" 30)
-                              (buffer-string))))
-      (should (string-match "...: 4\\+3"
-                            (with-current-buffer "*Python*"
-                              (buffer-string))))
-      ))))
+    (set-mark 52)
+    (goto-char 72)
+    (activate-mark)
+    (elpy-shell-kill t)
+    (elpy-shell-send-region-or-buffer)
+    (python-shell-send-string "print('OK')\n")
+    (should (string-match ">>> a = 2\\+2"
+                          (with-current-buffer "*Python*"
+                            (elpy/wait-for-output "OK" 30)
+                            (buffer-string))))
+    (should (string-match "...: 4\\+3"
+                          (with-current-buffer "*Python*"
+                            (buffer-string))))
+    )))
 
 (ert-deftest elpy-shell-should-echo-outputs ()
   (when (<= 25 emacs-major-version)


### PR DESCRIPTION
# PR Summary
Following 464e9f8c26f9a4b9332a4bcae3ff3ba06b250166, sending code to the shell has been shown to be way slower that before for ipython.

This is expected to be due to `elpy-shell-get-python-version`, quite slow for ipython.
This PR fix this by avoiding the use of this function.

# PR checklist

Please make sure that the following things have been addressed (and check the relevant checkboxes):

- [x] Commits respect our [guidelines](../CONTRIBUTING.rst)
- [x] Tests are passing properly (see [here](https://elpy.readthedocs.io/en/latest/extending.html#running-tests) on how to run Elpy's tests)
