### PR TITLE
Add warning when python binaries cannot be found

### DIFF
--- a/elpy-shell.el
+++ b/elpy-shell.el
@@ -233,6 +233,9 @@ Python process. This allows the process to start up."
          (proc (get-buffer-process bufname)))
     (if proc
         proc
+      (when (not (executable-find python-shell-interpreter))
+        (error "Python shell interpreter `%s' cannot be found. Please set `python-shell-interpreter' to an valid python binary."
+               python-shell-interpreter))
       (let ((default-directory (or (and elpy-shell-use-project-root
                                         (elpy-project-root))
                                    default-directory)))


### PR DESCRIPTION
# PR Summary
Follow #1549.

Add a (useful) warning when the python interpreter is not a valid python binary.

May not be completely useful for emacs 26, that already display a useful message.

# PR checklist

Please make sure that the following things have been addressed (and check the relevant checkboxes):

- [x] Commits respect our [guidelines](../CONTRIBUTING.rst)
- [x] Tests are passing properly (see [here](https://elpy.readthedocs.io/en/latest/extending.html#running-tests) on how to run Elpy's tests)
