### PR TITLE
Fix support for black > 19

### DIFF
--- a/elpy/blackutil.py
+++ b/elpy/blackutil.py
@@ -4,6 +4,7 @@
 
 import os
 import sys
+from pkg_resources import parse_version
 
 from elpy.rpc import Fault
 
@@ -23,17 +24,20 @@ def fix_code(code, directory):
 
     """
     if not black:
-        raise Fault('black not installed', code=400)
+        raise Fault("black not installed", code=400)
 
     try:
-        reformatted_source = black.format_file_contents(
-            src_contents=code,
-            line_length=black.DEFAULT_LINE_LENGTH,
-            fast=False
-        )
+        if parse_version(black.__version__) < parse_version("19.0"):
+            reformatted_source = black.format_file_contents(
+                src_contents=code, line_length=black.DEFAULT_LINE_LENGTH, fast=False
+            )
+        else:
+            fm = black.FileMode()
+            reformatted_source = black.format_file_contents(
+                src_contents=code, fast=False, mode=fm
+            )
         return reformatted_source
     except black.NothingChanged:
         return code
     except Exception as e:
-            raise Fault("Error during formatting: {}".format(e),
-                        code=400)
+        raise Fault("Error during formatting: {}".format(e), code=400)


### PR DESCRIPTION
# PR Summary
Arguments that need to be passed to black for code formatting changed with version 19.

This PR add support for black 19.

# PR checklist

Please make sure that the following things have been addressed (and check the relevant checkboxes):

- [x] Commits respect our [guidelines](../CONTRIBUTING.rst)
- [x] Tests are passing properly (see [here](https://elpy.readthedocs.io/en/latest/extending.html#running-tests) on how to run Elpy's tests)
