### PR TITLE
Add pyproject.toml to python project root finder

### DIFF
--- a/elpy.el
+++ b/elpy.el
@@ -1312,7 +1312,8 @@ this."
 
 This is marked with setup.py or setup.cfg."
   (or (locate-dominating-file default-directory "setup.py")
-      (locate-dominating-file default-directory "setup.cfg")))
+      (locate-dominating-file default-directory "setup.cfg")
+      (locate-dominating-file default-directory "pyproject.toml")))
 
 (defun elpy-project-find-git-root ()
   "Return the current git repository root, if any."

--- a/elpy.el
+++ b/elpy.el
@@ -1310,7 +1310,7 @@ this."
 (defun elpy-project-find-python-root ()
   "Return the current Python project root, if any.
 
-This is marked with setup.py or setup.cfg."
+This is marked with setup.py, setup.cfg or pyproject.toml."
   (or (locate-dominating-file default-directory "setup.py")
       (locate-dominating-file default-directory "setup.cfg")
       (locate-dominating-file default-directory "pyproject.toml")))

--- a/test/elpy-project-find-python-root-test.el
+++ b/test/elpy-project-find-python-root-test.el
@@ -13,3 +13,11 @@
     (find-file (f-join project-root "foo/bar.cfg"))
     (should (f-equal? (elpy-project-find-python-root)
                       project-root))))
+
+(ert-deftest elpy-project-find-python-root-should-find-pyproject-toml ()
+  (elpy-testcase ((:project project-root
+                            "pyproject.toml"
+                            "foo/bar.py"))
+    (find-file (f-join project-root "foo/bar.py"))
+    (should (f-equal? (elpy-project-find-python-root)
+                      project-root))))


### PR DESCRIPTION
# PR Summary

This simple change adds `pyproject.toml` to the list of filenames `elpy-project-find-python-root` looks for, to support projects that use `pyproject.toml` instead of `setup.py` or `setup.cfg`

# PR checklist

Please make sure that the following things have been addressed (and check the relevant checkboxes):

- [x] Commits respect our [guidelines](../CONTRIBUTING.rst)
- [x] Tests are passing properly (see [here](https://elpy.readthedocs.io/en/latest/extending.html#running-tests) on how to run Elpy's tests)

## For new features only:
- [x] Tests has been added to cover the change
- [x] The documentation has been updated
