### PR TITLE
Temporary workaround to avoid appearance of `^G` on MacOs

### DIFF
--- a/elpy-shell.el
+++ b/elpy-shell.el
@@ -629,7 +629,9 @@ print) the output of the last expression."
     (python-shell-send-string
      (format
       (concat
-       "import sys, codecs, os, ast;"
+       ;; Readline is only necessary for MacOs, see
+       ;; https://github.com/jorgenschaefer/elpy/issues/1550
+       "import sys, codecs, os, ast, readline;"
        "__pyfile = codecs.open('''%s''', encoding='''%s''');"
        "__code = __pyfile.read().encode('''%s''');"
        "__pyfile.close();"


### PR DESCRIPTION
# PR Summary
Follow #1550.

Thanks to @ConnorNelson for finding this workaround.

# PR checklist

Please make sure that the following things have been addressed (and check the relevant checkboxes):

- [x] Commits respect our [guidelines](../CONTRIBUTING.rst)
- [x] Tests are passing properly (see [here](https://elpy.readthedocs.io/en/latest/extending.html#running-tests) on how to run Elpy's tests)
