### PR TITLE
Add an option to customise the maxmimum number of caracter per line

### DIFF
--- a/elpy.el
+++ b/elpy.el
@@ -2185,6 +2185,11 @@ prefix argument is given, prompt for a symbol from the user."
 ;;;;;;;;;;;;;;;;;;;;;
 ;;; Code reformatting
 
+(defcustom elpy-fix-code-max-line-length 79
+  "Maximum number of line allowed when fixing code."
+  :type 'number
+  :group 'elpy)
+
 (defun elpy-format-code ()
   "Format code using the available formatter."
   (interactive)
@@ -2229,7 +2234,8 @@ root directory."
     (if (use-region-p)
         (let ((new-block (elpy-rpc method
                                    (list (elpy-rpc--region-contents)
-                                         directory)))
+                                         directory
+                                         elpy-fix-code-max-line-length)))
               (beg (region-beginning))
               (end (region-end)))
           (elpy-buffer--replace-region
@@ -2238,7 +2244,8 @@ root directory."
           (deactivate-mark))
       (let ((new-block (elpy-rpc method
                                  (list (elpy-rpc--buffer-contents)
-                                       directory)))
+                                       directory
+                                       elpy-fix-code-max-line-length)))
             (beg (point-min))
             (end (point-max)))
         (elpy-buffer--replace-region beg end new-block)

--- a/elpy.el
+++ b/elpy.el
@@ -2185,8 +2185,10 @@ prefix argument is given, prompt for a symbol from the user."
 ;;;;;;;;;;;;;;;;;;;;;
 ;;; Code reformatting
 
-(defcustom elpy-fix-code-max-line-length 79
-  "Maximum number of line allowed when fixing code."
+(defcustom elpy-fix-code-max-line-length nil
+  "Maximum number of line allowed when fixing code.
+
+When nil, use the formatter default value."
   :type 'number
   :group 'elpy)
 

--- a/elpy/auto_pep8.py
+++ b/elpy/auto_pep8.py
@@ -12,7 +12,7 @@ except ImportError:  # pragma: no cover
     autopep8 = None
 
 
-def fix_code(code, directory):
+def fix_code(code, directory, max_line_length=None):
     """Formats Python code to conform to the PEP 8 style guide.
 
     """
@@ -20,8 +20,12 @@ def fix_code(code, directory):
         raise Fault('autopep8 not installed, cannot fix code.',
                     code=400)
     old_dir = os.getcwd()
+    options = {}
+    if max_line_length is not None:
+        options = {"max-line-length": max_line_length}
+
     try:
         os.chdir(directory)
-        return autopep8.fix_code(code, apply_config=True)
+        return autopep8.fix_code(code, apply_config=True, options=options)
     finally:
         os.chdir(old_dir)

--- a/elpy/blackutil.py
+++ b/elpy/blackutil.py
@@ -18,20 +18,24 @@ except ImportError:  # pragma: no cover
     black = None
 
 
-def fix_code(code, directory):
+def fix_code(code, directory, max_line_length=None):
     """Formats Python code to conform to the PEP 8 style guide.
 
     """
     if not black:
         raise Fault("black not installed", code=400)
 
+    if max_line_length is None:
+        max_line_length = black.DEFAULT_LINE_LENGTH
+
     try:
         if parse_version(black.__version__) < parse_version("19.0"):
             reformatted_source = black.format_file_contents(
-                src_contents=code, line_length=black.DEFAULT_LINE_LENGTH, fast=False
+                src_contents=code, line_length=max_line_length, fast=False
             )
         else:
             fm = black.FileMode()
+            fm.line_length = max_line_length
             reformatted_source = black.format_file_contents(
                 src_contents=code, fast=False, mode=fm
             )

--- a/elpy/server.py
+++ b/elpy/server.py
@@ -207,26 +207,26 @@ class ElpyRPCServer(JSONRPCServer):
             raise Fault("get_names not implemented by current backend",
                         code=400)
 
-    def rpc_fix_code(self, source, directory):
+    def rpc_fix_code(self, source, directory, max_line_length=None):
         """Formats Python code to conform to the PEP 8 style guide.
 
         """
         source = get_source(source)
-        return fix_code(source, directory)
+        return fix_code(source, directory, max_line_length)
 
-    def rpc_fix_code_with_yapf(self, source, directory):
+    def rpc_fix_code_with_yapf(self, source, directory, max_line_length=None):
         """Formats Python code to conform to the PEP 8 style guide.
 
         """
         source = get_source(source)
-        return fix_code_with_yapf(source, directory)
+        return fix_code_with_yapf(source, directory, max_line_length)
 
-    def rpc_fix_code_with_black(self, source, directory):
+    def rpc_fix_code_with_black(self, source, directory, max_line_length=None):
         """Formats Python code to conform to the PEP 8 style guide.
 
         """
         source = get_source(source)
-        return fix_code_with_black(source, directory)
+        return fix_code_with_black(source, directory, max_line_length)
 
 
 def get_source(fileobj):

--- a/elpy/yapfutil.py
+++ b/elpy/yapfutil.py
@@ -28,7 +28,8 @@ def fix_code(code, directory, max_line_length=None):
         raise Fault('yapf not installed', code=400)
     style_config = file_resources.GetDefaultStyleForDir(directory or os.getcwd())
     style_dic = style.CreateStyleFromConfig(style_config)
-    style_dic['COLUMN_LIMIT'] = max_line_length
+    if max_line_length is not None:
+        style_dic['COLUMN_LIMIT'] = max_line_length
     def CreateElpyStyle():
         return style_dic
     style._STYLE_NAME_TO_FACTORY['elpy'] = CreateElpyStyle

--- a/elpy/yapfutil.py
+++ b/elpy/yapfutil.py
@@ -15,24 +15,31 @@ try:
         yapf_api = None
     else:
         from yapf.yapflib import yapf_api
-        from yapf.yapflib import file_resources
+        from yapf.yapflib import file_resources, style
 except ImportError:  # pragma: no cover
     yapf_api = None
 
 
-def fix_code(code, directory):
+def fix_code(code, directory, max_line_length=None):
     """Formats Python code to conform to the PEP 8 style guide.
 
     """
     if not yapf_api:
         raise Fault('yapf not installed', code=400)
     style_config = file_resources.GetDefaultStyleForDir(directory or os.getcwd())
+    style_dic = style.CreateStyleFromConfig(style_config)
+    style_dic['COLUMN_LIMIT'] = max_line_length
+    def CreateElpyStyle():
+        return style_dic
+    style._STYLE_NAME_TO_FACTORY['elpy'] = CreateElpyStyle
+    style._DEFAULT_STYLE_TO_FACTORY.append((style, CreateElpyStyle))
+
     try:
         reformatted_source, _ = yapf_api.FormatCode(code,
                                                     filename='<stdin>',
-                                                    style_config=style_config,
+                                                    style_config="elpy",
                                                     verify=False)
         return reformatted_source
     except Exception as e:
-            raise Fault("Error during formatting: {}".format(e),
-                        code=400)
+        raise Fault("Error during formatting: {}".format(e),
+                    code=400)


### PR DESCRIPTION
# PR Summary
Follow #1522.

Changing the maximal number of character per line for automatic code reformatting seems to be a very common thing to do.
This PR adds an option (`elpy-fix-code-max-line-length`) to specify this parameter for the code formatters supported by Elpy (autopep8, yapf and black).

# PR checklist

Please make sure that the following things have been addressed (and check the relevant checkboxes):

- [ ] Commits respect our [guidelines](../CONTRIBUTING.rst)
- [ ] Tests are passing properly (see [here](https://elpy.readthedocs.io/en/latest/extending.html#running-tests) on how to run Elpy's tests)

## For new features only:
- [ ] Tests has been added to cover the change
- [ ] The documentation has been updated
