### PR TITLE
Revert "Temporary workaround to avoid appearance of `^G` on MacOs"

### DIFF
--- a/elpy-shell.el
+++ b/elpy-shell.el
@@ -635,9 +635,7 @@ print) the output of the last expression."
     (python-shell-send-string
      (format
       (concat
-       ;; Readline is only necessary for MacOs, see
-       ;; https://github.com/jorgenschaefer/elpy/issues/1550
-       "import sys, codecs, os, ast, readline;"
+       "import sys, codecs, os, ast;"
        "__pyfile = codecs.open('''%s''', encoding='''%s''');"
        "__code = __pyfile.read().encode('''%s''');"
        "__pyfile.close();"


### PR DESCRIPTION
Reverts jorgenschaefer/elpy#1562.

Does not seem to fix MacOS issues...