### PR TITLE
Replace xmlrpclib with urllib2

### DIFF
--- a/elpy.el
+++ b/elpy.el
@@ -673,17 +673,17 @@ import warnings
 warnings.filterwarnings('ignore', category=FutureWarning)
 
 try:
-    import xmlrpclib
+    import urllib2 as urllib
 except ImportError:
-    import xmlrpc.client as xmlrpclib
+    import urllib.request as urllib
 
 from distutils.version import LooseVersion
 
 
 def latest(package, version=None):
     try:
-        with xmlrpclib.ServerProxy('https://pypi.python.org/pypi') as pypi:
-            latest = pypi.package_releases(package)[0]
+        response = urllib.urlopen('https://pypi.org/pypi/{package}/json'.format(package=package)).read()
+        latest = json.loads(response)['info']['version']
         if version is None or LooseVersion(version) < LooseVersion(latest):
             return latest
         else:


### PR DESCRIPTION
# PR Summary
Replace `xmlrpclib` with `urllib2`.

There has been issues with xmlrpclib being slow when doing
`elpy-config`. Luckily, with the new version of pypi, there are some
new json API's that can be used. These changes reflect that.

I noticed that SSL in Python 3.6+ is an issue on Mac OS when using urllib. (See here: https://stackoverflow.com/a/42334357/2178312)
Something to be aware of when users come to elpy about this but then again, this isn't elpy specific issue 🤷‍♂️ 

# PR checklist

Please make sure that the following things have been addressed (and check the relevant checkboxes):

- [x] Commits respect our [guidelines](../CONTRIBUTING.rst)
- [x] Tests are passing properly (see [here](https://elpy.readthedocs.io/en/latest/extending.html#running-tests) on how to run Elpy's tests)

## For new features only:
- [N/A] Tests has been added to cover the change
- [N/A] The documentation has been updated
