### PR TITLE
Don't send statement when there is no statement to send

### DIFF
--- a/elpy-shell.el
+++ b/elpy-shell.el
@@ -808,17 +808,17 @@ Otherwise, skips forward to the next code line and sends the
 corresponding statement."
   (interactive)
   (elpy-shell--ensure-shell-running)
-  (when (not elpy-shell-echo-input) (elpy-shell--append-to-shell-output "\n"))
-  (let ((beg (progn (elpy-shell--nav-beginning-of-statement)
-                    (save-excursion
-                      (beginning-of-line)
-                      (point))))
-        (end (progn (elpy-shell--nav-end-of-statement) (point))))
-    (unless (eq beg end)
-      (elpy-shell--flash-and-message-region beg end)
+  (elpy-shell--nav-beginning-of-statement)
+  ;; Make sure there is a statement to send
+  (when (not (looking-at "[[:space:]]*$"))
+    (when (not elpy-shell-echo-input) (elpy-shell--append-to-shell-output "\n"))
+    (let ((beg (save-excursion (beginning-of-line) (point)))
+          (end (progn (elpy-shell--nav-end-of-statement) (point))))
+      (unless (eq beg end)
+        (elpy-shell--flash-and-message-region beg end)
         (elpy-shell--with-maybe-echo
          (python-shell-send-string (python-shell-buffer-substring beg end)))))
-  (python-nav-forward-statement))
+    (python-nav-forward-statement)))
 
 (defun elpy-shell-send-top-statement-and-step ()
   "Send the current or next top-level statement to the Python shell and step.


### PR DESCRIPTION
# PR Summary
Follow #1591.

When using `elpy-send-statement` on the last buffer line, Elpy tries to send long empty strings to the shell.
This result in the display of a lot of shell prompt.

This PR fixes this behaviour.

# PR checklist

Please make sure that the following things have been addressed (and check the relevant checkboxes):

- [x] Commits respect our [guidelines](../CONTRIBUTING.rst)
- [x] Tests are passing properly (see [here](https://elpy.readthedocs.io/en/latest/extending.html#running-tests) on how to run Elpy's tests)