### PR TITLE
Simplify import completions test

### DIFF
--- a/elpy/tests/support.py
+++ b/elpy/tests/support.py
@@ -365,12 +365,7 @@ class RPCGetCompletionsTests(GenericRPCTests):
         completions = self.backend.rpc_get_completions(filename,
                                                        source,
                                                        offset)
-        if compat.PYTHON3:
-            expected = ["processing"]
-        else:
-            expected = ["file", "processing"]
-        self.assertEqual(sorted([cand['suffix'] for cand in completions]),
-                         sorted(expected))
+        self.assertIn("processing", [cand['suffix'] for cand in completions])
 
     def test_should_complete_packages_for_import(self):
         source, offset = source_and_offset("import email.mi_|_")


### PR DESCRIPTION
# PR Summary

Before: `test_should_complete_top_level_modules_for_import` attempts to
complete "import multi" and yields,
```
AssertionError: Lists differ: [file, pledispatch, processing] != [file, processing]
```
because my python installation carries "multipledispatch" as a valid import.

After: simplify test to merely verify "processing" is a valid completion.

# PR checklist

Please make sure that the following things have been addressed (and check the relevant checkboxes):

- [x] Commits respect our [guidelines](../CONTRIBUTING.rst)
- [x] Tests are passing properly (see [here](https://elpy.readthedocs.io/en/latest/extending.html#running-tests) on how to run Elpy's tests)

## For new features only:
- [ ] Tests has been added to cover the change
- [ ] The documentation has been updated
