### PR TITLE
Enable elpy-mode in python buffer when enabling Elpy

### DIFF
--- a/elpy.el
+++ b/elpy.el
@@ -607,6 +607,12 @@ This option need to bet set through `customize' or `customize-set-variable' to b
     (add-hook 'python-mode-hook 'elpy-mode)
     (add-hook 'pyvenv-post-activate-hooks 'elpy-rpc--disconnect)
     (add-hook 'inferior-python-mode-hook 'elpy-shell--enable-output-filter)
+    ;; Enable Elpy-mode in the opened python buffer
+    (dolist (buffer (buffer-list))
+      (and (not (string-match "^ ?\\*" (buffer-name buffer)))
+           (with-current-buffer buffer
+             (when (string= major-mode 'python-mode)
+               (elpy-mode t)))))
     (setq elpy-enabled-p t)))
 
 (defun elpy-disable ()


### PR DESCRIPTION
# PR Summary
Related to #1596.

If Elpy is enabled (with `elpy-enable`) while some python files are already open, `elpy-mode` will not be activated in them (before `elpy-mode` uses `python-mode-hook`).

This PR makes sure that elpy-mode is properly activated in already existing python buffer.

# PR checklist

Please make sure that the following things have been addressed (and check the relevant checkboxes):

- [x] Commits respect our [guidelines](../CONTRIBUTING.rst)
- [x] Tests are passing properly (see [here](https://elpy.readthedocs.io/en/latest/extending.html#running-tests) on how to run Elpy's tests)
