### PR TITLE
Use the toml library to parse pyproject.toml.

### DIFF
--- a/elpy/blackutil.py
+++ b/elpy/blackutil.py
@@ -7,7 +7,11 @@ from pkg_resources import parse_version
 
 import os
 
-import toml
+try:
+    import toml
+except ImportError:
+    toml = None
+
 from elpy.rpc import Fault
 
 BLACK_NOT_SUPPORTED = sys.version_info < (3, 6)
@@ -31,7 +35,7 @@ def fix_code(code, directory):
     line_length = black.DEFAULT_LINE_LENGTH
     string_normalization = True
     pyproject_path = os.path.join(directory, "pyproject.toml")
-    if os.path.exists(pyproject_path):
+    if toml is not None and os.path.exists(pyproject_path):
         pyproject_config = toml.load(pyproject_path)
         black_config = pyproject_config.get("tool", {}).get("black", {})
         if "line-length" in black_config:

--- a/elpy/blackutil.py
+++ b/elpy/blackutil.py
@@ -4,14 +4,10 @@
 
 import sys
 from pkg_resources import parse_version
-try:
-    # python 3
-    import configparser
-except ImportError:
-    # python 2
-    import ConfigParser as configparser
+
 import os
 
+import toml
 from elpy.rpc import Fault
 
 BLACK_NOT_SUPPORTED = sys.version_info < (3, 6)
@@ -34,27 +30,24 @@ def fix_code(code, directory):
     # Get black config from pyproject.toml
     line_length = black.DEFAULT_LINE_LENGTH
     string_normalization = True
-    parser = configparser.ConfigParser()
     pyproject_path = os.path.join(directory, "pyproject.toml")
-    if parser.read(pyproject_path):
-        if parser.has_option("tool.black", "line-length"):
-            line_length = parser.getint("tool.black", "line-length")
-        if parser.has_option("tool.black", "skip-string-normalization"):
-            string_normalization = not parser.getboolean(
-                "tool.black", "skip-string-normalization"
-            )
+    if os.path.exists(pyproject_path):
+        pyproject_config = toml.load(pyproject_path)
+        black_config = pyproject_config.get("tool", {}).get("black", {})
+        if "line-length" in black_config:
+            line_length = black_config["line-length"]
+        if "skip-string-normalization" in black_config:
+            string_normalization = not black_config["skip-string-normalization"]
     try:
         if parse_version(black.__version__) < parse_version("19.0"):
             reformatted_source = black.format_file_contents(
-                src_contents=code, line_length=line_length, fast=False
-            )
+                src_contents=code, line_length=line_length, fast=False)
         else:
             fm = black.FileMode(
-                line_length=line_length, string_normalization=string_normalization
-            )
+                line_length=line_length,
+                string_normalization=string_normalization)
             reformatted_source = black.format_file_contents(
-                src_contents=code, fast=False, mode=fm
-            )
+                src_contents=code, fast=False, mode=fm)
         return reformatted_source
     except black.NothingChanged:
         return code

--- a/elpy/tests/test_black.py
+++ b/elpy/tests/test_black.py
@@ -39,3 +39,17 @@ class BLACKTestCase(BackendTestCase):
     def _assert_format(self, src, expected):
         new_block = blackutil.fix_code(src, os.getcwd())
         self.assertEqual(new_block, expected)
+
+    def test_should_read_options_from_pyproject_toml(self):
+        with open('pyproject.toml', 'w') as f:
+            f.write('[tool.black]\nline-length = 10')
+
+        self.addCleanup(os.remove, 'pyproject.toml')
+
+        testdata = [('x=       123\n', 'x = 123\n'),
+                    ('x=1; \ny=2 \n', 'x = 1\ny = 2\n'),
+                    ('x, y, z, a, b, c = 123, 124, 125, 126, 127, 128',
+                     'x, y, z, a, b, c = (\n    123,\n    124,\n    125,'
+                     '\n    126,\n    127,\n    128,\n)\n')]
+        for src, expected in testdata:
+            self._assert_format(src, expected)

--- a/test/elpy-black-fix-code-test.el
+++ b/test/elpy-black-fix-code-test.el
@@ -103,7 +103,7 @@
     (elpy-testcase ()
        ;; create pyproject.toml
        (with-current-buffer (find-file-noselect "pyproject.toml")
-         (insert "[tool.black]\nline-length = 10")
+         (insert "[tool.black]\nline-length = 10\nexclude = '''\n'''\n")
          (save-buffer))
        (set-buffer-string-with-point
         "_|_print(1, 2, 3, 4, 5, 6, 7)"


### PR DESCRIPTION
# PR Summary
This is my attempt to fix #1610. The issue is using `configparser`, which doesn't handle multiline strings that's allowed in TOML files.

I added a multiline setting to the existing pyproject test to help validate my change. I'm using the `toml` library to do the parsing, which is installed as a dependency of `black`.

Please let me know if there's anything I should change!

# PR checklist

Please make sure that the following things have been addressed (and check the relevant checkboxes):

- [x] Commits respect our [guidelines](../CONTRIBUTING.rst)
- [x] Tests are passing properly (see [here](https://elpy.readthedocs.io/en/latest/extending.html#running-tests) on how to run Elpy's tests)

## For new features only:
- [ ] Tests has been added to cover the change
- [ ] The documentation has been updated
