### PR TITLE
Update Elpy dependencies

### DIFF
--- a/Cask
+++ b/Cask
@@ -3,12 +3,12 @@
 
 (package "elpy" "1.30.0" "Emacs Python Development Environment")
 
-(depends-on "company" "0.8.0")
-(depends-on "find-file-in-project" "3.3")
-(depends-on "highlight-indentation" "0.5.0")
+(depends-on "company" "0.9.10")
+(depends-on "find-file-in-project" "5.7.4")
+(depends-on "highlight-indentation" "0.7.0")
 (depends-on "pyvenv" "1.2")
-(depends-on "yasnippet" "0.8.0")
-(depends-on "s" "1.11.0")
+(depends-on "yasnippet" "0.13.0")
+(depends-on "s" "1.12.0")
 
 (development
  (depends-on "f")

--- a/elpy/jedibackend.py
+++ b/elpy/jedibackend.py
@@ -80,7 +80,8 @@ class JediBackend(object):
         # cases. See issue #76.
         if (
                 locations and
-                locations[0].module_path is None
+                (locations[0].module_path is None
+                 or locations[0].module_name == 'builtins')
         ):
             locations = run_with_debug(jedi, 'goto_assignments',
                                        source=source, line=line,

--- a/elpy/jedibackend.py
+++ b/elpy/jedibackend.py
@@ -81,7 +81,8 @@ class JediBackend(object):
         if (
                 locations and
                 (locations[0].module_path is None
-                 or locations[0].module_name == 'builtins')
+                 or locations[0].module_name == 'builtins'
+                 or locations[0].module_name == '__builtin__')
         ):
             locations = run_with_debug(jedi, 'goto_assignments',
                                        source=source, line=line,

--- a/elpy/tests/support.py
+++ b/elpy/tests/support.py
@@ -343,7 +343,7 @@ class RPCGetCompletionsTests(GenericRPCTests):
         for candidate in expected:
             self.assertIn(candidate, actual)
 
-    if sys.version_info >= (3, 5):
+    if sys.version_info >= (3, 5) or sys.version_info < (3, 0):
         JSON_COMPLETIONS = ["SONDecoder", "SONEncoder", "SONDecodeError"]
     else:
         JSON_COMPLETIONS = ["SONDecoder", "SONEncoder"]
@@ -378,8 +378,12 @@ class RPCGetCompletionsTests(GenericRPCTests):
         completions = self.backend.rpc_get_completions(filename,
                                                        source,
                                                        offset)
+        if sys.version_info < (3, 0):
+            compl = [u'me', u'METext']
+        else:
+            compl = ['me']
         self.assertEqual([cand['suffix'] for cand in completions],
-                         ["me"])
+                         compl)
 
     def test_should_not_complete_for_import(self):
         source, offset = source_and_offset("import foo.Conf_|_")

--- a/elpy/tests/support.py
+++ b/elpy/tests/support.py
@@ -118,8 +118,8 @@ class GenericRPCTests(object):
 
         self.rpc(filename, source, offset)
 
-    @unittest.skipIf((3, 3) <= sys.version_info < (3, 4),
-                     "Bug in jedi for Python 3.3")
+    # @unittest.skipIf((3, 3) <= sys.version_info < (3, 4),
+    #                  "Bug in jedi for Python 3.3")
     def test_should_not_fail_for_relative_import(self):
         source, offset = source_and_offset(
             "from .. import foo_|_"
@@ -390,8 +390,8 @@ class RPCGetCompletionsTests(GenericRPCTests):
         self.assertEqual([cand['suffix'] for cand in completions],
                          [])
 
-    @unittest.skipIf((3, 3) <= sys.version_info < (3, 4),
-                     "Bug in jedi for Python 3.3")
+    # @unittest.skipIf((3, 3) <= sys.version_info < (3, 4),
+    #                  "Bug in jedi for Python 3.3")
     def test_should_not_fail_for_short_module(self):
         source, offset = source_and_offset("from .. import foo_|_")
         filename = self.project_file("test.py", source)
@@ -692,8 +692,6 @@ class RPCGetAssignmentTests(GenericRPCTests):
 class RPCGetCalltipTests(GenericRPCTests):
     METHOD = "rpc_get_calltip"
 
-    @unittest.skipIf(sys.version_info >= (3, 0),
-                     "Bug in Jedi 0.9.0")
     def test_should_get_calltip(self):
         source, offset = source_and_offset(
             "import threading\nthreading.Thread(_|_")
@@ -706,8 +704,6 @@ class RPCGetCalltipTests(GenericRPCTests):
 
         self.assertEqual(calltip, expected)
 
-    @unittest.skipIf(sys.version_info >= (3, 0),
-                     "Bug in Jedi 0.9.0")
     def test_should_get_calltip_even_after_parens(self):
         source, offset = source_and_offset(
             "import threading\nthreading.Thread(foo()_|_")
@@ -719,8 +715,6 @@ class RPCGetCalltipTests(GenericRPCTests):
 
         self.assertEqual(self.THREAD_CALLTIP, actual)
 
-    @unittest.skipIf(sys.version_info >= (3, 0),
-                     "Bug in Jedi 0.9.0")
     def test_should_get_calltip_at_closing_paren(self):
         source, offset = source_and_offset(
             "import threading\nthreading.Thread(_|_)")

--- a/elpy/tests/test_jedibackend.py
+++ b/elpy/tests/test_jedibackend.py
@@ -55,13 +55,15 @@ class TestRPCGetDocstring(RPCGetDocstringTests,
         super(TestRPCGetDocstring, self).__init__(*args, **kwargs)
         if sys.version_info >= (3, 6):
             self.JSON_LOADS_DOCSTRING = (
-                'loads(s, *, encoding=None, cls=None, '
-                'object_hook=None, parse_float=None,'
+                'loads(s, encoding=None, cls=None, object_hook=None, '
+                'parse_float=None, parse_int=None, parse_constant=None, '
+                'object_pairs_hook=None, kw)'
             )
         else:
             self.JSON_LOADS_DOCSTRING = (
-                'loads(s, encoding=None, cls=None, '
-                'object_hook=None, parse_float=None,'
+                'loads(s, encoding=None, cls=None, object_hook=None, '
+                'parse_float=None, parse_int=None, parse_constant=None, '
+                'object_pairs_hook=None, kw)'
             )
 
     def check_docstring(self, docstring):
@@ -168,8 +170,8 @@ class TestRPCGetAssignment(RPCGetAssignmentTests,
 
 class TestRPCGetCalltip(RPCGetCalltipTests,
                         JediBackendTestCase):
-    KEYS_CALLTIP = {'index': 0,
-                    'params': [''],
+    KEYS_CALLTIP = {'index': None,
+                    'params': [],
                     'name': u'keys'}
     RADIX_CALLTIP = {'index': None,
                      'params': [],
@@ -178,14 +180,14 @@ class TestRPCGetCalltip(RPCGetCalltipTests,
                    'params': [u'a', u'b'],
                    'name': u'add'}
     if compat.PYTHON3:
-        THREAD_CALLTIP = {"name": "Thread",
-                          "params": ["group=None",
-                                     "target=None",
-                                     "name=None",
-                                     "args=()",
-                                     "kwargs=None",
-                                     "daemon=None"],
-                          "index": 0}
+        THREAD_CALLTIP = {'name': 'Thread',
+                          'index': 0,
+                          'params': ['group: None = ...',
+                                     'target: Optional[Callable[..., Any]] = ...',
+                                     'name: Optional[str] = ...',
+                                     'args: Iterable = ...',
+                                     'kwargs: Mapping[str, Any] = ...',
+                                     'daemon: Optional[bool] = ...']}
     else:
         THREAD_CALLTIP = {"name": "Thread",
                           "params": ["group=None",

--- a/elpy/tests/test_jedibackend.py
+++ b/elpy/tests/test_jedibackend.py
@@ -189,14 +189,13 @@ class TestRPCGetCalltip(RPCGetCalltipTests,
                                      'kwargs: Mapping[str, Any] = ...',
                                      'daemon: Optional[bool] = ...']}
     else:
-        THREAD_CALLTIP = {"name": "Thread",
-                          "params": ["group=None",
-                                     "target=None",
-                                     "name=None",
-                                     "args=()",
-                                     "kwargs=None",
-                                     "verbose=None"],
-                          "index": 0}
+        THREAD_CALLTIP = {'index': 0,
+                          'name': u'Thread',
+                          'params': [u'group: None = ...',
+                                     u'target: Optional[Callable[..., Any]] = ...',
+                                     u'name: Optional[str] = ...',
+                                     u'args: Iterable = ...',
+                                     u'kwargs: Mapping[str, Any] = ...']}
 
     def test_should_not_fail_with_get_subscope_by_name(self):
         # Bug #677 / jedi#628

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,6 +1,6 @@
 bumpversion==0.5.3
-coverage==4.5.1
-mock==2.0.0
+coverage==4.5.3
+mock==3.0.5
 nose==1.3.7
-twine==1.11.0
-wheel==0.31.1
+twine==1.13.0
+wheel==0.33.4

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
-flake8==3.5.0
-jedi==0.13.3
-rope==0.11.0
-autopep8==1.4.3
-yapf==0.26.0
+flake8==3.7.7
+jedi==0.14.0
+rope==0.14.0
+autopep8==1.4.4
+yapf==0.27.0

--- a/requirements3.txt
+++ b/requirements3.txt
@@ -1,6 +1,6 @@
-flake8==3.5.0
-jedi==0.13.3
+flake8==3.7.7
+jedi==0.14.0
 rope_py3k==0.9.4-1
-autopep8==1.4
-yapf==0.26
+autopep8==1.4.4
+yapf==0.27
 black==19.3b0


### PR DESCRIPTION
# PR Summary
Travis tests seems to be broken (see PR #1611) because Elpy depedencies are out-of-date.
This PR is just a dependencies update.
