### PR TITLE
Fixed bug where elpy modifies company-frontends global value

### DIFF
--- a/elpy.el
+++ b/elpy.el
@@ -3736,8 +3736,7 @@ and return the list."
      (eldoc-add-command-completions "company-")
      (eldoc-add-command-completions "python-indent-dedent-line-backspace")
      (set (make-local-variable 'company-frontends)
-          (delq 'company-echo-metadata-frontend
-                (mapcar #'identity company-frontends)))
+          (remq 'company-echo-metadata-frontend company-frontends))
      (set (make-local-variable 'eldoc-documentation-function)
           'elpy-eldoc-documentation)
      (eldoc-mode 1))

--- a/elpy.el
+++ b/elpy.el
@@ -3736,7 +3736,8 @@ and return the list."
      (eldoc-add-command-completions "company-")
      (eldoc-add-command-completions "python-indent-dedent-line-backspace")
      (set (make-local-variable 'company-frontends)
-          (delq 'company-echo-metadata-frontend company-frontends))
+          (delq 'company-echo-metadata-frontend
+                (mapcar #'identity company-frontends)))
      (set (make-local-variable 'eldoc-documentation-function)
           'elpy-eldoc-documentation)
      (eldoc-mode 1))


### PR DESCRIPTION
# PR Summary

I noticed that elpy removes `company-echo-metadata-frontend` from the global value of `company-frontends`. I believe this is caused by trying to disable `company-echo-metadata-frontend` to avoid conflicting with eldoc, but `delq` modifies the references to cons cells, thus even though `company-frontends` is made local, its global value still gets affected.

This PR fixes that.

# PR checklist

Please make sure that the following things have been addressed (and check the relevant checkboxes):

- [x] Commits respect our [guidelines](../CONTRIBUTING.rst)
- [x] Tests are passing properly (see [here](https://elpy.readthedocs.io/en/latest/extending.html#running-tests) on how to run Elpy's tests)