### PR TITLE
Fix tests following changes in calltip format in jedi

### DIFF
--- a/elpy/tests/test_jedibackend.py
+++ b/elpy/tests/test_jedibackend.py
@@ -55,15 +55,15 @@ class TestRPCGetDocstring(RPCGetDocstringTests,
         super(TestRPCGetDocstring, self).__init__(*args, **kwargs)
         if sys.version_info >= (3, 6):
             self.JSON_LOADS_DOCSTRING = (
-                'loads(s, encoding=None, cls=None, object_hook=None, '
+                'loads(s, *, encoding=None, cls=None, object_hook=None, '
                 'parse_float=None, parse_int=None, parse_constant=None, '
-                'object_pairs_hook=None, kw)'
+                'object_pairs_hook=None, **kw)'
             )
         else:
             self.JSON_LOADS_DOCSTRING = (
                 'loads(s, encoding=None, cls=None, object_hook=None, '
                 'parse_float=None, parse_int=None, parse_constant=None, '
-                'object_pairs_hook=None, kw)'
+                'object_pairs_hook=None, **kw)'
             )
 
     def check_docstring(self, docstring):
@@ -182,20 +182,21 @@ class TestRPCGetCalltip(RPCGetCalltipTests,
     if compat.PYTHON3:
         THREAD_CALLTIP = {'name': 'Thread',
                           'index': 0,
-                          'params': ['group: None = ...',
-                                     'target: Optional[Callable[..., Any]] = ...',
-                                     'name: Optional[str] = ...',
-                                     'args: Iterable = ...',
-                                     'kwargs: Mapping[str, Any] = ...',
-                                     'daemon: Optional[bool] = ...']}
+                          'params': ['group: None=...',
+                                     'target: Optional[Callable[..., Any]]=...',
+                                     'name: Optional[str]=...',
+                                     'args: Iterable=...',
+                                     'kwargs: Mapping[str, Any]=...',
+                                     'daemon: Optional[bool]=...']}
+
     else:
         THREAD_CALLTIP = {'index': 0,
                           'name': u'Thread',
-                          'params': [u'group: None = ...',
-                                     u'target: Optional[Callable[..., Any]] = ...',
-                                     u'name: Optional[str] = ...',
-                                     u'args: Iterable = ...',
-                                     u'kwargs: Mapping[str, Any] = ...']}
+                          'params': [u'group: None=...',
+                                     u'target: Optional[Callable[..., Any]]=...',
+                                     u'name: Optional[str]=...',
+                                     u'args: Iterable=...',
+                                     u'kwargs: Mapping[str, Any]=...']}
 
     def test_should_not_fail_with_get_subscope_by_name(self):
         # Bug #677 / jedi#628


### PR DESCRIPTION
# PR Summary
Calltips and docstring format changed with jedi 14.
This PR fixes the tests following those changes.

# PR checklist
- [x] Commits respect our [guidelines](../CONTRIBUTING.rst)
- [x] Tests are passing properly (see [here](https://elpy.readthedocs.io/en/latest/extending.html#running-tests) on how to run Elpy's tests)
