### PR TITLE
elpy-get-info-from-shell grammar fixes

### DIFF
--- a/docs/ide.rst
+++ b/docs/ide.rst
@@ -109,9 +109,9 @@ documentation is a good place for further information.
     If `t`, use the shell to gather docstrings and completions. Normally elpy
     provides completion and documentation using static code analysis (from
     jedi). With this option, elpy will add the completion candidates
-    and the docstrings from the associated python shell. This allows to have
-    decent completion candidates and documentation when the static code analysis
-    fails. the static code analysis fails.
+    and the docstrings from the associated python shell; This activates
+    fallback completion candidates for cases when the static code analysis
+    fails.
 
 
 Navigation

--- a/elpy.el
+++ b/elpy.el
@@ -296,7 +296,7 @@ this feature."
 (defcustom elpy-get-info-from-shell nil
   "If t, use the shell to gather docstrings and completions.
 
-Normally elpy provides completion and documentation using static code analysis (from jedi). With this option set to t, elpy will add the completion candidates and the docstrings from the associated python shell. This allows to have decent completion candidates and documentation when the static code analysis fails."
+Normally elpy provides completion and documentation using static code analysis (from jedi). With this option set to t, elpy will add the completion candidates and the docstrings from the associated python shell; This activates fallback completion candidates for cases when static code analysis fails."
   :type 'boolean
   :group 'elpy)
 


### PR DESCRIPTION
# PR Summary
Just a minor grammar update to fix "allows to" in a way that reads smoothly.


# PR checklist

Please make sure that the following things have been addressed (and check the relevant checkboxes):

- [x] Commits respect our [guidelines](../CONTRIBUTING.rst)
- [x] Tests are passing properly (see [here](https://elpy.readthedocs.io/en/latest/extending.html#running-tests) on how to run Elpy's tests)

## For new features only:
- [ ] Tests has been added to cover the change
- [x] The documentation has been updated
