### PR TITLE
Avoid C-g in elpy-pdb keybinding

### DIFF
--- a/docs/ide.rst
+++ b/docs/ide.rst
@@ -593,7 +593,7 @@ Note that this interface is only available for Emacs 25 and above.
 .. _pdb: https://docs.python.org/3/library/pdb.html
 
 .. command:: elpy-pdb-debug-buffer
-   :kbd: C-c C-g g
+   :kbd: C-c C-u d
 
    Run pdb on the current buffer. If no breakpoints has been set using
    :command:`elpy-pdb-toggle-breakpoint-at-point`, the debugger will
@@ -607,7 +607,7 @@ Note that this interface is only available for Emacs 25 and above.
 .. _pdb commands: https://docs.python.org/3/library/pdb.html#debugger-commands
 
 .. command:: elpy-pdb-toggle-breakpoint-at-point
-   :kbd: C-c C-g b
+   :kbd: C-c C-u b
 
    Add (or remove) a breakpoint on the current line. Elpy adds a red
    circle to the fringe to indicate the presence of a breakpoint. You
@@ -617,12 +617,12 @@ Note that this interface is only available for Emacs 25 and above.
    With a prefix argument :kbd:`C-u`, remove all the breakpoints.
 
 .. command:: elpy-pdb-break-at-point
-   :kbd: C-c C-g p
+   :kbd: C-c C-u p
 
    Run pdb on the current buffer and pause at the cursor position.
 
 .. command:: elpy-pdb-debug-last-exception
-   :kbd: C-c C-g e
+   :kbd: C-c C-u e
 
    Run post-mortem pdb on the last exception.
 

--- a/elpy.el
+++ b/elpy.el
@@ -500,14 +500,14 @@ This option need to bet set through `customize' or `customize-set-variable' to b
 
 (defvar elpy-pdb-map
   (let ((map (make-sparse-keymap)))
-    (define-key map (kbd "g") 'elpy-pdb-debug-buffer)
+    (define-key map (kbd "d") 'elpy-pdb-debug-buffer)
     (define-key map (kbd "p") 'elpy-pdb-break-at-point)
     (define-key map (kbd "e") 'elpy-pdb-debug-last-exception)
     (define-key map (kbd "b") 'elpy-pdb-toggle-breakpoint-at-point)
     map)
   "Key map for the shell related commands")
 (fset 'elpy-pdb-map elpy-pdb-map)
-(define-key elpy-mode-map (kbd "C-c C-g") 'elpy-pdb-map)
+(define-key elpy-mode-map (kbd "C-c C-u") 'elpy-pdb-map)
 
 (easy-menu-define elpy-menu elpy-mode-map
   "Elpy Mode Menu"


### PR DESCRIPTION
# PR Summary
Follow # 1635.

Change elpy-pdb keybindings, from `C-c C-g` to `C-c C-u`.

# PR checklist

Please make sure that the following things have been addressed (and check the relevant checkboxes):

- [x] Commits respect our [guidelines](../CONTRIBUTING.rst)
- [x] Tests are passing properly (see [here](https://elpy.readthedocs.io/en/latest/extending.html#running-tests) on how to run Elpy's tests)
- [x] The documentation has been updated
