### PR TITLE
Removed hard-written occurences of "python"

### DIFF
--- a/elpy.el
+++ b/elpy.el
@@ -325,8 +325,10 @@ edited instead. Setting this variable to nil disables this feature."
   :safe 'elpy-test-runner-p
   :group 'elpy)
 
-(defcustom elpy-test-discover-runner-command '("python" "-m" "unittest")
-  "The command to use for `elpy-test-discover-runner'."
+(defcustom elpy-test-discover-runner-command '("python-shell-interpreter" "-m" "unittest")
+  "The command to use for `elpy-test-discover-runner'.
+If the string \"python-shell-interpreter\" is present, it will be replaced with
+the value of `python-shell-interpreter'."
   :type '(repeat string)
   :group 'elpy)
 
@@ -2010,6 +2012,15 @@ This uses the `elpy-test-runner-p' symbol property."
                         (cons command args)
                         " "))))
 
+(defun elpy-test-get-discover-runner ()
+  "Return the test discover runner from `elpy-test-discover-runner-command'."
+  (cl-loop
+   for string in elpy-test-discover-runner-command
+   if (string= string "python-shell-interpreter")
+   collect python-shell-interpreter
+   else
+   collect string))
+
 (defun elpy-test-discover-runner (top _file module test)
   "Test the project using the python unittest discover runner.
 
@@ -2021,7 +2032,7 @@ This requires Python 2.7 or later."
                (t "discover"))))
     (apply #'elpy-test-run
            top
-           (append elpy-test-discover-runner-command
+           (append (elpy-test-get-discover-runner)
                    (list test)))))
 (put 'elpy-test-discover-runner 'elpy-test-runner-p t)
 

--- a/test/elpy-black-fix-code-test.el
+++ b/test/elpy-black-fix-code-test.el
@@ -4,7 +4,8 @@
     (setq *elpy-black-fix-code--black-supported*
           (not (string< (or (getenv "TRAVIS_PYTHON_VERSION")
                             (with-temp-buffer
-                              (call-process "python" nil '(t t) nil "--version")
+                              (call-process elpy-rpc-python-command
+                                            nil '(t t) nil "--version")
                               (goto-char (point-min))
                               (re-search-forward "\\([0-9.]+\\)" nil t)
                               (or (match-string 1) "")))

--- a/test/elpy-rpc--find-buffer-test.el
+++ b/test/elpy-rpc--find-buffer-test.el
@@ -3,9 +3,9 @@
     (mletf* ((buffer (current-buffer))
              (elpy-rpc--process-buffer-p (buf) (equal buf buffer)))
       (setq elpy-rpc--backend-library-root "test-project"
-            elpy-rpc--backend-python-command (executable-find "python"))
+            elpy-rpc--backend-python-command (executable-find elpy-rpc-python-command))
       (should (equal (elpy-rpc--find-buffer "test-project"
-                                            "python")
+                                            elpy-rpc-python-command)
                      (current-buffer))))))
 
 (ert-deftest elpy-rpc--find-buffer-should-not-find-without-process-buffer ()
@@ -13,10 +13,10 @@
     (mletf* ((buffer (current-buffer))
              (elpy-rpc--process-buffer-p (buf) nil))
       (setq elpy-rpc--backend-library-root "test-project"
-            elpy-rpc--backend-python-command (executable-find "python"))
+            elpy-rpc--backend-python-command (executable-find elpy-rpc-python-command))
 
       (should (equal (elpy-rpc--find-buffer "test-project"
-                                            "python")
+                                            elpy-rpc-python-command)
                      nil)))))
 
 (ert-deftest elpy-rpc--find-buffer-should-not-find-with-bad-project-root ()
@@ -24,10 +24,10 @@
     (mletf* ((buffer (current-buffer))
              (elpy-rpc--process-buffer-p (buf) t))
       (setq elpy-rpc--backend-library-root "bad-test-project"
-            elpy-rpc--backend-python-command (executable-find "python"))
+            elpy-rpc--backend-python-command (executable-find elpy-rpc-python-command))
 
       (should (equal (elpy-rpc--find-buffer "test-project"
-                                            "python")
+                                            elpy-rpc-python-command)
                      nil)))))
 
 (ert-deftest elpy-rpc--find-buffer-should-not-find-without-bad-python-command ()

--- a/test/elpy-rpc--open-test.el
+++ b/test/elpy-rpc--open-test.el
@@ -20,13 +20,13 @@
               (proc fun)
               (when (eq proc 'test-process)
                 (setq filter fun))))
-      (with-current-buffer (elpy-rpc--open "/tmp" "python")
+      (with-current-buffer (elpy-rpc--open "/tmp" elpy-rpc-python-command)
         (should elpy-rpc--buffer-p)
         (should (equal requested-library-root "/tmp"))
         (should (equal elpy-rpc--buffer (current-buffer)))
         (should (equal elpy-rpc--backend-library-root "/tmp"))
         (should (equal elpy-rpc--backend-python-command
-                       (executable-find "python")))
+                       (executable-find elpy-rpc-python-command)))
         (should (equal default-directory "/"))
         (should (equal exit-flag-disabled-for 'test-process))
         (should (equal sentinel 'elpy-rpc--sentinel))
@@ -43,16 +43,16 @@
              (set-process-sentinel (proc fun) nil)
              (set-process-filter (proc fun) nil))
 
-      (elpy-rpc--open "/tmp" "python")
+      (elpy-rpc--open "/tmp" elpy-rpc-python-command)
 
       (should (equal environment "test-environment")))))
 
 (ert-deftest elpy-rpc--open-should-include-full-path ()
   (elpy-testcase ()
-    (let ((buf (elpy-rpc--open "/tmp" "python")))
-      (should (string-match (executable-find "python")
+    (let ((buf (elpy-rpc--open "/tmp" elpy-rpc-python-command)))
+      (should (string-match (executable-find elpy-rpc-python-command)
                             (buffer-name buf)))
       (should
        (equal (buffer-local-value 'elpy-rpc--backend-python-command
                                   buf)
-              (executable-find "python"))))))
+              (executable-find elpy-rpc-python-command))))))

--- a/test/elpy-test-discover-runner-test.el
+++ b/test/elpy-test-discover-runner-test.el
@@ -12,7 +12,7 @@
       (elpy-test-discover-runner "/project/root/" nil nil nil)
 
       (should (equal command
-                     '("python" "-m" "unittest" "discover")))
+                     (list python-shell-interpreter "-m" "unittest" "discover")))
       (should (equal top "/project/root/")))))
 
 (ert-deftest elpy-test-discover-runner-should-run-test-module ()
@@ -28,7 +28,7 @@
                                  nil)
 
       (should (equal command
-                     '("python" "-m" "unittest"
+                     (list python-shell-interpreter "-m" "unittest"
                        "package.module")))
       (should (equal top "/project/root/")))))
 
@@ -45,7 +45,7 @@
                                  "TestClass")
 
       (should (equal command
-                     '("python" "-m" "unittest"
+                     (list python-shell-interpreter "-m" "unittest"
                        "package.module.TestClass")))
       (should (equal top "/project/root/")))))
 
@@ -62,6 +62,6 @@
                                  "TestClass.test_method")
 
       (should (equal command
-                     '("python" "-m" "unittest"
+                     (list python-shell-interpreter "-m" "unittest"
                        "package.module.TestClass.test_method")))
       (should (equal top "/project/root/")))))


### PR DESCRIPTION
# PR Summary
Follow #1636 
Remove hard-written occurrences of "python" from Elpy's code in favor of `python-shell-interpreter`.

This will avoid test failure and weird behaviour when using python binaries with exotic names.

# PR checklist

Please make sure that the following things have been addressed (and check the relevant checkboxes):

- [x] Commits respect our [guidelines](../CONTRIBUTING.rst)
- [x] Tests are passing properly (see [here](https://elpy.readthedocs.io/en/latest/extending.html#running-tests) on how to run Elpy's tests)
