### PR TITLE
Replace pdb snippet with a oneliner

### DIFF
--- a/snippets/python-mode/pdb
+++ b/snippets/python-mode/pdb
@@ -3,4 +3,4 @@
 # key: pdb
 # group: Debug
 # --
-import pdb; pdb.set_trace()
+__import__("pdb").set_trace()


### PR DESCRIPTION
# PR Summary
Follow #1643. 

Replace the snippet triggered by `pdb` from `import pdb; pdb.set_trace()` to `__import__("pdb").set_trace()`.
The new value has the advantage of being a oneliner and of being less confusing for automatic formaters.

# PR checklist

Please make sure that the following things have been addressed (and check the relevant checkboxes):

- [x] Commits respect our [guidelines](../CONTRIBUTING.rst)
- [x] Tests are passing properly (see [here](https://elpy.readthedocs.io/en/latest/extending.html#running-tests) on how to run Elpy's tests)
