### PR TITLE
Add a variable to customize Elpy's RPC path

### DIFF
--- a/docs/concepts.rst
+++ b/docs/concepts.rst
@@ -44,6 +44,16 @@ There are a few options and commands related to the RPC process.
    Please do note that this is *not* an interactive interpreter, so do
    not set this to ``"ipython"`` or similar.
 
+.. option:: elpy-rpc-venv-path
+
+   Path to the virtualenv used by the RPC.
+   This defaults to a virtualenv named ``"elpy-rpc-venv"``, created in
+   the current workon home (returned by ``(pyvenv-workon-home)``).
+
+   If it does not exist, the virtualenv will be created using
+   ``elpy-rpc-python-command'` and populated with the needed
+   packages from ``(elpy-rpc--get-package-list)``.")
+
 .. option:: elpy-rpc-large-buffer-size
 
    The size in character starting from which Elpy will transfer buffer

--- a/docs/concepts.rst
+++ b/docs/concepts.rst
@@ -22,7 +22,7 @@ RPC processes are used to provide code completion, documentation and
 other features. To do so, they use python packages (jedi, yapf, rope, ...)
 that are installed in a dedicated virtualenv
 (``.emacs.d/elpy/rpc-venv`` by default). Those packages can be updated
-through the configuration panel (accessible through :kbd:`M-x
+through the configuration panel (accessible with :kbd:`M-x
 elpy-config`).
 
 By default, Elpy will also find the :index:`library root` of the
@@ -48,15 +48,15 @@ There are a few options and commands related to the RPC process.
 .. option:: elpy-rpc-virtualenv-path
 
    Path to the virtualenv used by the RPC.
-   This defaults to a virtualenv in ``".emacs.d/elpy/rpc-venv"``.
 
-   Can be a path, a function returning a path, ``'global`` (use the
-   global system environment) or ``'current`` (use the currently
-   active environment).
+   Can be `default` (create a dedicated virtualenv
+   ``.emacs.d/elpy/rpc-venv``), `global` (use the global system
+   environment), `current` (use the currently active environment), a
+   virtualenv path or a function returning a virtualenv path.
 
    If the default virtual environment does not exist, it will be
-   created using ``elpy-rpc-python-command'` and populated with the
-   needed packages from ``(elpy-rpc--get-package-list)``.
+   created using `elpy-rpc-python-command` and populated with the
+   needed packages from `elpy-rpc--get-package-list`.
 
 .. option:: elpy-rpc-large-buffer-size
 

--- a/docs/concepts.rst
+++ b/docs/concepts.rst
@@ -20,8 +20,8 @@ well as in the buffer list (:kbd:`C-x C-b`) as buffers named
 
 RPC processes are used to provide code completion, documentation and
 other features. To do so, they use python packages (jedi, yapf,
-rope, ...) that are installed in a dedicated virtualenv named
-``elpy-rpc-venv``. Those packages can be updated through the
+rope, ...) that are installed in a dedicated virtualenv in
+``.emacs.d/elpy/rpc-venv``. Those packages can be updated through the
 configuration panel (accessible through :kbd:`M-x elpy-config`).
 
 By default, Elpy will also find the :index:`library root` of the
@@ -47,7 +47,7 @@ There are a few options and commands related to the RPC process.
 .. option:: elpy-rpc-venv-path
 
    Path to the virtualenv used by the RPC.
-   This defaults to a virtualenv named ``"elpy-rpc-venv"``, created in
+   This defaults to a virtualenv in ``".emacs.d/elpy/rpc-venv"``, created in
    the current workon home (returned by ``(pyvenv-workon-home)``).
 
    If it does not exist, the virtualenv will be created using

--- a/docs/concepts.rst
+++ b/docs/concepts.rst
@@ -19,10 +19,11 @@ well as in the buffer list (:kbd:`C-x C-b`) as buffers named
 ``*elpy-rpc[...]*``.
 
 RPC processes are used to provide code completion, documentation and
-other features. To do so, they use python packages (jedi, yapf,
-rope, ...) that are installed in a dedicated virtualenv in
-``.emacs.d/elpy/rpc-venv``. Those packages can be updated through the
-configuration panel (accessible through :kbd:`M-x elpy-config`).
+other features. To do so, they use python packages (jedi, yapf, rope, ...)
+that are installed in a dedicated virtualenv
+(``.emacs.d/elpy/rpc-venv`` by default). Those packages can be updated
+through the configuration panel (accessible through :kbd:`M-x
+elpy-config`).
 
 By default, Elpy will also find the :index:`library root` of the
 current file and pass that to the RPC functions. The library root is
@@ -44,15 +45,19 @@ There are a few options and commands related to the RPC process.
    Please do note that this is *not* an interactive interpreter, so do
    not set this to ``"ipython"`` or similar.
 
-.. option:: elpy-rpc-venv-path
+.. option:: elpy-rpc-virtualenv-path
 
    Path to the virtualenv used by the RPC.
-   This defaults to a virtualenv in ``".emacs.d/elpy/rpc-venv"``, created in
-   the current workon home (returned by ``(pyvenv-workon-home)``).
+   This defaults to a virtualenv in ``".emacs.d/elpy/rpc-venv"``.
 
    If it does not exist, the virtualenv will be created using
    ``elpy-rpc-python-command'` and populated with the needed
    packages from ``(elpy-rpc--get-package-list)``.")
+
+   Before version 1.32, elpy was starting the RPC in the current
+   environment. You can get this behavior back by setting
+   ``elpy-rpc-virtualenv-path`` to ``(lambda () (or pyvenv-virtual-env
+   (elpy-rpc-default-virtualenv-path)))``.
 
 .. option:: elpy-rpc-large-buffer-size
 

--- a/docs/concepts.rst
+++ b/docs/concepts.rst
@@ -50,14 +50,13 @@ There are a few options and commands related to the RPC process.
    Path to the virtualenv used by the RPC.
    This defaults to a virtualenv in ``".emacs.d/elpy/rpc-venv"``.
 
-   If it does not exist, the virtualenv will be created using
-   ``elpy-rpc-python-command'` and populated with the needed
-   packages from ``(elpy-rpc--get-package-list)``.")
+   Can be a path, a function returning a path, ``'global`` (use the
+   global system environment) or ``'current`` (use the currently
+   active environment).
 
-   Before version 1.32, elpy was starting the RPC in the current
-   environment. You can get this behavior back by setting
-   ``elpy-rpc-virtualenv-path`` to ``(lambda () (or pyvenv-virtual-env
-   (elpy-rpc-default-virtualenv-path)))``.
+   If the default virtual environment does not exist, it will be
+   created using ``elpy-rpc-python-command'` and populated with the
+   needed packages from ``(elpy-rpc--get-package-list)``.
 
 .. option:: elpy-rpc-large-buffer-size
 

--- a/elpy-rpc.el
+++ b/elpy-rpc.el
@@ -188,11 +188,10 @@ packages from `elpy-rpc--get-package-list'."
 
 (defun elpy-rpc-get-virtualenv-path ()
   "Return the RPC virutalenv path to use."
-  (let ((rpc-venv-path
-         (if (stringp elpy-rpc-virtualenv-path)
-             elpy-rpc-virtualenv-path
-           (funcall elpy-rpc-virtualenv-path))))
-    rpc-venv-path))
+  (expand-file-name
+   (if (stringp elpy-rpc-virtualenv-path)
+       elpy-rpc-virtualenv-path
+       (funcall elpy-rpc-virtualenv-path))))
 
 (defun elpy-rpc--get-package-list ()
   "Return the list of packages to be installed in the RPC virtualenv."
@@ -271,13 +270,14 @@ binaries used to create the virtualenv."
                                 is-default-rpc-venv
                                 (not (string= venv-python-path-command
                                               elpy-rpc-python-command))))
-         (venv-creation-allowed (or is-default-rpc-venv
-                                    (and
-                                     (not is-venv-exist)
-                                     (y-or-n-p
-                                      (format
-                                       "Elpy RPC virtualenv was set to '%s', but this virtualenv does not exist, create it ?"
-                                       rpc-venv-path))))))
+         (venv-creation-allowed (and
+                                 (not is-venv-exist)
+                                 (y-or-n-p
+                                  (if is-default-rpc-venv
+                                      (format "Elpy needs a virtualenv to provide static code analysis, create one in '%s' ?" rpc-venv-path)
+                                    (format
+                                     "`elpy-rpc-virtualenv-path' was set to '%s', but this virtualenv does not exist, create it ?"
+                                     rpc-venv-path))))))
     ;; Delete the rpc virtualenv if obsolete
     (when venv-need-update
       (delete-directory rpc-venv-path t)
@@ -285,10 +285,10 @@ binaries used to create the virtualenv."
     ;; Create a new rpc venv if necessary
     (unless is-venv-exist
       (if (not venv-creation-allowed)
-          (message "Please set `elpy-rpc-virtualenv-path` to a proper value.")
+          (message "Please indicate the virtualenv you wish to use with `elpy-rpc-virtualenv-path'.")
         (let ((deact-venv pyvenv-virtual-env))
           ;; Create the venv
-          (message "Elpy is creating the RPC virtualenv... (This may take a while, but should only happen once in a while)")
+          (message "Elpy is creating the RPC virtualenv in '%s'" rpc-venv-path)
           ;; temporary workaround (waiting for  https://github.com/jorgenschaefer/pyvenv/pull/90 to be merged)
           ;; (save-window-excursion
           ;;   (pyvenv-create elpy-rpc-venv-name elpy-rpc-python-command))

--- a/elpy.el
+++ b/elpy.el
@@ -970,7 +970,8 @@ virtual_env_short"
         (puthash "rpc_virtualenv" rpc-venv config)
         (if rpc-venv
             (puthash "rpc_virtualenv_short"
-                     (file-name-nondirectory rpc-venv) config)
+                     (file-name-nondirectory (directory-file-name rpc-venv))
+                       config)
           (puthash "rpc_virtualenv_short" nil config)))
       (with-elpy-rpc-virtualenv-activated
        (puthash "rpc_python" elpy-rpc-python-command config)

--- a/elpy.el
+++ b/elpy.el
@@ -954,8 +954,8 @@ elpy_version
 python_interactive
 python_interactive_version
 python_interactive_executable
-rpc_venv
-rpc_venv_short
+rpc_virtualenv
+rpc_virtualenv_short
 rpc_python
 rpc_python_version
 rpc_python_executable
@@ -966,13 +966,13 @@ virtual_env_short"
   (with-temp-buffer
     (let ((config (make-hash-table :test #'equal)))
       (puthash "emacs_version" emacs-version config)
-      (let ((rpc-venv (elpy-rpc-get-or-create-venv)))
-        (puthash "rpc_venv" rpc-venv config)
+      (let ((rpc-venv (elpy-rpc-get-or-create-virtualenv)))
+        (puthash "rpc_virtualenv" rpc-venv config)
         (if rpc-venv
-            (puthash "rpc_venv_short"
+            (puthash "rpc_virtualenv_short"
                      (file-name-nondirectory rpc-venv) config)
-          (puthash "rpc_venv_short" nil config)))
-      (with-elpy-rpc-venv-activated
+          (puthash "rpc_virtualenv_short" nil config)))
+      (with-elpy-rpc-virtualenv-activated
        (puthash "rpc_python" elpy-rpc-python-command config)
        (puthash "rpc_python_executable"
                 (executable-find elpy-rpc-python-command)
@@ -998,7 +998,7 @@ virtual_env_short"
         (if venv
             (puthash "virtual_env_short" (file-name-nondirectory venv) config)
           (puthash "virtual_env_short" nil config)))
-      (with-elpy-rpc-venv-activated
+      (with-elpy-rpc-virtualenv-activated
        (let ((return-value (ignore-errors
                              (let ((process-environment
                                     (elpy-rpc--environment))
@@ -1037,8 +1037,8 @@ virtual_env_short"
         (rpc-python (gethash "rpc_python" config))
         (rpc-python-executable (gethash "rpc_python_executable" config))
         (rpc-python-version (gethash "rpc_python_version" config))
-        (rpc-venv (gethash "rpc_venv" config))
-        (rpc-venv-short (gethash "rpc_venv_short" config))
+        (rpc-virtualenv (gethash "rpc_virtualenv" config))
+        (rpc-virtualenv-short (gethash "rpc_virtualenv_short" config))
         (jedi-version (gethash "jedi_version" config))
         (jedi-latest (gethash "jedi_latest" config))
         (rope-version (gethash "rope_version" config))
@@ -1087,8 +1087,8 @@ virtual_env_short"
                   "Not configured")))
             ("RPC virtualenv"
               . ,(format "%s (%s)"
-                      rpc-venv-short
-                      rpc-venv))
+                      rpc-virtualenv-short
+                      rpc-virtualenv))
             ((" Python" (lambda ()
                              (customize-variable
                               'elpy-rpc-python-command)))
@@ -1251,7 +1251,7 @@ PyPI, or nil if that's VERSION."
 
 (defun elpy-insert--pip-button-action (widget &optional _event)
   "The :action option for the pip button widget."
-  (with-elpy-rpc-venv-activated
+  (with-elpy-rpc-virtualenv-activated
    (async-shell-command (widget-get widget :command))))
 
 ;;;;;;;;;;;;

--- a/test/elpy-config--get-config-test.el
+++ b/test/elpy-config--get-config-test.el
@@ -8,8 +8,8 @@
                      "python_interactive"
                      "python_interactive_version"
                      "python_interactive_executable"
-                     "rpc_venv"
-                     "rpc_venv_short"
+                     "rpc_virtualenv"
+                     "rpc_virtualenv_short"
                      "rpc_python"
                      "rpc_python_version"
                      "rpc_python_executable"
@@ -32,7 +32,7 @@
 
       (should (equal environment "test-environment")))))
 
-(ert-deftest elpy-config--get-config-should-be-evaluated-in-the-rpc-venv ()
+(ert-deftest elpy-config--get-config-should-be-evaluated-in-the-rpc-virtualenv ()
   (elpy-testcase ()
     (should (string-match "elpy-rpc-venv/bin/python"
                           (gethash "rpc_python_executable"

--- a/test/elpy-config--get-config-test.el
+++ b/test/elpy-config--get-config-test.el
@@ -34,6 +34,6 @@
 
 (ert-deftest elpy-config--get-config-should-be-evaluated-in-the-rpc-virtualenv ()
   (elpy-testcase ()
-    (should (string-match "elpy-rpc-venv/bin/python"
+    (should (string-match "elpy/rpc-venv/bin/python"
                           (gethash "rpc_python_executable"
                                    (elpy-config--get-config))))))

--- a/test/elpy-rpc--open-test.el
+++ b/test/elpy-rpc--open-test.el
@@ -26,7 +26,7 @@
         (should (equal elpy-rpc--buffer (current-buffer)))
         (should (equal elpy-rpc--backend-library-root "/tmp"))
         (should (equal elpy-rpc--backend-python-command
-                       (with-elpy-rpc-venv-activated
+                       (with-elpy-rpc-virtualenv-activated
                         (executable-find elpy-rpc-python-command))))
         (should (equal default-directory "/"))
         (should (equal exit-flag-disabled-for 'test-process))
@@ -48,7 +48,7 @@
 
       (should (equal environment "test-environment")))))
 
-(ert-deftest elpy-rpc--open-should-include-venv-name ()
+(ert-deftest elpy-rpc--open-should-include-virtualenv-name ()
   (elpy-testcase ()
     (let ((buf (elpy-rpc--open "/tmp" elpy-rpc-python-command)))
       (should (string-match (directory-file-name
@@ -60,11 +60,11 @@
       (should
        (equal (buffer-local-value 'elpy-rpc--backend-python-command
                                   buf)
-              (with-elpy-rpc-venv-activated
+              (with-elpy-rpc-virtualenv-activated
                (executable-find elpy-rpc-python-command)))))))
 
-(ert-deftest elpy-rpc--open-should-open-in-a-dedicated-venv ()
+(ert-deftest elpy-rpc--open-should-open-in-a-dedicated-virtualenv ()
   (elpy-testcase ()
     (elpy-rpc--get-rpc-buffer)
-    (with-elpy-rpc-venv-activated
+    (with-elpy-rpc-virtualenv-activated
      (should (string= "elpy-rpc-venv" pyvenv-virtual-env-name)))))

--- a/test/elpy-rpc--open-test.el
+++ b/test/elpy-rpc--open-test.el
@@ -67,4 +67,4 @@
   (elpy-testcase ()
     (elpy-rpc--get-rpc-buffer)
     (with-elpy-rpc-virtualenv-activated
-     (should (string= "elpy-rpc-venv" pyvenv-virtual-env-name)))))
+     (should (string= "rpc-venv" pyvenv-virtual-env-name)))))

--- a/test/elpy-rpc-get-venv-test.el
+++ b/test/elpy-rpc-get-venv-test.el
@@ -2,13 +2,13 @@
 
 (ert-deftest elpy-rpc-get-virtualenv-should-return-virtualenv ()
   (elpy-testcase ()
-    (should (string-match "elpy-rpc-venv" (elpy-rpc-get-or-create-virtualenv)))))
+    (should (string-match "elpy/rpc-venv" (elpy-rpc-get-or-create-virtualenv)))))
 
 (ert-deftest elpy-rpc-get-virtualenv-should-create-the-virtualenv-if-necessary ()
   (elpy-testcase ()
-    (should (string-match "elpy-rpc-venv" (elpy-rpc-get-or-create-virtualenv)))
+    (should (string-match "elpy/rpc-venv" (elpy-rpc-get-or-create-virtualenv)))
     (delete-directory (elpy-rpc-get-or-create-virtualenv) t nil)
-    (should (string-match "elpy-rpc-venv" (elpy-rpc-get-or-create-virtualenv)))
+    (should (string-match "elpy/rpc-venv" (elpy-rpc-get-or-create-virtualenv)))
     (should (file-exists-p (elpy-rpc-get-or-create-virtualenv)))))
 
 (ert-deftest elpy-rpc-get-virtualenv-should-not-reinstall-the-virtualenv-every-time ()
@@ -38,10 +38,11 @@
      ;; the cookie file
      (with-temp-file venv-python-path-command-file
        (insert "Another python command")))
-   (mletf* ((message (mess) (setq messages (concat messages mess)))
+   (mletf* ((message (mess &rest rest)
+                     (setq messages (concat messages (apply 'format mess rest))))
             (messages ""))
      (elpy-rpc-get-or-create-virtualenv)
-     (should (string-match "lpy is creating the RPC virtualenv" messages)))))
+     (should (string-match "lpy is \\(creating\\|updating\\) the RPC virtualenv" messages)))))
 
 (ert-deftest elpy-rpc-get-virtualenv-should-NOT-update-the-virtualenv-when-it-is-not-the-default-venv ()
   (elpy-testcase ()

--- a/test/elpy-rpc-get-venv-test.el
+++ b/test/elpy-rpc-get-venv-test.el
@@ -1,20 +1,62 @@
 ;;; -*-coding: utf-8-*-
 
-(ert-deftest elpy-rpc-get-venv-should-return-venv ()
+(ert-deftest elpy-rpc-get-virtualenv-should-return-virtualenv ()
   (elpy-testcase ()
-    (should (string-match "elpy-rpc-venv" (elpy-rpc-get-or-create-venv)))))
+    (should (string-match "elpy-rpc-venv" (elpy-rpc-get-or-create-virtualenv)))))
 
-(ert-deftest elpy-rpc-get-venv-should-create-the-venv-if-necessary ()
+(ert-deftest elpy-rpc-get-virtualenv-should-create-the-virtualenv-if-necessary ()
   (elpy-testcase ()
-    (should (string-match "elpy-rpc-venv" (elpy-rpc-get-or-create-venv)))
-    (delete-directory (elpy-rpc-get-or-create-venv) t nil)
-    (should (string-match "elpy-rpc-venv" (elpy-rpc-get-or-create-venv)))
-    (should (file-exists-p (elpy-rpc-get-or-create-venv)))))
+    (should (string-match "elpy-rpc-venv" (elpy-rpc-get-or-create-virtualenv)))
+    (delete-directory (elpy-rpc-get-or-create-virtualenv) t nil)
+    (should (string-match "elpy-rpc-venv" (elpy-rpc-get-or-create-virtualenv)))
+    (should (file-exists-p (elpy-rpc-get-or-create-virtualenv)))))
 
-(ert-deftest elpy-rpc-get-venv-should-not-perturbate-the-current-venv ()
+(ert-deftest elpy-rpc-get-virtualenv-should-not-reinstall-the-virtualenv-every-time ()
+  (elpy-testcase ()
+   (elpy-rpc-get-or-create-virtualenv)
+   (mletf* ((message (mess) (setq messages (concat messages mess)))
+            (messages ""))
+     (elpy-rpc-get-or-create-virtualenv)
+     (should-not (string-match "lpy is creating the RPC virtualenv"
+                               messages)))))
+
+(ert-deftest elpy-rpc-get-virtualenv-should-not-perturbate-the-current-virtualenv ()
   (elpy-testcase ()
     (let ((old-venv pyvenv-virtual-env))
       (pyvenv-workon "elpy-test-venv")
-      (elpy-rpc-get-or-create-venv)
+      (elpy-rpc-get-or-create-virtualenv)
       (should (string= pyvenv-virtual-env-name "elpy-test-venv"))
       (pyvenv-workon old-venv))))
+
+(ert-deftest elpy-rpc-get-virtualenv-should-update-the-virtualenv-when-rpc-command-change ()
+  (elpy-testcase ()
+   (let ((rpc-venv-path (elpy-rpc-get-or-create-virtualenv))
+         (venv-python-path-command-file
+          (concat (file-name-as-directory (elpy-rpc-get-virtualenv-path))
+                  "elpy-rpc-python-path-command")))
+     ;; Simulate a modification of `elpy-rpc-python-command' by modifying
+     ;; the cookie file
+     (with-temp-file venv-python-path-command-file
+       (insert "Another python command")))
+   (mletf* ((message (mess) (setq messages (concat messages mess)))
+            (messages ""))
+     (elpy-rpc-get-or-create-virtualenv)
+     (should (string-match "lpy is creating the RPC virtualenv" messages)))))
+
+(ert-deftest elpy-rpc-get-virtualenv-should-NOT-update-the-virtualenv-when-it-is-not-the-default-venv ()
+  (elpy-testcase ()
+   (let ((elpy-rpc-virtualenv-path (concat
+                                    (file-name-as-directory (pyvenv-workon-home))
+                                    "elpy-test-venv")))
+   (mletf* ((message (mess) (setq messages (concat messages mess)))
+            (messages ""))
+     (elpy-rpc-get-or-create-virtualenv)
+     (should-not (string-match "lpy is installing the RPC virtualenv" messages))))))
+
+(ert-deftest elpy-rpc-get-virtualenv-should-ask-before-creating-venvs ()
+  (elpy-testcase ()
+   (mletf* ((elpy-rpc-virtualenv-path "other-venv")
+            (was-asked nil)
+            (y-or-n-p (prompt) (setq was-asked t) nil))
+     (elpy-rpc-get-or-create-virtualenv)
+     (should was-asked))))

--- a/test/elpy-rpc-get-virtualenv-path-test.el
+++ b/test/elpy-rpc-get-virtualenv-path-test.el
@@ -1,0 +1,38 @@
+;;; -*-coding: utf-8-*-
+
+
+(ert-deftest elpy-rpc-get-virtualenv-path-should-return-default-path ()
+  (elpy-testcase ()
+    (should (string-match "elpy/rpc-venv" (elpy-rpc-get-virtualenv-path)))
+    (pyvenv-workon "elpy-test-venv")
+    (should (string-match "elpy/rpc-venv" (elpy-rpc-get-virtualenv-path)))
+    (pyvenv-deactivate)))
+
+(ert-deftest elpy-rpc-get-virtualenv-path-should-return-current-venv-path ()
+  (elpy-testcase ()
+    (let ((elpy-rpc-virtualenv-path 'current))
+      (should (string-match "\\(travis/virtualenv/python\\|.virtualenvs/elpy\\)"
+                            (elpy-rpc-get-virtualenv-path)))
+      (pyvenv-workon "elpy-test-venv")
+      (should (string-match "elpy-test-venv" (elpy-rpc-get-virtualenv-path)))
+      (pyvenv-deactivate))))
+
+(ert-deftest elpy-rpc-get-virtualenv-path-should-return-global-venv-path ()
+  (elpy-testcase ()
+    (let ((elpy-rpc-virtualenv-path 'global))
+      (should (string-match "\\(travis/virtualenv/python\\|.virtualenvs/elpy\\)"
+                            (elpy-rpc-get-virtualenv-path)))
+      (pyvenv-workon "elpy-test-venv")
+      (should (string-match "\\(travis/virtualenv/python\\|.virtualenvs/elpy\\)"
+                            (elpy-rpc-get-virtualenv-path)))
+      (pyvenv-deactivate))))
+
+(ert-deftest elpy-rpc-get-virtualenv-path-should-return-custom-venv ()
+  (elpy-testcase ()
+    (let ((elpy-rpc-virtualenv-path "elpy-test-venv"))
+      (should (string-match "elpy-test-venv" (elpy-rpc-get-virtualenv-path))))))
+
+(ert-deftest elpy-rpc-get-virtualenv-path-should-return-custom-venv-with-fun ()
+  (elpy-testcase ()
+    (let ((elpy-rpc-virtualenv-path (lambda () "elpy-test-venv")))
+      (should (string-match "elpy-test-venv" (elpy-rpc-get-virtualenv-path))))))

--- a/test/elpy-with-rpc-venv-activated-test.el
+++ b/test/elpy-with-rpc-venv-activated-test.el
@@ -1,17 +1,17 @@
 ;;; -*-coding: utf-8-*-
 
-(ert-deftest elpy-with-rpc-venv-activated-should-temporarily-activate-the-rpc-venv ()
+(ert-deftest elpy-with-rpc-virtualenv-activated-should-temporarily-activate-the-rpc-virtualenv ()
   (elpy-testcase ()
     (let ((current-venv pyvenv-virtual-env-name))
-    (with-elpy-rpc-venv-activated
+    (with-elpy-rpc-virtualenv-activated
      (should (string= pyvenv-virtual-env-name "elpy-rpc-venv")))
     (should (string= pyvenv-virtual-env-name current-venv)))))
 
-(ert-deftest elpy-with-rpc-venv-activated-should-handle-errors ()
+(ert-deftest elpy-with-rpc-virtualenv-activated-should-handle-errors ()
   (elpy-testcase ()
     (let ((current-venv pyvenv-virtual-env-name))
       (condition-case nil
-          (with-elpy-rpc-venv-activated
+          (with-elpy-rpc-virtualenv-activated
            (error "nope"))
           (error t))
     (should (string= pyvenv-virtual-env-name current-venv)))))

--- a/test/elpy-with-rpc-venv-activated-test.el
+++ b/test/elpy-with-rpc-venv-activated-test.el
@@ -4,7 +4,7 @@
   (elpy-testcase ()
     (let ((current-venv pyvenv-virtual-env-name))
     (with-elpy-rpc-virtualenv-activated
-     (should (string= pyvenv-virtual-env-name "elpy-rpc-venv")))
+     (should (string= pyvenv-virtual-env-name "rpc-venv")))
     (should (string= pyvenv-virtual-env-name current-venv)))))
 
 (ert-deftest elpy-with-rpc-virtualenv-activated-should-handle-errors ()


### PR DESCRIPTION
# PR Summary
Follow #1652.  

PR #1548 broke some users workflow by enforcing the use of a given virtualenv for Elpy's RPC.
This doesn't allow users to have full control of the package version they want to be installed in the RPC.

This PR introduces a new option `elpy-rpc-venv-path` that allows customizing the virtualenv used by the RPC.

### Cases:
 - I want the last version of the RPC packages: do nothing
 - I want the RPC to use a specific virtualenv where I can control the packages version: `(setq elpy-rpc-venv-path "/path/to/the/RPC/venv")`
- I want the RPC to use the current virtualenv: `(setq elpy-rpc-venv-path (lambda () pyvenv-virtual-env))`

### Todo list
- [x] Make sure the different options for `elpy-rpc-virtualenv-path` work properly (`'global`, `'current`, path and function).
- [x] Add an option to start the RPC in the global env (like `/usr`)
- [x] Update the documentation
- [x] Update the tests (add new ones ?)
- [x] Add something to the documentation to describe the different cases