### PR TITLE
Make sure Django project roots are detected properly

### DIFF
--- a/elpy-django.el
+++ b/elpy-django.el
@@ -144,6 +144,13 @@ test arguments in `elpy-django-test-runner-args'."
           (expand-file-name (concat (locate-dominating-file default-directory "manage.py") "manage.py")))
     (elpy-django 1)))
 
+(defun elpy-project-find-django-root ()
+  "Return the current Django project root, if any.
+
+This is marked with 'manage.py' or 'django-admin.py'."
+  (or (locate-dominating-file default-directory "django-admin.py")
+      (locate-dominating-file default-directory "manage.py")))
+
 (defun elpy-django--get-commands ()
   "Return list of django commands."
   (let ((dj-commands-str nil)
@@ -269,7 +276,12 @@ servers running per project.
 When called with a prefix (C-u), it will prompt for additional args."
   (interactive "P")
   (let* ((cmd (concat elpy-django-command " " elpy-django-server-command))
-         (proj-root (file-name-base (directory-file-name (elpy-project-root))))
+         (proj-root (if (elpy-project-root)
+                        (file-name-base (directory-file-name
+                                         (elpy-project-root)))
+                      (message "Elpy cannot find the root of the current django project. Starting the server in the current directory: '%s'."
+                               default-directory)
+                      default-directory))
          (buff-name (format "*runserver[%s]*" proj-root)))
     ;; Kill any previous instance of runserver since we might be doing something new
     (when (get-buffer buff-name)

--- a/elpy.el
+++ b/elpy.el
@@ -169,7 +169,9 @@ These will be checked in turn. The first directory found is used."
               (const :tag "Mercurial project root (.hg)"
                      elpy-project-find-hg-root)
               (const :tag "Subversion project root (.svn)"
-                     elpy-project-find-svn-root))
+                     elpy-project-find-svn-root)
+              (const :tag "Django project root (manage.py, django-admin.py)"
+                     elpy-project-find-django-root))
   :group 'elpy)
 
 (make-obsolete-variable 'elpy-company-hide-modeline
@@ -1284,7 +1286,7 @@ this."
 (defun elpy-project-find-python-root ()
   "Return the current Python project root, if any.
 
-This is marked with setup.py, setup.cfg or pyproject.toml."
+This is marked with 'setup.py', 'setup.cfg' or 'pyproject.toml'."
   (or (locate-dominating-file default-directory "setup.py")
       (locate-dominating-file default-directory "setup.cfg")
       (locate-dominating-file default-directory "pyproject.toml")))
@@ -3245,6 +3247,13 @@ display the current class and method instead."
 (defun elpy-module-django (command &rest _args)
   "Module to provide Django support."
   (pcase command
+    (`global-init
+     (add-to-list 'elpy-project-root-finder-functions
+                  'elpy-project-find-django-root t))
+    (`global-stop
+     (setq elpy-project-root-finder-functions
+           (remove 'elpy-project-find-django-root
+                   elpy-project-root-finder-functions)))
     (`buffer-init
      (elpy-django-setup))
     (`buffer-stop

--- a/test/elpy-project-find-django-root-test.el
+++ b/test/elpy-project-find-django-root-test.el
@@ -1,0 +1,15 @@
+(ert-deftest elpy-project-find-django-root-should-find-setup-py ()
+  (elpy-testcase ((:project project-root
+                            "django-admin.py"
+                            "foo/bar.py"))
+    (find-file (f-join project-root "foo/bar.py"))
+    (should (f-equal? (elpy-project-find-django-root)
+                      project-root))))
+
+(ert-deftest elpy-project-find-django-root-should-find-setup-cfg ()
+  (elpy-testcase ((:project project-root
+                            "manage.py"
+                            "foo/bar.cfg"))
+    (find-file (f-join project-root "foo/bar.cfg"))
+    (should (f-equal? (elpy-project-find-django-root)
+                      project-root))))


### PR DESCRIPTION
# PR Summary
Follow #1654. 

Elpy is currently using projectile files (`.projectile`), python package files (`setup.py`, `pyproject.toml`, ...) and vcs files (`.git`, `.svn`, `.hg`, ...) to detect where the project root is.

This PR add `manage.py` and `django-admin.py` to the list of detected files when `django-mode` is activated. This can be useful for Django users that do not use projectile and vcs.

# PR checklist

Please make sure that the following things have been addressed (and check the relevant checkboxes):

- [x] Commits respect our [guidelines](../CONTRIBUTING.rst)
- [x] Tests are passing properly (see [here](https://elpy.readthedocs.io/en/latest/extending.html#running-tests) on how to run Elpy's tests)
- [x] Tests has been added to cover the change
