### PR TITLE
Fix 1550: Minimize length of string sent to process-send-string

### DIFF
--- a/elpy-shell.el
+++ b/elpy-shell.el
@@ -263,7 +263,9 @@ If ASK-FOR-EACH-ONE is non-nil, ask before killing each python process."
 
 If SIT is non-nil, sit for that many seconds after creating a
 Python process. This allows the process to start up."
-  (let* ((bufname (format "*%s*" (python-shell-get-process-name nil)))
+  (let* ((process-connection-type
+          (if (string-equal system-type "darwin") nil t))  ;; see https://github.com/jorgenschaefer/elpy/pull/1671
+         (bufname (format "*%s*" (python-shell-get-process-name nil)))
          (proc (get-buffer-process bufname)))
     (if proc
         proc

--- a/test/elpy-module-yasnippet-test.el
+++ b/test/elpy-module-yasnippet-test.el
@@ -34,8 +34,8 @@
 
 (ert-deftest elpy-snippet-split-args ()
   (elpy-testcase ()
+    (elpy-enable)
     (python-mode)
-    (elpy-mode)
     (let ((args "self, arg1, arg2 :int, arg3=4, arg4='message', arg5 :int, arg6 :float=65.4, *args, **kwargs"))
       (should (equal (elpy-snippet-split-args args)
 	     '("self" "arg1" "arg2" "arg3" "arg4" "arg5" "arg6" "*args" "**kwargs"))))

--- a/test/elpy-shell-send-file-test.el
+++ b/test/elpy-shell-send-file-test.el
@@ -1,0 +1,11 @@
+(ert-deftest elpy-shell-send-file-should-accept-large-strings ()
+  (elpy-testcase ()
+   (elpy-enable)
+   (python-mode)
+   (let ((test-string (make-string 6000 ?a))
+         (process (elpy-shell-get-or-create-process)))
+     (python-shell-send-string
+      (format "print('start');foo='%s';print('end');" test-string) process)
+     (with-current-buffer (process-buffer process)
+       (elpy/wait-for-output "start")
+       (should (string-match "end" (buffer-string)))))))


### PR DESCRIPTION
# PR Summary

Too long of a string causes the string to be sent in batches
due to the limit of the input buffer size of processes
on some machines.

https://github.com/jorgenschaefer/elpy/issues/1550

This reverts commit 740b0a046f8b1750d8fccd8e578df67efc04e927
and introduces an alternative fix for the performance
enhancement that commit introduced.

The notes and repro details below are copy/pasted from the 1550 issue thread. 

I can recreate this on-demand by changing the length of the string sent to `process-send-string`.

```
DEFUN ("process-send-string", Fprocess_send_string, Sprocess_send_string,
       2, 2, 0,
       doc: /* Send PROCESS the contents of STRING as input.
PROCESS may be a process, a buffer, the name of a process or buffer, or
nil, indicating the current buffer's process.
If STRING is larger than the input buffer of the process (the length
of which depends on the process connection type and the operating
system), it is sent in several bunches.  This may happen even for
shorter strings.  Output from processes can arrive in between bunches.

If PROCESS is a non-blocking network process that hasn't been fully
set up yet, this function will block until socket setup has completed.  */)
```

On my mac, Mojave 10.14.6 and Python 2.7.11, if I checkout `740b0a0~1` and make the following change, then I get the error.

```
diff --git a/elpy-shell.el b/elpy-shell.el
index d16baaf..1ce3e5d 100644
--- a/elpy-shell.el
+++ b/elpy-shell.el
@@ -628,6 +628,14 @@ print) the output of the last expression."
       (concat
        "import sys, codecs, os, ast;"
        "__pyfile = codecs.open('''%s''', encoding='''%s''');"
+	   "('abcdefgabcdefgabcdefgabcdefgabcdefgabcdefgabcdefgabcdefgabcdefg)"
+	   "('abcdefgabcdefgabcdefgabcdefgabcdefgabcdefgabcdefgabcdefgabcdefg)"
+	   "('abcdefgabcdefgabcdefgabcdefgabcdefgabcdefgabcdefgabcdefgabcdefg)"
+	   "('abcdefgabcdefgabcdefgabcdefgabcdefgabcdefgabcdefgabcdefgabcdefg)"
+	   "('abcdefgabcdefgabcdefgabcdefgabcdefgabcdefgabcdefgabcdefgabcdefg)"
+	   "('abcdefgabcdefgabcdefgabcdefgabcdefgabcdefgabcdefgabcdefgabcdefg)"
+	   "('abcdefgabcdefgabcdefgabcdefgabcdefgabcdefgabcdefgabcdefgabcdefg)"
+	   "('abcdefgabcdefgabcdefgabcdefgabcdefgabcdefgabcdefgabcdefgabcdefg)"
        "__code = __pyfile.read().encode('''%s''');"
        "__pyfile.close();"
        (when (and delete temp-file-name)
```

With that change, this is the error I see when I try to evaulate a buffer.

```
>>> print("HI")
...: print("BYE")
import codecs, os, ast;__pyfile = codecs.open('''/var/folders/jy/nwdc6ngd1012k8mqbb_3tz_c0000gn/T/pyoNfgqv''', encoding='''utf-8''');('abcdefgabcdefgabcdefgabcdefgabcdefgabcdefgabcdefgabcdefgabcdefg)('abcdefgabcdefgabcdefgabcdefgabcdefgabcdefgabcdefgabcdefgabcdefg)('abcdefgabcdefgabcdefgabcdefgabcdefgabcdefgabcdefgabcdefgabcdefg)('abcdefgabcdefgabcdefgabcdefgabcdefgabcdefgabcdefgabcdefgabcdefg)('abcdefgabcdefgabcdefgabcdefgabcdefgabcdefgabcdefgabcdefgabcdefg)('abcdefgabcdefgabcdefgabcdefgabcdefgabcdefgabcdefgabcdefgabcdefg)('abcdefgabcdefgabcdefgabcdefgabcdefgabcdefgabcdefgabcdefgabcdefg)('abcdefgabcdefgabcdefgabcdefgabcdefgabcdefgabcdefgabcdefgabcdefg)__code = __pyfile.read().encode('''utf-8''');__pyfile.close();os.remove('''/var/folders/jy/nwdc6ngd1012k8mqbb_3tz_c0000gn/T/pyoNfgqv''');__block = ast.parse(__code, '''/tmp/foo.py''', mode='exec');__block.body = __block.body if not isinstance(__block.body[0], ast.If) else __block.body if not isinstance(__block.body[0].test, ast.Name) else __block.body if not __
^G
^G
^G
```

Scroll to the right of that code block and you'll notice the string is truncated.

If I remove those lines that do nothing but increase the length of the string, I get the following output.

```
>>> print("HI")
...: print("BYE")
import codecs, os, ast;__pyfile = codecs.open('''/var/folders/jy/nwdc6ngd1012k8mqbb_3tz_c0000gn/T/pypUfhiS''', encoding='''utf-8''');__code = __pyfile.read().encode('''utf-8''');__pyfile.close();os.remove('''/var/folders/jy/nwdc6ngd1012k8mqbb_3tz_c0000gn/T/pypUfhiS''');__block = ast.parse(__code, '''/tmp/foo.py''', mode='exec');__block.body = __block.body if not isinstance(__block.body[0], ast.If) else __block.body if not isinstance(__block.body[0].test, ast.Name) else __block.body if not __block.body[0].test.id == 'True' else __block.body[0].body;__last = __block.body[-1];__isexpr = isinstance(__last,ast.Expr);_ = __block.body.pop() if __isexpr else None;exec(compile(__block, '''/tmp/foo.py''', mode='exec'));eval(compile(ast.Expression(__last.value), '''/tmp/foo.py''', mode='eval')) if __isexpr else None
HI
BYE
>>> 
```

That string is not truncated and my comint buffer doesn't break. I'm still curious why the `import codecs` line is being output. But at least the comint buffer doesn't break and start showing those `^G` symbols.

# PR checklist

Please make sure that the following things have been addressed (and check the relevant checkboxes):

- [ ] Commits respect our [guidelines](../CONTRIBUTING.rst)
- [ ] Tests are passing properly (see [here](https://elpy.readthedocs.io/en/latest/extending.html#running-tests) on how to run Elpy's tests)

## For new features only:
- [ ] Tests has been added to cover the change
- [ ] The documentation has been updated
