### PR TITLE
Allow to interact with buffers resulting from `elpy-django-cmd`

### DIFF
--- a/elpy-django.el
+++ b/elpy-django.el
@@ -266,10 +266,18 @@ it will prompt for other flags/arguments to run."
             elpy-django-always-prompt
             (member cmd elpy-django-commands-with-req-arg))
     (setq cmd (concat cmd " " (read-shell-command (concat cmd ": ") "--noinput"))))
+  ;;
   (cond ((string= cmd "shell")
          (run-python (concat elpy-django-command " shell -i python") t t))
         (t
-         (compile (concat elpy-django-command " " cmd)))))
+         (let* ((program (car (split-string elpy-django-command)))
+                (args (cdr (split-string elpy-django-command)))
+                (buffer-name (format "django-%s" (car (split-string cmd)))))
+           (when (get-buffer (format "*%s*" buffer-name))
+             (kill-buffer (format "*%s*" buffer-name)))
+           (pop-to-buffer
+            (apply 'make-comint buffer-name program nil
+                   (append args (split-string cmd))))))))
 
 (defun elpy-django-runserver (arg)
   "Start the server and automatically add the ipaddr and port.

--- a/requirements-rpc.txt
+++ b/requirements-rpc.txt
@@ -2,3 +2,4 @@ jedi==0.15.1
 rope==0.14.0
 autopep8==1.4.4
 yapf==0.28
+setuptools==41.2

--- a/test/elpy-module-django-test.el
+++ b/test/elpy-module-django-test.el
@@ -1,5 +1,6 @@
 ;; Better way of doing tests? Since, I actually need a Django project
 ;; to test out the `runserver' command
+
 (ert-deftest elpy-module-django-buffer-init ()
   "elpy-django should not be activated since it won't find the
 `manage.py' file."
@@ -36,15 +37,19 @@ default to `django-admin.py'."
     (should (string= "django-admin.py" elpy-django-command))))
 
 (ert-deftest elpy-module-django-command ()
-  (mletf* ((compile (arg) arg)
-           (output (elpy-django-command "migrate")))
+  (mletf* ((output nil)
+           (make-comint (bufname prog ignore cmd &rest rest)
+                        (setq output (concat prog " " cmd))))
+          (elpy-django-command "migrate")
           (should (string= output "django-admin.py migrate"))))
 
 (ert-deftest elpy-module-django-commands-with-required-arg ()
   (dolist (cmd elpy-django-commands-with-req-arg)
-    (mletf* ((compile (arg) arg)
-             (read-shell-command (arg1 agr2) "test")
-             (output (elpy-django-command cmd)))
+    (mletf* ((output nil)
+             (make-comint (bufname prog ignore cmd &rest rest)
+                          (setq output (concat prog " " cmd " " (car rest))))
+             (read-shell-command (arg1 agr2) "test"))
+            (elpy-django-command cmd)
             (should (string= output (concat "django-admin.py " cmd " test"))))))
 
 ;; Test the parsing. Also, another way of shortening string?
@@ -139,4 +144,3 @@ keys as regular expression"
                     (elpy-django--get-test-runner)))
 
           (should (equal (length elpy-django--test-runner-cache) 7))))
-          


### PR DESCRIPTION
# PR Summary
Follow #1672.

At the moment, Elpy is able to run Django commands (shell, createsuperuser, dbshell, ...) but does it with `compile` which does not allow to interact with the resulting buffers.

This PR switches from `compile` to `make-comint` to allow users interaction (using the shell, using the database shell, inputting passwords, ...).

# PR checklist

Please make sure that the following things have been addressed (and check the relevant checkboxes):

- [x] Commits respect our [guidelines](../CONTRIBUTING.rst)
- [x] Tests are passing properly (see [here](https://elpy.readthedocs.io/en/latest/extending.html#running-tests) on how to run Elpy's tests)