### PR TITLE
Make Python shell starting directory customizable

### DIFF
--- a/docs/concepts.rst
+++ b/docs/concepts.rst
@@ -49,9 +49,9 @@ There are a few options and commands related to the RPC process.
 
    Path to the virtualenv used by the RPC.
 
-   Can be `default` (create a dedicated virtualenv
-   ``.emacs.d/elpy/rpc-venv``), `global` (use the global system
-   environment), `current` (use the currently active environment), a
+   Can be `'default` (create a dedicated virtualenv
+   ``.emacs.d/elpy/rpc-venv``), `'global` (use the global system
+   environment), `'current` (use the currently active environment), a
    virtualenv path or a function returning a virtualenv path.
 
    If the default virtual environment does not exist, it will be

--- a/docs/ide.rst
+++ b/docs/ide.rst
@@ -258,7 +258,14 @@ The Shell Buffer
    By default, Elpy tries to find the root directory of the current project
    (git, svn or hg repository, python package or projectile project) and
    starts the python interpreter here. This behaviour can be suppressed
-   with the option ``elpy-shell-use-project-root``.
+   with the option ``elpy-shell-starting-directory``.
+
+.. option:: elpy-shell-starting-directory
+
+   Govern the directory in which Python shells will be started.
+   Can be ``'project-root`` (default) to use the current project root,
+   ``'current-directory`` to use the buffer current directory, or a
+   string indicating a specific path.
 
 .. command:: elpy-shell-toggle-dedicated-shell
 

--- a/test/elpy-shell-starting-directory-test.el
+++ b/test/elpy-shell-starting-directory-test.el
@@ -1,0 +1,33 @@
+
+(ert-deftest elpy-shell-starting-directory-in-project-mode ()
+  (elpy-testcase ()
+    (let ((elpy-shell-starting-directory 'project-root))
+      (python-mode)
+      (elpy-mode)
+      (elpy-shell-switch-to-shell)
+      (should (string= default-directory (elpy-project-root))))))
+
+(ert-deftest elpy-shell-starting-directory-in-current-buffer-mode ()
+  (elpy-testcase ()
+    (let ((elpy-shell-starting-directory 'current-buffer)
+          (curdir default-directory))
+      (python-mode)
+      (elpy-mode)
+      (elpy-shell-switch-to-shell)
+      (should (string= default-directory curdir)))))
+
+(ert-deftest elpy-shell-starting-directory-in-specific-path-mode ()
+  (elpy-testcase ()
+    (let ((elpy-shell-starting-directory temporary-file-directory))
+      (python-mode)
+      (elpy-mode)
+      (elpy-shell-switch-to-shell)
+      (should (string= default-directory temporary-file-directory)))))
+
+(ert-deftest elpy-shell-starting-directory-should-fail-when-misconfigured ()
+  (elpy-testcase ()
+    (let ((elpy-shell-starting-directory 'something-else))
+      (python-mode)
+      (elpy-mode)
+      (should-error
+      (elpy-shell-switch-to-shell)))))


### PR DESCRIPTION
# PR Summary
Follow #1306.

Make the Python shell starting directory customisable.

# PR checklist
- [x] Commits respect our [guidelines](../CONTRIBUTING.rst)
- [x] Tests are passing properly (see [here](https://elpy.readthedocs.io/en/latest/extending.html#running-tests) on how to run Elpy's tests)
- [x] Tests has been added to cover the change
- [x] The documentation has been updated
