### PR TITLE
More reliable way of finding the system python binaries

### DIFF
--- a/elpy-rpc.el
+++ b/elpy-rpc.el
@@ -200,15 +200,12 @@ needed packages from `elpy-rpc--get-package-list'."
    ((eq elpy-rpc-virtualenv-path 'default)
     (elpy-rpc-default-virtualenv-path))
    ((eq elpy-rpc-virtualenv-path 'global)
-    (let ((deact-venv pyvenv-virtual-env))
-      (when deact-venv (pyvenv-deactivate))
-      (prog1
-          (directory-file-name
-           (file-name-directory
-            (directory-file-name
-             (file-name-directory
-              (executable-find elpy-rpc-python-command)))))
-        (when deact-venv (pyvenv-activate deact-venv)))))
+    (let ((exec-path (reverse exec-path)))
+      (directory-file-name
+       (file-name-directory
+        (directory-file-name
+         (file-name-directory
+          (executable-find elpy-rpc-python-command)))))))
    ((eq elpy-rpc-virtualenv-path 'current)
     (directory-file-name
      (file-name-directory

--- a/elpy.el
+++ b/elpy.el
@@ -1089,9 +1089,11 @@ virtual_env_short"
                  (t
                   "Not configured")))
             ("RPC virtualenv"
-              . ,(format "%s (%s)"
-                      rpc-virtualenv-short
-                      rpc-virtualenv))
+             . ,(format "%s (%s)"
+                        (if (eq elpy-rpc-virtualenv-path 'global)
+                            "system"
+                          rpc-virtualenv-short)
+                        rpc-virtualenv))
             ((" Python" (lambda ()
                              (customize-variable
                               'elpy-rpc-python-command)))

--- a/test/elpy-rpc-get-virtualenv-path-test.el
+++ b/test/elpy-rpc-get-virtualenv-path-test.el
@@ -21,10 +21,10 @@
 (ert-deftest elpy-rpc-get-virtualenv-path-should-return-global-venv-path ()
   (elpy-testcase ()
     (let ((elpy-rpc-virtualenv-path 'global))
-      (should (string-match "\\(travis/virtualenv/python\\|.virtualenvs/elpy\\)"
+      (should-not (string-match "\\(travis/virtualenv\\|.virtualenvs\\)"
                             (elpy-rpc-get-virtualenv-path)))
       (pyvenv-workon "elpy-test-venv")
-      (should (string-match "\\(travis/virtualenv/python\\|.virtualenvs/elpy\\)"
+      (should-not (string-match "\\(travis/virtualenv\\|.virtualenvs\\)"
                             (elpy-rpc-get-virtualenv-path)))
       (pyvenv-deactivate))))
 


### PR DESCRIPTION
# PR Summary
When `elpy-rpc-virtualenv-path` is set to `'global` and Emacs is started from a virtualenv, Elpy's RPC is at the moment using this last virtualenv, instead os using the system binaries.

WIth this PR, Elpy has a more reliable way of finding the system python binaries that fix this issue.

# PR checklist
- [x] Commits respect our [guidelines](../CONTRIBUTING.rst)
- [x] Tests are passing properly (see [here](https://elpy.readthedocs.io/en/latest/extending.html#running-tests) on how to run Elpy's tests)
