### PR TITLE
Use more sensible name for `elpy-rpc-virtualenv-path` option

### DIFF
--- a/docs/concepts.rst
+++ b/docs/concepts.rst
@@ -50,7 +50,7 @@ There are a few options and commands related to the RPC process.
    Path to the virtualenv used by the RPC.
 
    Can be `'default` (create a dedicated virtualenv
-   ``.emacs.d/elpy/rpc-venv``), `'global` (use the global system
+   ``.emacs.d/elpy/rpc-venv``), `'system` (use the system
    environment), `'current` (use the currently active environment), a
    virtualenv path or a function returning a virtualenv path.
 

--- a/elpy-rpc.el
+++ b/elpy-rpc.el
@@ -174,17 +174,17 @@ This maps call IDs to functions.")
 (defcustom elpy-rpc-virtualenv-path 'default
   "Path to the virtualenv used by the RPC.
 
-Can be `default' (create a dedicated virtualenv in \".emacs.d/elpy\"),
-`global' (use the global system environment), `current' (use the
-currently active environment), a virtualenv path or a function
-returning a virtualenv path.
+Can be `default' (create a dedicated virtualenv in
+\".emacs.d/elpy\"), `system' (use the system environment),
+`current' (use the currently active environment), a virtualenv
+path or a function returning a virtualenv path.
 
 If the default virtual environment does not exist, it will be
 created using `elpy-rpc-python-command' and populated with the
 needed packages from `elpy-rpc--get-package-list'."
 
   :type '(choice (const :tag "Dedicated environment" default)
-                 (const :tag "Global environment" global)
+                 (const :tag "Global environment" system)
                  (const :tag "Current environment" current)
                  (string :tag "Virtualenv path")
                  (function :tag "Function returning the virtualenv path"))
@@ -199,7 +199,8 @@ needed packages from `elpy-rpc--get-package-list'."
   (cond
    ((eq elpy-rpc-virtualenv-path 'default)
     (elpy-rpc-default-virtualenv-path))
-   ((eq elpy-rpc-virtualenv-path 'global)
+   ((or (eq elpy-rpc-virtualenv-path 'system)
+        (eq elpy-rpc-virtualenv-path 'global))  ;; for backward compatibility
     (let ((exec-path (reverse exec-path)))
       (directory-file-name
        (file-name-directory
@@ -582,7 +583,7 @@ died, this will kill the process and buffer."
           (name (format " *elpy-rpc [project:%s environment:%s]*"
                         library-root
                         (or deactivated-environment
-                            "global")))
+                            "system")))
           (new-elpy-rpc-buffer (generate-new-buffer name))
           (proc nil))
      (when (not full-python-command)

--- a/elpy.el
+++ b/elpy.el
@@ -1090,7 +1090,8 @@ virtual_env_short"
                   "Not configured")))
             ("RPC virtualenv"
              . ,(format "%s (%s)"
-                        (if (eq elpy-rpc-virtualenv-path 'global)
+                        (if (or (eq elpy-rpc-virtualenv-path 'system)
+                                (eq elpy-rpc-virtualenv-path 'global))  ;; for backward compatibility
                             "system"
                           rpc-virtualenv-short)
                         rpc-virtualenv))

--- a/test/elpy-rpc-get-virtualenv-path-test.el
+++ b/test/elpy-rpc-get-virtualenv-path-test.el
@@ -20,7 +20,7 @@
 
 (ert-deftest elpy-rpc-get-virtualenv-path-should-return-global-venv-path ()
   (elpy-testcase ()
-    (let ((elpy-rpc-virtualenv-path 'global))
+    (let ((elpy-rpc-virtualenv-path 'system))
       (should-not (string-match "\\(travis/virtualenv\\|.virtualenvs\\)"
                             (elpy-rpc-get-virtualenv-path)))
       (pyvenv-workon "elpy-test-venv")


### PR DESCRIPTION
# PR Summary
Follow #1673.

For the option `elpy-rpc-virtualenv-path`, the name `'system` makes more sens than `'global` to refer to the use of the system python binaries (see [this](https://github.com/jorgenschaefer/elpy/issues/1673#issuecomment-537289523) comment).

This PR just change that.

# PR checklist
- [x] Commits respect our [guidelines](../CONTRIBUTING.rst)
- [x] Tests are passing properly (see [here](https://elpy.readthedocs.io/en/latest/extending.html#running-tests) on how to run Elpy's tests)
