### PR TITLE
Add string sent by Elpy to the comint history

### DIFF
--- a/docs/ide.rst
+++ b/docs/ide.rst
@@ -403,6 +403,12 @@ accidental code execution, e.g.:
 
    Also bound to :kbd:`C-c C-c`.
 
+.. option:: elpy-shell-add-to-shell-history
+
+   If `t`, Elpy will make the code sent available in the shell
+   history. This allows to use `comint-previous-input` (:kbd:`C-up`)
+   in the python shell to get back the pieces of code sent by Elpy.
+
 The list of remaining commands to send code fragments is:
 
 .. command:: elpy-shell-send-top-statement

--- a/elpy-shell.el
+++ b/elpy-shell.el
@@ -881,11 +881,10 @@ corresponding statement."
           (end (progn (elpy-shell--nav-end-of-statement) (point))))
       (unless (eq beg end)
         (elpy-shell--flash-and-message-region beg end)
-        (let ((substring (python-shell-buffer-substring beg end))
-              (substring-original (buffer-substring beg end)))
-          (elpy-shell--add-to-shell-history substring-original)
-          (elpy-shell--with-maybe-echo
-           (python-shell-send-string substring)))))
+        (elpy-shell--add-to-shell-history (buffer-substring beg end))
+        (elpy-shell--with-maybe-echo
+         (python-shell-send-string
+          (python-shell-buffer-substring beg end)))))
     (python-nav-forward-statement)))
 
 (defun elpy-shell-send-top-statement-and-step ()
@@ -903,11 +902,9 @@ line and sends the corresponding top-level statement."
         ;; single line
         (elpy-shell-send-statement-and-step)
       ;; multiple lines
-      (let ((substring (python-shell-buffer-substring beg end))
-            (substring-original (buffer-substring beg end)))
-        (elpy-shell--add-to-shell-history substring-original)
-        (elpy-shell--with-maybe-echo
-         (python-shell-send-string substring)))
+      (elpy-shell--add-to-shell-history (buffer-substring beg end))
+      (elpy-shell--with-maybe-echo
+       (python-shell-send-string (python-shell-buffer-substring beg end)))
       (setq mark-active nil)
       (python-nav-forward-statement))))
 
@@ -967,11 +964,10 @@ below point and send the group around this statement."
             ;; multiple lines
             (unless elpy-shell-echo-input
               (elpy-shell--append-to-shell-output "\n"))
-            (let ((substring (python-shell-buffer-substring beg end))
-                  (substring-original (buffer-substring beg end)))
-              (elpy-shell--add-to-shell-history substring-original)
-              (elpy-shell--with-maybe-echo
-               (python-shell-send-string substring)))
+            (elpy-shell--add-to-shell-history (buffer-substring beg end))
+            (elpy-shell--with-maybe-echo
+             (python-shell-send-string
+              (python-shell-buffer-substring beg end)))
             (python-nav-forward-statement)))
       (goto-char (point-max)))
     (setq mark-active nil)))
@@ -1004,11 +1000,9 @@ variables `elpy-shell-cell-boundary-regexp' and
           (elpy-shell--flash-and-message-region beg end)
           (unless elpy-shell-echo-input
             (elpy-shell--append-to-shell-output "\n"))
-          (let ((substring (python-shell-buffer-substring beg end))
-                (substring-original (buffer-substring beg end)))
-            (elpy-shell--add-to-shell-history substring-original)
-            (elpy-shell--with-maybe-echo
-             (python-shell-send-string substring)))
+          (elpy-shell--add-to-shell-history (buffer-substring beg end))
+          (elpy-shell--with-maybe-echo
+           (python-shell-send-string (python-shell-buffer-substring beg end)))
           (goto-char end)
           (python-nav-forward-statement))
       (message "Not in a codecell."))))

--- a/elpy-shell.el
+++ b/elpy-shell.el
@@ -155,10 +155,10 @@ the code cell beginnings defined here."
   :group 'elpy)
 
 (defcustom elpy-shell-add-to-shell-history nil
-  "If Elpy should add the code send to the shell to the shell history.
-This allows to use `comint-previous-input' in the python shell to
-get back the pieces of code sent by Elpy. This affects the
-functions:
+  "If Elpy should make the code sent to the shell available in the
+shell history. This allows to use `comint-previous-input' in the
+python shell to get back the pieces of code sent by Elpy. This affects
+the following functions:
 - `elpy-shell-send-statement'
 - `elpy-shell-send-top-statement'
 - `elpy-shell-send-group'

--- a/elpy.el
+++ b/elpy.el
@@ -445,7 +445,7 @@ This option need to bet set through `customize' or `customize-set-variable' to b
                  "Send Region to Python"
                "Send Buffer to Python")
       :help "Send the current region or the whole buffer to Python"]
-     ["Send Definition" python-shell-send-defun
+     ["Send Definition" elpy-shell-send-defun
       :help "Send current definition to Python"]
      ["Kill Python shell" elpy-shell-kill
       :help "Kill the current Python shell"]

--- a/test/elpy-shell-add-to-shell-history-test.el
+++ b/test/elpy-shell-add-to-shell-history-test.el
@@ -14,6 +14,19 @@
                           "." 1))))
           (should (string= "a = 2 + 4" last-hist)))))))
 
+(ert-deftest elpy-shell-send-statement-should-NOT-add-to-shell-history ()
+  (elpy-testcase ()
+    (python-mode)
+    (elpy-mode)
+    (let ((elpy-shell-add-to-shell-history nil))
+      (insert "a = 2 + 4")
+      (elpy-shell-send-statement)
+      (python-shell-send-string "print('OK')\n")
+      (with-current-buffer "*Python*"
+        (elpy/wait-for-output "OK")
+        (should-error (comint-previous-matching-input-string-position "."
+                                                                      1))))))
+
 (ert-deftest elpy-shell-send-statement-should-add-multilines-statements-to-shell-history ()
   (elpy-testcase ()
     (python-mode)
@@ -50,6 +63,19 @@
                          (comint-previous-matching-input-string-position
                           "." 1))))
           (should (string= "a = 2 + 4" last-hist)))))))
+
+(ert-deftest elpy-shell-send-region-should-NOT-add-to-shell-history ()
+  (elpy-testcase ()
+    (python-mode)
+    (elpy-mode)
+    (let ((elpy-shell-add-to-shell-history nil))
+      (insert "a = 2 + 4")
+      (elpy/mark-region 0 10)
+      (elpy-shell-send-region-or-buffer)
+      (python-shell-send-string "print('OK')\n")
+      (with-current-buffer "*Python*"
+        (elpy/wait-for-output "OK")
+        (should-error (comint-previous-matching-input-string-position "." 1))))))
 
 (ert-deftest elpy-shell-send-region-should-add-multilines-statements-to-shell-history ()
   (elpy-testcase ()

--- a/test/elpy-shell-add-to-shell-history-test.el
+++ b/test/elpy-shell-add-to-shell-history-test.el
@@ -1,0 +1,72 @@
+(ert-deftest elpy-shell-send-statement-should-add-to-shell-history ()
+  (elpy-testcase ()
+    (python-mode)
+    (elpy-mode)
+    (let ((elpy-shell-add-to-shell-history t))
+      (insert "a = 2 + 4")
+      (elpy-shell-send-statement)
+      (python-shell-send-string "print('OK')\n")
+      (with-current-buffer "*Python*"
+        (elpy/wait-for-output "OK")
+        (let ((last-hist
+               (ring-ref comint-input-ring
+                         (comint-previous-matching-input-string-position
+                          "." 1))))
+          (should (string= "a = 2 + 4" last-hist)))))))
+
+(ert-deftest elpy-shell-send-statement-should-add-multilines-statements-to-shell-history ()
+  (elpy-testcase ()
+    (python-mode)
+    (elpy-mode)
+    (let ((elpy-shell-add-to-shell-history t))
+      (insert "def foo(a):\n"
+              "  d = a + 2\n"
+              "  return d\n")
+      (goto-char 4)
+      (elpy-shell-send-statement)
+      (python-shell-send-string "print('OK')\n")
+      (with-current-buffer "*Python*"
+        (elpy/wait-for-output "OK")
+        (let ((last-hist
+               (ring-ref comint-input-ring
+                         (comint-previous-matching-input-string-position
+                          "." 1))))
+          (should (string= "def foo(a):\n  d = a + 2\n  return d"
+                           last-hist)))))))
+
+(ert-deftest elpy-shell-send-region-should-add-to-shell-history ()
+  (elpy-testcase ()
+    (python-mode)
+    (elpy-mode)
+    (let ((elpy-shell-add-to-shell-history t))
+      (insert "a = 2 + 4")
+      (elpy/mark-region 0 10)
+      (elpy-shell-send-region-or-buffer)
+      (python-shell-send-string "print('OK')\n")
+      (with-current-buffer "*Python*"
+        (elpy/wait-for-output "OK")
+        (let ((last-hist
+               (ring-ref comint-input-ring
+                         (comint-previous-matching-input-string-position
+                          "." 1))))
+          (should (string= "a = 2 + 4" last-hist)))))))
+
+(ert-deftest elpy-shell-send-region-should-add-multilines-statements-to-shell-history ()
+  (elpy-testcase ()
+    (python-mode)
+    (elpy-mode)
+    (let ((elpy-shell-add-to-shell-history t))
+      (insert "def foo(a):\n"
+              "  d = a + 2\n"
+              "  return d")
+      (elpy/mark-region 0 35)
+      (elpy-shell-send-region-or-buffer)
+      (python-shell-send-string "print('OK')\n")
+      (with-current-buffer "*Python*"
+        (elpy/wait-for-output "OK")
+        (let ((last-hist
+               (ring-ref comint-input-ring
+                         (comint-previous-matching-input-string-position
+                          "." 1))))
+          (should (string= "def foo(a):\n  d = a + 2\n  return d"
+                           last-hist)))))))

--- a/test/elpy-shell-echo-inputs-and-outputs-test.el
+++ b/test/elpy-shell-echo-inputs-and-outputs-test.el
@@ -120,5 +120,4 @@
     (python-shell-send-string "print('OK')\n")
     (should (string-match "^7" (with-current-buffer "*Python*"
                                  (elpy/wait-for-output "OK" 30)
-                                 (buffer-string))))
-    )))
+                                 (buffer-string)))))))


### PR DESCRIPTION
# PR Summary
Follow #1430.

When sending a statement/region/defun/group/codecell, Elpy is now adding the sent string to the comint history. 
This allows to get those inputs back from the shell with `comint-previous-input` and similar.

# PR checklist
- [x] Add an option because this could be quite annoying if enabled by default.
- [x] Commits respect our [guidelines](../CONTRIBUTING.rst)
- [x] Tests are passing properly (see [here](https://elpy.readthedocs.io/en/latest/extending.html#running-tests) on how to run Elpy's tests)
- [x] Tests has been added to cover the change
- [x] The documentation has been updated
