### PR TITLE
fix #1685

### DIFF
--- a/elpy-rpc.el
+++ b/elpy-rpc.el
@@ -250,6 +250,8 @@ BODY."
                                                pyvenv-post-deactivate-hooks))
            (deactivated-environment
             (or pyvenv-virtual-env
+                (when (string-equal system-type "windows-nt")
+                  (executable-find elpy-rpc-python-command))
                 ;; global env
                 (directory-file-name
                  (file-name-directory


### PR DESCRIPTION
# PR Summary

In Jedi, function [jedi.create_environment](https://github.com/davidhalter/jedi/blob/a6fcf779d41862de50d25cbe964c64831c7d64bc/jedi/api/environment.py#L344) accept a python executable path (windows, linux
and macOS) or a directory path which containing the bin directory. But on
windows the variable `deactivated-environment` has got incorrect path, so elpy.jedibackend.JediBackend can not be initialized with an error 'C:\xxxx\Scripts\python.exe missing'

BTW, may be we need a right way to handle the difference between different OS.

# PR checklist

Please make sure that the following things have been addressed (and check the relevant checkboxes):

- [x] Commits respect our [guidelines](../CONTRIBUTING.rst)
- [x] Tests are passing properly (see [here](https://elpy.readthedocs.io/en/latest/extending.html#running-tests) on how to run Elpy's tests)

## For new features only:
- [ ] Tests has been added to cover the change
- [ ] The documentation has been updated
