### PR TITLE
Allow to run tests without using virtualenvs

### DIFF
--- a/docs/extending.rst
+++ b/docs/extending.rst
@@ -72,3 +72,8 @@ and run the ``setup`` script in it:
 
 
 You can now run ``./scripts/test`` to run Elpy's test suite.
+
+If you cannot (or do not want to) use virtual environments on your
+system, you can set the environment variable
+ELPY_TEST_DONT_USE_VIRTUALENV to skip tests involving virtual
+environments: ``ELPY_TEST_DONT_USE_VIRTUALENV=t ./scripts/test``.

--- a/elpy-django.el
+++ b/elpy-django.el
@@ -192,7 +192,7 @@ The result is memoized on project root and `DJANGO_SETTINGS_MODULE'"
         (django-settings-env (getenv "DJANGO_SETTINGS_MODULE"))
         (default-directory (elpy-project-root)))
     ;; If no Django settings has been set, then nothing will work. Warn user
-    (when (not django-settings-env)
+    (unless django-settings-env
       (error "Please set environment variable `DJANGO_SETTINGS_MODULE' if you'd like to run the test runner"))
 
     (let* ((runner-key (list default-directory django-settings-env))

--- a/elpy-profile.el
+++ b/elpy-profile.el
@@ -59,7 +59,7 @@
           (message  "[%s] Profiling failed" filename)
           (display-buffer  "*elpy-profile-log*"))
       (message  "[%s] Profiling succeeded" filename)
-      (when (not dont-display)
+      (unless dont-display
         (elpy-profile--display-profiling prof-file)))))
 
 (defun elpy-profile--file (file &optional in-dir dont-display)

--- a/elpy-refactor.el
+++ b/elpy-refactor.el
@@ -85,7 +85,7 @@ created."
               (description (cdr (assq 'description option)))
               (name (cdr (assq 'name option)))
               (args (cdr (assq 'args option))))
-          (when (not (equal category last-category))
+          (unless (equal category last-category)
             (when last-category
               (insert "\n"))
             (insert (propertize category 'face 'bold) "\n")
@@ -155,7 +155,7 @@ Available types:
 
 The user can review the changes and confirm them with
 \\[elpy-refactor-commit]."
-  (when (not changes)
+  (unless changes
     (error "No changes for this refactoring action."))
   (with-current-buffer (get-buffer-create "*Elpy Refactor*")
     (elpy-refactor-mode)
@@ -221,7 +221,7 @@ The user can review the changes and confirm them with
 (defun elpy-refactor-commit ()
   "Commit the changes in the current buffer."
   (interactive)
-  (when (not elpy-refactor-changes)
+  (unless elpy-refactor-changes
     (error "No changes to commit."))
   ;; Restore the window configuration as the first thing so that
   ;; changes below are visible to the user. Especially the point

--- a/elpy-rpc.el
+++ b/elpy-rpc.el
@@ -263,14 +263,14 @@ During the execution of BODY the following variables are available:
             (same-venv (file-equal-p current-environment
                                      (elpy-rpc-get-or-create-virtualenv)))
             current-environment-is-deactivated)
-       (when (not same-venv)
+       (unless same-venv
          (pyvenv-activate (elpy-rpc-get-or-create-virtualenv))
          (setq current-environment-is-deactivated t))
        (let (venv-err result)
          (condition-case err
              (setq result (progn ,@body))
            (error (setq venv-err (format "%s" err))))
-         (when (not same-venv)
+         (unless same-venv
            (if venv-was-activated
                (pyvenv-activate (directory-file-name
                                  current-environment))
@@ -422,7 +422,7 @@ not exist anymore."
 
 (defun elpy-promise-resolve (promise value)
   "Resolve PROMISE with VALUE."
-  (when (not (elpy-promise-resolved-p promise))
+  (unless (elpy-promise-resolved-p promise)
     (unwind-protect
         (let ((success-callback (elpy-promise-success-callback promise)))
           (when success-callback
@@ -435,7 +435,7 @@ not exist anymore."
 
 (defun elpy-promise-reject (promise reason)
   "Reject PROMISE because of REASON."
-  (when (not (elpy-promise-resolved-p promise))
+  (unless (elpy-promise-resolved-p promise)
     (unwind-protect
         (let ((error-callback (elpy-promise-error-callback promise)))
           (when error-callback
@@ -475,7 +475,7 @@ See http://debbugs.gnu.org/cgi/bugreport.cgi?bug=17647"
 If SUCCESS and optionally ERROR is given, return immediately and
 call those when a result is available. Otherwise, wait for a
 result and return that."
-  (when (not error)
+  (unless error
     (setq error #'elpy-rpc--default-error-callback))
   (if success
       (elpy-rpc--call method params success error)
@@ -532,16 +532,16 @@ Returns a PROMISE object."
   "Register for PROMISE to be called when CALL-ID returns.
 
 Must be called in an elpy-rpc buffer."
-  (when (not elpy-rpc--buffer-p)
+  (unless elpy-rpc--buffer-p
     (error "Must be called in RPC buffer"))
-  (when (not elpy-rpc--backend-callbacks)
+  (unless elpy-rpc--backend-callbacks
     (setq elpy-rpc--backend-callbacks (make-hash-table :test #'equal)))
   (puthash call-id promise elpy-rpc--backend-callbacks))
 
 (defun elpy-rpc--get-rpc-buffer ()
   "Return the RPC buffer associated with the current buffer,
 creating one if necessary."
-  (when (not (elpy-rpc--process-buffer-p elpy-rpc--buffer))
+  (unless (elpy-rpc--process-buffer-p elpy-rpc--buffer)
     (setq elpy-rpc--buffer
           (or (elpy-rpc--find-buffer (elpy-library-root)
                                      elpy-rpc-python-command)
@@ -595,7 +595,7 @@ died, this will kill the process and buffer."
                         current-environment))
           (new-elpy-rpc-buffer (generate-new-buffer name))
           (proc nil))
-     (when (not full-python-command)
+     (unless full-python-command
        (error "Can't find Python command, configure `elpy-rpc-python-command'"))
      (with-current-buffer new-elpy-rpc-buffer
        (setq elpy-rpc--buffer-p t
@@ -715,7 +715,7 @@ RPC calls with the event."
 
 (defun elpy-rpc--check-backend-version (rpc-version)
   "Check that we are using the right version."
-  (when (not (equal rpc-version elpy-version))
+  (unless (equal rpc-version elpy-version)
     (elpy-insert--popup "*Elpy Version Mismatch*"
       (elpy-insert--header "Elpy Version Mismatch")
       (elpy-insert--para
@@ -737,7 +737,7 @@ RPC calls with the event."
 
 This is usually an error or backtrace."
   (let ((buf (get-buffer "*Elpy Output*")))
-    (when (not buf)
+    (unless buf
       (elpy-insert--popup "*Elpy Output*"
         (elpy-insert--header "Output from Backend")
         (elpy-insert--para
@@ -759,7 +759,7 @@ This is usually an error or backtrace."
         (error-object (cdr (assq 'error json)))
         (result (cdr (assq 'result json))))
     (let ((promise (gethash call-id elpy-rpc--backend-callbacks)))
-      (when (not promise)
+      (unless promise
         (error "Received a response for unknown call-id %s" call-id))
       (remhash call-id elpy-rpc--backend-callbacks)
       (if error-object
@@ -872,7 +872,7 @@ This is usually an error or backtrace."
                           ")\n")
                   (insert (format "%s(\n    %s\n)\n"
                                   function-name function-args)))))
-            (when (not (= 0 (current-column)))
+            (unless (= 0 (current-column))
               (insert "\n"))
             (insert "```"))
           (setq elpy-rpc--last-error-popup (float-time))))))))

--- a/elpy-shell.el
+++ b/elpy-shell.el
@@ -247,7 +247,7 @@ Python process. This allows the process to start up."
          (proc (get-buffer-process bufname)))
     (if proc
         proc
-      (when (not (executable-find python-shell-interpreter))
+      (unless (executable-find python-shell-interpreter)
         (error "Python shell interpreter `%s' cannot be found. Please set `python-shell-interpreter' to a valid python binary."
                python-shell-interpreter))
       (let ((default-directory
@@ -527,7 +527,7 @@ complete). Otherwise, does nothing."
 
 Unless NO-FONT-LOCK is set, formats STRING as shell input.
 Prepends a continuation promt if PREPEND-CONT-PROMPT is set."
-  (when (not (string-empty-p string))
+  (unless (string-empty-p string)
   (let* ((process (elpy-shell-get-or-create-process))
          (process-buf (process-buffer process))
          (mark-point (process-mark process)))
@@ -832,8 +832,8 @@ corresponding statement."
   (elpy-shell--ensure-shell-running)
   (elpy-shell--nav-beginning-of-statement)
   ;; Make sure there is a statement to send
-  (when (not (looking-at "[[:space:]]*$"))
-    (when (not elpy-shell-echo-input) (elpy-shell--append-to-shell-output "\n"))
+  (unless (looking-at "[[:space:]]*$")
+    (unless elpy-shell-echo-input) (elpy-shell--append-to-shell-output "\n")
     (let ((beg (save-excursion (beginning-of-line) (point)))
           (end (progn (elpy-shell--nav-end-of-statement) (point))))
       (unless (eq beg end)
@@ -916,7 +916,7 @@ below point and send the group around this statement."
               ;; single line
               (elpy-shell-send-statement-and-step)
             ;; multiple lines
-            (when (not elpy-shell-echo-input)
+            (unless elpy-shell-echo-input
               (elpy-shell--append-to-shell-output "\n"))
             (elpy-shell--with-maybe-echo
              (python-shell-send-region beg end))
@@ -950,7 +950,7 @@ variables `elpy-shell-cell-boundary-regexp' and
     (if beg
         (progn
           (elpy-shell--flash-and-message-region beg end)
-          (when (not elpy-shell-echo-input)
+          (unless elpy-shell-echo-input
             (elpy-shell--append-to-shell-output "\n"))
           (elpy-shell--with-maybe-echo
            (python-shell-send-region beg end))
@@ -990,7 +990,7 @@ __name__ == '__main__' to be false to avoid accidental execution
 of code. With prefix argument, this code is executed."
   (interactive "P")
   (elpy-shell--ensure-shell-running)
-  (when (not elpy-shell-echo-input) (elpy-shell--append-to-shell-output "\n"))
+  (unless elpy-shell-echo-input) (elpy-shell--append-to-shell-output "\n")
   (let ((if-main-regex "^if +__name__ +== +[\"']__main__[\"'] *:")
         (has-if-main-and-removed nil))
     (if (use-region-p)
@@ -1037,7 +1037,7 @@ switches focus to Python shell buffer."
   (let ((orig (point)))
     (setq current-prefix-arg my-prefix-arg)
     (call-interactively step-fun)
-    (when (not step)
+    (unless step
       (goto-char orig)))
   (when go
     (elpy-shell-switch-to-shell)))

--- a/elpy-shell.el
+++ b/elpy-shell.el
@@ -833,7 +833,7 @@ corresponding statement."
   (elpy-shell--nav-beginning-of-statement)
   ;; Make sure there is a statement to send
   (unless (looking-at "[[:space:]]*$")
-    (unless elpy-shell-echo-input) (elpy-shell--append-to-shell-output "\n")
+    (unless elpy-shell-echo-input (elpy-shell--append-to-shell-output "\n"))
     (let ((beg (save-excursion (beginning-of-line) (point)))
           (end (progn (elpy-shell--nav-end-of-statement) (point))))
       (unless (eq beg end)
@@ -990,7 +990,7 @@ __name__ == '__main__' to be false to avoid accidental execution
 of code. With prefix argument, this code is executed."
   (interactive "P")
   (elpy-shell--ensure-shell-running)
-  (unless elpy-shell-echo-input) (elpy-shell--append-to-shell-output "\n")
+  (unless elpy-shell-echo-input (elpy-shell--append-to-shell-output "\n"))
   (let ((if-main-regex "^if +__name__ +== +[\"']__main__[\"'] *:")
         (has-if-main-and-removed nil))
     (if (use-region-p)

--- a/elpy.el
+++ b/elpy.el
@@ -546,7 +546,7 @@ virtualenv.
 
 \\{elpy-mode-map}"
   :lighter " Elpy"
-  (when (not (derived-mode-p 'python-mode))
+  (unless (derived-mode-p 'python-mode)
     (error "Elpy only works with `python-mode'"))
   (when (boundp 'xref-backend-functions)
     (add-hook 'xref-backend-functions #'elpy--xref-backend nil t))
@@ -747,7 +747,7 @@ item in another window.\n\n")
 
 (defun elpy-config--insert-configuration-problems (&optional config)
   "Insert help text and widgets for configuration problems."
-  (when (not config)
+  (unless config
     (setq config (elpy-config--get-config)))
   (let* ((rpc-python-version (gethash "rpc_python_version" config))
          (rope-pypi-package  (if (and rpc-python-version
@@ -759,7 +759,7 @@ item in another window.\n\n")
     (insert "\n")
 
     ;; Python not found
-    (when (not (gethash "rpc_python_executable" config))
+    (unless (gethash "rpc_python_executable" config)
       (elpy-insert--para
        "Elpy can not find the configured Python interpreter. Please make "
        "sure that the variable `elpy-rpc-python-command' points to a "
@@ -870,7 +870,7 @@ item in another window.\n\n")
 
 
     ;; No autopep8 available
-    (when (not (gethash "autopep8_version" config))
+    (unless (gethash "autopep8_version" config)
       (elpy-insert--para
        "The autopep8 package is not available. Commands using this will "
        "not work.\n")
@@ -890,7 +890,7 @@ item in another window.\n\n")
       (insert "\n\n"))
 
     ;; No yapf available
-    (when (not (gethash "yapf_version" config))
+    (unless (gethash "yapf_version" config)
       (elpy-insert--para
        "The yapf package is not available. Commands using this will "
        "not work.\n")
@@ -910,7 +910,7 @@ item in another window.\n\n")
       (insert "\n\n"))
 
     ;; No black available
-    (when (not (gethash "black_version" config))
+    (unless (gethash "black_version" config)
       (elpy-insert--para
        "The black package is not available. Commands using this will "
        "not work.\n")
@@ -930,7 +930,7 @@ item in another window.\n\n")
       (insert "\n\n"))
 
     ;; Syntax checker not available
-    (when (not (executable-find (car (split-string elpy-syntax-check-command))))
+    (unless (executable-find (car (split-string elpy-syntax-check-command)))
       (elpy-insert--para
        "The configured syntax checker could not be found. Elpy uses this "
        "program to provide syntax checks of your programs, so you might "
@@ -1027,7 +1027,7 @@ virtual_env_short"
 
 (defun elpy-config--insert-configuration-table (&optional config)
   "Insert a table describing the current Elpy config."
-  (when (not config)
+  (unless config
     (setq config (elpy-config--get-config)))
   (let ((emacs-version (gethash "emacs_version" config))
         (elpy-python-version (gethash "elpy_version" config))
@@ -1269,7 +1269,7 @@ See `elpy-project-root-finder-functions' for a way to configure
 how the project root is found. You can also set the variable
 `elpy-project-root' in, for example, .dir-locals.el to override
 this."
-  (when (not elpy-project-root)
+  (unless elpy-project-root
     (setq elpy-project-root
           (run-hook-with-args-until-success
            'elpy-project-root-finder-functions)))
@@ -1508,7 +1508,7 @@ A test file is named test_<name>.py if the current file is
   (catch 'return
     (let (full-name directory file)
       (setq full-name (buffer-file-name))
-      (when (not full-name)
+      (unless full-name
         (throw 'return nil))
       (setq full-name (expand-file-name full-name)
             directory (file-name-directory full-name)
@@ -1581,7 +1581,7 @@ Returns a full path name for that module."
 or the project root if WHOLE-PROJECT-P is non-nil (interactively,
 with a prefix argument)."
   (interactive "P")
-  (when (not (buffer-file-name))
+  (unless (buffer-file-name)
     (error "Can't check a buffer without a file"))
   (save-some-buffers (not compilation-ask-about-save) nil)
   (let ((process-environment (python-shell-calculate-process-environment))
@@ -1833,7 +1833,7 @@ indentation levels."
     (beginning-of-line)
     (push-mark (point) nil t)
     (goto-char end)
-    (when (not (= (point) (line-beginning-position)))
+    (unless (= (point) (line-beginning-position))
       (end-of-line))))
 
 (defun elpy-nav-indent-shift-right (&optional _count)
@@ -2080,21 +2080,21 @@ If there is no documentation for the symbol at point, or if a
 prefix argument is given, prompt for a symbol from the user."
   (interactive)
   (let ((doc nil))
-    (when (not current-prefix-arg)
+    (unless current-prefix-arg
       (setq doc (elpy-rpc-get-docstring))
-      (when (not doc)
+      (unless doc
         (save-excursion
           (python-nav-backward-up-list)
           (setq doc (elpy-rpc-get-docstring))))
-      (when (not doc)
+      (unless doc
         (setq doc (elpy-rpc-get-pydoc-documentation
                    (elpy-doc--symbol-at-point))))
-      (when (not doc)
+      (unless doc
         (save-excursion
           (python-nav-backward-up-list)
           (setq doc (elpy-rpc-get-pydoc-documentation
                      (elpy-doc--symbol-at-point))))))
-    (when (not doc)
+    (unless doc
       (setq doc (elpy-rpc-get-pydoc-documentation
                  (elpy-doc--read-identifier-from-minibuffer
                   (elpy-doc--symbol-at-point)))))
@@ -2389,7 +2389,7 @@ name."
            "The symbol '" name "' was found in multiple files. Editing "
            "all locations:\n\n")
           (maphash (lambda (key _value)
-                     (when (not (member key filenames))
+                     (unless (member key filenames)
                        (setq filenames (cons key filenames))))
                    locations)
           (dolist (filename (sort filenames #'string<))
@@ -2604,7 +2604,7 @@ This is needed to get information on the identifier with jedi
   "Run the global-init method of Elpy modules.
 
 Make sure this only happens once."
-  (when (not elpy-modules-initialized-p)
+  (unless elpy-modules-initialized-p
     (elpy-modules-run 'global-init)
     (setq elpy-modules-initialized-p t)))
 
@@ -2827,7 +2827,7 @@ Add parentheses in case ANNOTATION is \"class\", \"function\", or
 \"instance\",unless the completion is already looking at a left
  parenthesis,or unless NAME is a Python exception outside a reasonably
  formed raise statement,or unless NAME is no callable instance."
-  (when (not (looking-at-p "\("))
+  (unless (looking-at-p "\(")
     (cond ((string= annotation "function")
            (insert "()")
            (backward-char 1))
@@ -2849,7 +2849,7 @@ Add parentheses in case ANNOTATION is \"class\", \"function\", or
            ;; backend to eliminate the `elpy-rpc-get-calltip' call below.
            (insert "()")
            (backward-char 1)
-           (when (not (elpy-rpc-get-calltip))
+           (unless (elpy-rpc-get-calltip)
              (backward-char 1)
              (delete-char 2))))))
 
@@ -3070,7 +3070,7 @@ display the current class and method instead."
      (when (version< emacs-version "26.1")
        (elpy-modules-remove-modeline-lighter 'flymake-mode))
      ;; Add our initializer function.
-     (when (not (version<= "26.1" emacs-version))
+     (unless (version<= "26.1" emacs-version)
        (add-to-list 'flymake-allowed-file-name-masks
                     '("\\.py\\'" elpy-flymake-python-init))))
 
@@ -3138,7 +3138,7 @@ display the current class and method instead."
 
 (defun elpy-flymake-python-init ()
   ;; Make sure it's not a remote buffer as flymake would not work
-  (when (not (file-remote-p buffer-file-name))
+  (unless (file-remote-p buffer-file-name)
     (let* ((temp-file (flymake-init-create-temp-buffer-copy
                        'flymake-create-temp-inplace)))
       (list python-check-command
@@ -3219,7 +3219,7 @@ display the current class and method instead."
 
      ;; yas-snippet-dirs can be a string for a single directory. Make
      ;; sure it's a list in that case so we can add our own entry.
-     (when (not (listp yas-snippet-dirs))
+     (unless (listp yas-snippet-dirs)
        (setq yas-snippet-dirs (list yas-snippet-dirs)))
      (add-to-list 'yas-snippet-dirs
                   (concat (file-name-directory (locate-library "elpy"))
@@ -3337,51 +3337,51 @@ display the current class and method instead."
 ;; Emacs version is 24.4.
 
 ;; Functions for Emacs 24 before 24.3
-(when (not (fboundp 'python-info-current-defun))
+(unless (fboundp 'python-info-current-defun)
   (defalias 'python-info-current-defun 'python-current-defun))
 
-(when (not (fboundp 'python-nav-forward-statement))
+(unless (fboundp 'python-nav-forward-statement)
   (defun python-nav-forward-statement (&rest ignored)
     "Function added in Emacs 24.3"
     (error "Enhanced Python navigation only available in Emacs 24.3+")))
 
-(when (not (fboundp 'python-nav-backward-up-list))
+(unless (fboundp 'python-nav-backward-up-list)
   (defun python-nav-backward-up-list ()
     "Compatibility function for older Emacsen"
     (ignore-errors
       (backward-up-list))))
 
-(when (not (fboundp 'python-shell-calculate-exec-path))
+(unless (fboundp 'python-shell-calculate-exec-path)
   (defun python-shell-calculate-exec-path ()
     "Compatibility function for older Emacsen."
     exec-path))
 
-(when (not (fboundp 'python-shell-calculate-process-environment))
+(unless (fboundp 'python-shell-calculate-process-environment)
   (defun python-shell-calculate-process-environment ()
     "Compatibility function for older Emacsen."
     process-environment))
 
-(when (not (fboundp 'python-shell-get-process-name))
+(unless (fboundp 'python-shell-get-process-name)
   (defun python-shell-get-process-name (_dedicated)
     "Compatibility function for older Emacsen."
     "Python"))
 
-(when (not (fboundp 'python-shell-parse-command))
+(unless (fboundp 'python-shell-parse-command)
   (defun python-shell-parse-command ()
     "Compatibility function for older Emacsen."
     python-python-command))
 
-(when (not (fboundp 'python-shell-send-buffer))
+(unless (fboundp 'python-shell-send-buffer)
   (defun python-shell-send-buffer (&optional _arg)
     (python-send-buffer)))
 
-(when (not (fboundp 'python-shell-send-string))
+(unless (fboundp 'python-shell-send-string)
   (defalias 'python-shell-send-string 'python-send-string))
 
-(when (not (fboundp 'python-indent-shift-right))
+(unless (fboundp 'python-indent-shift-right)
   (defalias 'python-indent-shift-right 'python-shift-right))
 
-(when (not (fboundp 'python-indent-shift-left))
+(unless (fboundp 'python-indent-shift-left)
   (defalias 'python-indent-shift-left 'python-shift-left))
 
 ;; Emacs 24.2 made `locate-dominating-file' accept a predicate instead
@@ -3434,7 +3434,7 @@ which we're looking."
   )
 
 ;; highlight-indentation 0.5 does not use modes yet
-(when (not (fboundp 'highlight-indentation-mode))
+(unless (fboundp 'highlight-indentation-mode)
   (defun highlight-indentation-mode (on-or-off)
     (cond
      ((and (> on-or-off 0)

--- a/snippets/python-mode/.yas-setup.el
+++ b/snippets/python-mode/.yas-setup.el
@@ -19,7 +19,7 @@
                (elpy-snippet-split-args
                 (buffer-substring-no-properties start end))))))
         class method args)
-    (when (not current-arglist)
+    (unless current-arglist
       (setq current-arglist '(("self"))))
     (if (and current-defun
              (string-match "^\\(.*\\)\\.\\(.*\\)$" current-defun))

--- a/test/elpy-config--get-config-test.el
+++ b/test/elpy-config--get-config-test.el
@@ -32,9 +32,10 @@
 
       (should (equal environment "test-environment")))))
 
-(ert-deftest elpy-config--get-config-should-be-evaluated-in-the-rpc-virtualenv ()
-  (elpy-testcase ()
-    (let ((elpy-rpc-virtualenv-path 'default))
-      (should (string-match "elpy/rpc-venv/bin/python"
-                            (gethash "rpc_python_executable"
-                                     (elpy-config--get-config)))))))
+(when (not elpy-test-dont-use-virtualenv)
+  (ert-deftest elpy-config--get-config-should-be-evaluated-in-the-rpc-virtualenv ()
+    (elpy-testcase ()
+      (let ((elpy-rpc-virtualenv-path 'default))
+        (should (string-match "elpy/rpc-venv/bin/python"
+                              (gethash "rpc_python_executable"
+                                       (elpy-config--get-config))))))))

--- a/test/elpy-config--get-config-test.el
+++ b/test/elpy-config--get-config-test.el
@@ -32,7 +32,7 @@
 
       (should (equal environment "test-environment")))))
 
-(when (not elpy-test-dont-use-virtualenv)
+(unless elpy-test-dont-use-virtualenv
   (ert-deftest elpy-config--get-config-should-be-evaluated-in-the-rpc-virtualenv ()
     (elpy-testcase ()
       (let ((elpy-rpc-virtualenv-path 'default))

--- a/test/elpy-rpc--open-test.el
+++ b/test/elpy-rpc--open-test.el
@@ -63,9 +63,10 @@
               (with-elpy-rpc-virtualenv-activated
                (executable-find elpy-rpc-python-command)))))))
 
-(ert-deftest elpy-rpc--open-should-open-in-a-dedicated-virtualenv ()
-  (elpy-testcase ()
-    (let ((elpy-rpc-virtualenv-path 'default))
-      (elpy-rpc--get-rpc-buffer)
-      (with-elpy-rpc-virtualenv-activated
-       (should (string= "rpc-venv" pyvenv-virtual-env-name))))))
+(when (not elpy-test-dont-use-virtualenv)
+  (ert-deftest elpy-rpc--open-should-open-in-a-dedicated-virtualenv ()
+    (elpy-testcase ()
+      (let ((elpy-rpc-virtualenv-path 'default))
+        (elpy-rpc--get-rpc-buffer)
+        (with-elpy-rpc-virtualenv-activated
+         (should (string= "rpc-venv" pyvenv-virtual-env-name)))))))

--- a/test/elpy-rpc--open-test.el
+++ b/test/elpy-rpc--open-test.el
@@ -10,7 +10,7 @@
              (filter nil)
              (set-process-query-on-exit-flag
               (proc flag)
-              (when (not flag)
+              (unless flag
                 (setq exit-flag-disabled-for proc)))
              (set-process-sentinel
               (proc fun)
@@ -63,7 +63,7 @@
               (with-elpy-rpc-virtualenv-activated
                (executable-find elpy-rpc-python-command)))))))
 
-(when (not elpy-test-dont-use-virtualenv)
+(unless elpy-test-dont-use-virtualenv
   (ert-deftest elpy-rpc--open-should-open-in-a-dedicated-virtualenv ()
     (elpy-testcase ()
       (let ((elpy-rpc-virtualenv-path 'default))

--- a/test/elpy-rpc-get-venv-test.el
+++ b/test/elpy-rpc-get-venv-test.el
@@ -5,7 +5,7 @@
     (let ((elpy-rpc-virtualenv-path 'default))
       (should (string-match "elpy/rpc-venv" (elpy-rpc-get-or-create-virtualenv))))))
 
-(when (not elpy-test-dont-use-virtualenv)
+(unless elpy-test-dont-use-virtualenv
   (ert-deftest elpy-rpc-get-virtualenv-should-create-the-virtualenv-if-necessary ()
     (elpy-testcase ()
       (let ((elpy-rpc-virtualenv-path 'default))
@@ -27,7 +27,7 @@
      (should-not (string-match "lpy is creating the RPC virtualenv"
                                messages)))))
 
-(when (not elpy-test-dont-use-virtualenv)
+(unless elpy-test-dont-use-virtualenv
   (ert-deftest elpy-rpc-get-virtualenv-should-not-perturbate-the-current-virtualenv ()
     (elpy-testcase ()
       (let ((old-venv pyvenv-virtual-env))
@@ -38,7 +38,7 @@
             (pyvenv-workon old-venv)
           (pyvenv-deactivate))))))
 
-(when (not elpy-test-dont-use-virtualenv)
+(unless elpy-test-dont-use-virtualenv
   (ert-deftest elpy-rpc-get-virtualenv-should-update-the-virtualenv-when-rpc-command-change ()
     (elpy-testcase ()
      (let ((elpy-rpc-virtualenv-path 'default))
@@ -57,20 +57,21 @@
                (elpy-rpc-get-or-create-virtualenv)
                (should (string-match "lpy is \\(creating\\|updating\\) the RPC virtualenv" messages)))))))
 
-(when (not elpy-test-dont-use-virtualenv)
+(unless elpy-test-dont-use-virtualenv
   (ert-deftest elpy-rpc-get-virtualenv-should-NOT-update-the-virtualenv-when-it-is-not-the-default-venv ()
     (elpy-testcase ()
      (let ((elpy-rpc-virtualenv-path (concat
-                                      (file-name-as-directory (pyvenv-workon-home))
+                                      (file-name-as-directory
+                                       (pyvenv-workon-home))
                                       "elpy-test-venv")))
-     (mletf* ((message (mess &rest rest)
+       (mletf* ((message (mess &rest rest)
                          (setq messages
                                (concat messages (apply 'format mess rest))))
-              (messages ""))
-       (elpy-rpc-get-or-create-virtualenv)
-       (should-not (string-match "lpy is installing the RPC virtualenv" messages)))))))
+                (messages ""))
+               (elpy-rpc-get-or-create-virtualenv)
+               (should-not (string-match "lpy is installing the RPC virtualenv" messages)))))))
 
-(when (not elpy-test-dont-use-virtualenv)
+(unless elpy-test-dont-use-virtualenv
   (ert-deftest elpy-rpc-get-virtualenv-should-ask-before-creating-venvs ()
     (elpy-testcase ()
      (mletf* ((elpy-rpc-virtualenv-path "other-venv")

--- a/test/elpy-rpc-get-venv-test.el
+++ b/test/elpy-rpc-get-venv-test.el
@@ -5,15 +5,16 @@
     (let ((elpy-rpc-virtualenv-path 'default))
       (should (string-match "elpy/rpc-venv" (elpy-rpc-get-or-create-virtualenv))))))
 
-(ert-deftest elpy-rpc-get-virtualenv-should-create-the-virtualenv-if-necessary ()
-  (elpy-testcase ()
-    (let ((elpy-rpc-virtualenv-path 'default))
-      (should (string-match "elpy/rpc-venv"
-                            (elpy-rpc-get-or-create-virtualenv)))
-      (delete-directory (elpy-rpc-get-or-create-virtualenv) t nil)
-      (should (string-match "elpy/rpc-venv"
-                            (elpy-rpc-get-or-create-virtualenv)))
-      (should (file-exists-p (elpy-rpc-get-or-create-virtualenv))))))
+(when (not elpy-test-dont-use-virtualenv)
+  (ert-deftest elpy-rpc-get-virtualenv-should-create-the-virtualenv-if-necessary ()
+    (elpy-testcase ()
+      (let ((elpy-rpc-virtualenv-path 'default))
+        (should (string-match "elpy/rpc-venv"
+                              (elpy-rpc-get-or-create-virtualenv)))
+        (delete-directory (elpy-rpc-get-or-create-virtualenv) t nil)
+        (should (string-match "elpy/rpc-venv"
+                              (elpy-rpc-get-or-create-virtualenv)))
+        (should (file-exists-p (elpy-rpc-get-or-create-virtualenv)))))))
 
 (ert-deftest elpy-rpc-get-virtualenv-should-not-reinstall-the-virtualenv-every-time ()
   (elpy-testcase ()
@@ -26,48 +27,54 @@
      (should-not (string-match "lpy is creating the RPC virtualenv"
                                messages)))))
 
-(ert-deftest elpy-rpc-get-virtualenv-should-not-perturbate-the-current-virtualenv ()
-  (elpy-testcase ()
-    (let ((old-venv pyvenv-virtual-env))
-      (pyvenv-workon "elpy-test-venv")
-      (elpy-rpc-get-or-create-virtualenv)
-      (should (string= pyvenv-virtual-env-name "elpy-test-venv"))
-      (pyvenv-workon old-venv))))
+(when (not elpy-test-dont-use-virtualenv)
+  (ert-deftest elpy-rpc-get-virtualenv-should-not-perturbate-the-current-virtualenv ()
+    (elpy-testcase ()
+      (let ((old-venv pyvenv-virtual-env))
+        (pyvenv-workon "elpy-test-venv")
+        (elpy-rpc-get-or-create-virtualenv)
+        (should (string= pyvenv-virtual-env-name "elpy-test-venv"))
+        (if old-venv
+            (pyvenv-workon old-venv)
+          (pyvenv-deactivate))))))
 
-(ert-deftest elpy-rpc-get-virtualenv-should-update-the-virtualenv-when-rpc-command-change ()
-  (elpy-testcase ()
-   (let ((elpy-rpc-virtualenv-path 'default))
-     (let* ((rpc-venv-path (elpy-rpc-get-or-create-virtualenv))
-            (venv-python-path-command-file
-             (concat (file-name-as-directory (elpy-rpc-get-virtualenv-path))
-                     "elpy-rpc-python-path-command")))
-       ;; Simulate a modification of `elpy-rpc-python-command' by modifying
-       ;; the cookie file
-       (with-temp-file venv-python-path-command-file
-         (insert "Another python command")))
+(when (not elpy-test-dont-use-virtualenv)
+  (ert-deftest elpy-rpc-get-virtualenv-should-update-the-virtualenv-when-rpc-command-change ()
+    (elpy-testcase ()
+     (let ((elpy-rpc-virtualenv-path 'default))
+       (let* ((rpc-venv-path (elpy-rpc-get-or-create-virtualenv))
+              (venv-python-path-command-file
+               (concat (file-name-as-directory (elpy-rpc-get-virtualenv-path))
+                       "elpy-rpc-python-path-command")))
+         ;; Simulate a modification of `elpy-rpc-python-command' by modifying
+         ;; the cookie file
+         (with-temp-file venv-python-path-command-file
+           (insert "Another python command")))
+       (mletf* ((message (mess &rest rest)
+                         (setq messages
+                               (concat messages (apply 'format mess rest))))
+                (messages ""))
+               (elpy-rpc-get-or-create-virtualenv)
+               (should (string-match "lpy is \\(creating\\|updating\\) the RPC virtualenv" messages)))))))
+
+(when (not elpy-test-dont-use-virtualenv)
+  (ert-deftest elpy-rpc-get-virtualenv-should-NOT-update-the-virtualenv-when-it-is-not-the-default-venv ()
+    (elpy-testcase ()
+     (let ((elpy-rpc-virtualenv-path (concat
+                                      (file-name-as-directory (pyvenv-workon-home))
+                                      "elpy-test-venv")))
      (mletf* ((message (mess &rest rest)
-                       (setq messages
-                             (concat messages (apply 'format mess rest))))
+                         (setq messages
+                               (concat messages (apply 'format mess rest))))
               (messages ""))
-             (elpy-rpc-get-or-create-virtualenv)
-             (should (string-match "lpy is \\(creating\\|updating\\) the RPC virtualenv" messages))))))
+       (elpy-rpc-get-or-create-virtualenv)
+       (should-not (string-match "lpy is installing the RPC virtualenv" messages)))))))
 
-(ert-deftest elpy-rpc-get-virtualenv-should-NOT-update-the-virtualenv-when-it-is-not-the-default-venv ()
-  (elpy-testcase ()
-   (let ((elpy-rpc-virtualenv-path (concat
-                                    (file-name-as-directory (pyvenv-workon-home))
-                                    "elpy-test-venv")))
-   (mletf* ((message (mess &rest rest)
-                       (setq messages
-                             (concat messages (apply 'format mess rest))))
-            (messages ""))
-     (elpy-rpc-get-or-create-virtualenv)
-     (should-not (string-match "lpy is installing the RPC virtualenv" messages))))))
-
-(ert-deftest elpy-rpc-get-virtualenv-should-ask-before-creating-venvs ()
-  (elpy-testcase ()
-   (mletf* ((elpy-rpc-virtualenv-path "other-venv")
-            (was-asked nil)
-            (y-or-n-p (prompt) (setq was-asked t) nil))
-     (elpy-rpc-get-or-create-virtualenv)
-     (should was-asked))))
+(when (not elpy-test-dont-use-virtualenv)
+  (ert-deftest elpy-rpc-get-virtualenv-should-ask-before-creating-venvs ()
+    (elpy-testcase ()
+     (mletf* ((elpy-rpc-virtualenv-path "other-venv")
+              (was-asked nil)
+              (y-or-n-p (prompt) (setq was-asked t) nil))
+       (elpy-rpc-get-or-create-virtualenv)
+       (should was-asked)))))

--- a/test/elpy-rpc-get-virtualenv-path-test.el
+++ b/test/elpy-rpc-get-virtualenv-path-test.el
@@ -1,7 +1,7 @@
 ;;; -*-coding: utf-8-*-
 
 
-(when (not elpy-test-dont-use-virtualenv)
+(unless elpy-test-dont-use-virtualenv
   (ert-deftest elpy-rpc-get-virtualenv-path-should-return-default-path ()
     (elpy-testcase ()
       (let ((elpy-rpc-virtualenv-path 'default)
@@ -13,7 +13,7 @@
             (pyvenv-activate old-venv)
           (pyvenv-deactivate))))))
 
-(when (not elpy-test-dont-use-virtualenv)
+(unless elpy-test-dont-use-virtualenv
   (ert-deftest elpy-rpc-get-virtualenv-path-should-return-current-venv-path ()
     (elpy-testcase ()
       (let ((elpy-rpc-virtualenv-path 'current)
@@ -39,13 +39,13 @@
           (pyvenv-activate old-venv)
         (pyvenv-deactivate)))))
 
-(when (not elpy-test-dont-use-virtualenv)
+(unless elpy-test-dont-use-virtualenv
  (ert-deftest elpy-rpc-get-virtualenv-path-should-return-custom-venv ()
    (elpy-testcase ()
      (let ((elpy-rpc-virtualenv-path "elpy-test-venv"))
        (should (string-match "elpy-test-venv" (elpy-rpc-get-virtualenv-path)))))))
 
-(when (not elpy-test-dont-use-virtualenv)
+(unless elpy-test-dont-use-virtualenv
  (ert-deftest elpy-rpc-get-virtualenv-path-should-return-custom-venv-with-fun ()
    (elpy-testcase ()
      (let ((elpy-rpc-virtualenv-path (lambda () "elpy-test-venv")))

--- a/test/elpy-rpc-get-virtualenv-path-test.el
+++ b/test/elpy-rpc-get-virtualenv-path-test.el
@@ -1,39 +1,52 @@
 ;;; -*-coding: utf-8-*-
 
 
-(ert-deftest elpy-rpc-get-virtualenv-path-should-return-default-path ()
-  (elpy-testcase ()
-    (let ((elpy-rpc-virtualenv-path 'default))
-      (should (string-match "elpy/rpc-venv" (elpy-rpc-get-virtualenv-path)))
-      (pyvenv-workon "elpy-test-venv")
-      (should (string-match "elpy/rpc-venv" (elpy-rpc-get-virtualenv-path)))
-      (pyvenv-deactivate))))
+(when (not elpy-test-dont-use-virtualenv)
+  (ert-deftest elpy-rpc-get-virtualenv-path-should-return-default-path ()
+    (elpy-testcase ()
+      (let ((elpy-rpc-virtualenv-path 'default)
+            (old-venv pyvenv-virtual-env))
+        (should (string-match "elpy/rpc-venv" (elpy-rpc-get-virtualenv-path)))
+        (pyvenv-workon "elpy-test-venv")
+        (should (string-match "elpy/rpc-venv" (elpy-rpc-get-virtualenv-path)))
+        (if old-venv
+            (pyvenv-activate old-venv)
+          (pyvenv-deactivate))))))
 
-(ert-deftest elpy-rpc-get-virtualenv-path-should-return-current-venv-path ()
-  (elpy-testcase ()
-    (let ((elpy-rpc-virtualenv-path 'current))
-      (should (string-match "\\(travis/virtualenv/python\\|.virtualenvs/elpy\\)"
-                            (elpy-rpc-get-virtualenv-path)))
-      (pyvenv-workon "elpy-test-venv")
-      (should (string-match "elpy-test-venv" (elpy-rpc-get-virtualenv-path)))
-      (pyvenv-deactivate))))
+(when (not elpy-test-dont-use-virtualenv)
+  (ert-deftest elpy-rpc-get-virtualenv-path-should-return-current-venv-path ()
+    (elpy-testcase ()
+      (let ((elpy-rpc-virtualenv-path 'current)
+            (old-venv pyvenv-virtual-env))
+        (should (string-match "\\(travis/virtualenv/python\\|.virtualenvs/elpy\\)"
+                              (elpy-rpc-get-virtualenv-path)))
+        (pyvenv-workon "elpy-test-venv")
+        (should (string-match "elpy-test-venv" (elpy-rpc-get-virtualenv-path)))
+        (if old-venv
+            (pyvenv-activate old-venv)
+          (pyvenv-deactivate))))))
 
 (ert-deftest elpy-rpc-get-virtualenv-path-should-return-global-venv-path ()
   (elpy-testcase ()
-    (let ((elpy-rpc-virtualenv-path 'system))
+    (let ((elpy-rpc-virtualenv-path 'system)
+          (old-venv pyvenv-virtual-env))
       (should-not (string-match "\\(travis/virtualenv\\|.virtualenvs\\)"
                             (elpy-rpc-get-virtualenv-path)))
       (pyvenv-workon "elpy-test-venv")
       (should-not (string-match "\\(travis/virtualenv\\|.virtualenvs\\)"
                             (elpy-rpc-get-virtualenv-path)))
-      (pyvenv-deactivate))))
+      (if old-venv
+          (pyvenv-activate old-venv)
+        (pyvenv-deactivate)))))
 
-(ert-deftest elpy-rpc-get-virtualenv-path-should-return-custom-venv ()
-  (elpy-testcase ()
-    (let ((elpy-rpc-virtualenv-path "elpy-test-venv"))
-      (should (string-match "elpy-test-venv" (elpy-rpc-get-virtualenv-path))))))
+(when (not elpy-test-dont-use-virtualenv)
+ (ert-deftest elpy-rpc-get-virtualenv-path-should-return-custom-venv ()
+   (elpy-testcase ()
+     (let ((elpy-rpc-virtualenv-path "elpy-test-venv"))
+       (should (string-match "elpy-test-venv" (elpy-rpc-get-virtualenv-path)))))))
 
-(ert-deftest elpy-rpc-get-virtualenv-path-should-return-custom-venv-with-fun ()
-  (elpy-testcase ()
-    (let ((elpy-rpc-virtualenv-path (lambda () "elpy-test-venv")))
-      (should (string-match "elpy-test-venv" (elpy-rpc-get-virtualenv-path))))))
+(when (not elpy-test-dont-use-virtualenv)
+ (ert-deftest elpy-rpc-get-virtualenv-path-should-return-custom-venv-with-fun ()
+   (elpy-testcase ()
+     (let ((elpy-rpc-virtualenv-path (lambda () "elpy-test-venv")))
+       (should (string-match "elpy-test-venv" (elpy-rpc-get-virtualenv-path)))))))

--- a/test/elpy-shell-echo-inputs-and-outputs-test.el
+++ b/test/elpy-shell-echo-inputs-and-outputs-test.el
@@ -41,6 +41,7 @@
     ;; on "for i in range(10):"
     (goto-char 30)
     (elpy-shell-kill t)
+    ;; Send statement
     (elpy-shell-send-statement)
     (python-shell-send-string "print('OK')\n")
     (should (string-match ">>> for i in range(10):"

--- a/test/elpy-with-rpc-venv-activated-test.el
+++ b/test/elpy-with-rpc-venv-activated-test.el
@@ -1,21 +1,5 @@
 ;;; -*-coding: utf-8-*-
 
-(ert-deftest elpy-with-rpc-virtualenv-activated-should-temporarily-activate-the-rpc-virtualenv ()
-  (elpy-testcase ()
-    (let ((elpy-rpc-virtualenv-path 'default)
-          (current-venv pyvenv-virtual-env-name))
-    (with-elpy-rpc-virtualenv-activated
-     (should (string= pyvenv-virtual-env-name "rpc-venv")))
-    (should (string= pyvenv-virtual-env-name current-venv)))))
-
-(ert-deftest elpy-with-rpc-virtualenv-activated-should-handle-errors ()
-  (elpy-testcase ()
-    (let ((current-venv pyvenv-virtual-env-name))
-      (condition-case nil
-          (with-elpy-rpc-virtualenv-activated
-           (error "nope"))
-          (error t))
-    (should (string= pyvenv-virtual-env-name current-venv)))))
 
 (ert-deftest elpy-with-rpc-virtualenv-should-not-activate-venv-when-using-the-same-venv ()
   ;; when the current environment is the same as the RPC environment,
@@ -38,3 +22,21 @@
         (with-elpy-rpc-virtualenv-activated
          "pass")
         (should venv-has-been-activated)))))
+
+(when (not elpy-test-dont-use-virtualenv)
+  (ert-deftest elpy-with-rpc-virtualenv-activated-should-temporarily-activate-the-rpc-virtualenv ()
+    (elpy-testcase ()
+      (let ((elpy-rpc-virtualenv-path 'default)
+            (current-venv pyvenv-virtual-env-name))
+      (with-elpy-rpc-virtualenv-activated
+       (should (string= pyvenv-virtual-env-name "rpc-venv")))
+      (should (string= pyvenv-virtual-env-name current-venv)))))
+
+  (ert-deftest elpy-with-rpc-virtualenv-activated-should-handle-errors ()
+    (elpy-testcase ()
+      (let ((current-venv pyvenv-virtual-env-name))
+        (condition-case nil
+            (with-elpy-rpc-virtualenv-activated
+             (error "nope"))
+            (error t))
+      (should (string= pyvenv-virtual-env-name current-venv))))))

--- a/test/elpy-with-rpc-venv-activated-test.el
+++ b/test/elpy-with-rpc-venv-activated-test.el
@@ -23,7 +23,7 @@
          "pass")
         (should venv-has-been-activated)))))
 
-(when (not elpy-test-dont-use-virtualenv)
+(unless elpy-test-dont-use-virtualenv
   (ert-deftest elpy-with-rpc-virtualenv-activated-should-temporarily-activate-the-rpc-virtualenv ()
     (elpy-testcase ()
       (let ((elpy-rpc-virtualenv-path 'default)

--- a/test/test-helper.el
+++ b/test/test-helper.el
@@ -56,11 +56,11 @@ Run BODY with that binding."
        (unwind-protect
            (progn ,@body)
          (dolist (proc (process-list))
-           (when (not (member proc ,old-process-list))
+           (unless (member proc ,old-process-list)
              (kill-process proc)))
          (let ((kill-buffer-query-functions nil))
            (dolist (buf (buffer-list))
-             (when (not (member buf ,old-buffer-list))
+             (unless (member buf ,old-buffer-list)
                (kill-buffer buf))))))))
 
 (defun elpy-testcase-transform-spec (speclist body)
@@ -77,7 +77,7 @@ Run BODY with that binding."
               ,(elpy-testcase-transform-spec (cdr speclist)
                                              body))))
         (`:emacs-required
-         (when (not (version< emacs-version (cadr spec)))
+         (unless (version< emacs-version (cadr spec))
            (elpy-testcase-transform-spec (cdr speclist)
 					 body)))
         (`:teardown
@@ -126,7 +126,7 @@ for that file."
                        (cadr spec)))
            (fullname (format "%s/%s" basedir filename))
            (dirname (file-name-directory fullname)))
-      (when (not (file-directory-p dirname))
+      (unless (file-directory-p dirname)
         (make-directory dirname t))
       (write-region contents nil fullname))))
 

--- a/test/test-helper.el
+++ b/test/test-helper.el
@@ -10,6 +10,14 @@
 (require 'elpy)
 ;; Travis regularly has some lag for some reason.
 (setq elpy-rpc-timeout 10)
+;; If the environment variable `ELPY_TEST_DONT_USE_VIRTUALENV' is
+;; defined, don't check for features involving virtualenvs.
+;; This permits testing on platforms that do not allow virtualenvs
+;; (for the Debian package for example)
+(setq elpy-test-dont-use-virtualenv (getenv "ELPY_TEST_DONT_USE_VIRTUALENV"))
+(when elpy-test-dont-use-virtualenv
+  (message "ELPY_TEST_DONT_USE_VIRTUALENV is set, skipping tests using virtualenvs.")
+  (setq elpy-rpc-virtualenv-path 'system))
 
 (defmacro mletf* (bindings &rest body)
   "Liket `cl-letf*', just with a slightly more concise function syntax.


### PR DESCRIPTION
# PR Summary
Follow #1673.

This allows to run Elpy test suite on system that cannot use virtual environments.
This is notably helpful for the Debian package 

# PR checklist
- [x] Commits respect our [guidelines](../CONTRIBUTING.rst)
- [x] Tests are passing properly (see [here](https://elpy.readthedocs.io/en/latest/extending.html#running-tests) on how to run Elpy's tests
- [x] The documentation has been updated
