### PR TITLE
Use native python fontification when sending input to shell (fix #1428)

### DIFF
--- a/elpy-shell.el
+++ b/elpy-shell.el
@@ -519,8 +519,10 @@ complete). Otherwise, does nothing."
   (let ((from-point (point)))
     (insert string)
     (if (not no-font-lock)
-        (add-text-properties from-point (point)
-                             (list 'front-sticky t 'font-lock-face face)))))
+        (if (eq face 'python-font-lock)
+            (python-shell-font-lock-post-command-hook)
+          (add-text-properties from-point (point)
+                               (list 'front-sticky t 'font-lock-face face))))))
 
 (defun elpy-shell--append-to-shell-output (string &optional no-font-lock prepend-cont-prompt)
   "Append the given STRING to the output of the Python shell buffer.
@@ -540,7 +542,7 @@ Prepends a continuation promt if PREPEND-CONT-PROMPT is set."
                    (lines (split-string string "\n")))
               (goto-char mark-point)
               (elpy-shell--insert-and-font-lock
-               (car lines) 'comint-highlight-input no-font-lock)
+               (car lines) 'python-font-lock no-font-lock)
               (when (cdr lines)
                   ;; no additional newline at end for multiline
                   (dolist (line (cdr lines))
@@ -548,11 +550,11 @@ Prepends a continuation promt if PREPEND-CONT-PROMPT is set."
                     (elpy-shell--insert-and-font-lock
                      prompt 'comint-highlight-prompt no-font-lock)
                     (elpy-shell--insert-and-font-lock
-                     line 'comint-highlight-input no-font-lock)))
+                     line 'python-font-lock no-font-lock)))
                 ;; but put one for single line
                 (insert "\n"))
           (elpy-shell--insert-and-font-lock
-           string 'comint-highlight-input no-font-lock))
+           string 'python-font-lock no-font-lock))
         (set-marker (process-mark process) (point)))))))
 
 (defun elpy-shell--string-head-lines (string n)


### PR DESCRIPTION
# PR Summary

Use full python font locking in shell, even when sending input from an elpy buffer. Fixes #1428 

**Warning**: this is not ready for merging because it requires some changes upstream that I'm pushing here: https://debbugs.gnu.org/cgi/bugreport.cgi?bug=32344

Specifically, these two very simple patches should be merged:

* https://debbugs.gnu.org/cgi/bugreport.cgi?msg=20;att=1;bug=32344;filename=0001-Option-for-comint-to-honour-original-input-highlight.patch

* https://debbugs.gnu.org/cgi/bugreport.cgi?msg=35;att=1;bug=32344;filename=0001-Keep-python-shell-input-colorization-in-comint.patch

Alternatively we could add an "experimental module" (disabled by default) to get this [1] working now using some elisp hack:

```elisp
(advice-add 'elpy-shell--insert-and-font-lock
            :around (lambda (f string face &optional no-font-lock)
                      (if (not (eq face 'comint-highlight-input))
                          (funcall f string face no-font-lock)
                        (funcall f string face t)
                        (python-shell-font-lock-post-command-hook))))
```
But let's hope my patches get merged upstream.


# PR checklist

Please make sure that the following things have been addressed (and check the relevant checkboxes):

- [x] Commits respect our [guidelines](../CONTRIBUTING.rst)
- [x] Tests are passing properly (see [here](https://elpy.readthedocs.io/en/latest/extending.html#running-tests) on how to run Elpy's tests)

---

[1] And probably other stuff that require monkey-patching hacks. Related to https://github.com/jorgenschaefer/elpy/issues/1531