### PR TITLE
Make Elpy aware of decorators

### DIFF
--- a/docs/ide.rst
+++ b/docs/ide.rst
@@ -323,8 +323,9 @@ for each combination of: whether or not the point should move after sending
 
    Send the current statement to the Python shell and keep point position. Here
    statement refers to the Python statement the point is on, including
-   potentially nested statements and, if point is on an if/elif/else clause, the
-   entire if statement (with all its elif/else clauses).
+   potentially nested statements. If point is on an if/elif/else clause send the
+   entire if statement (with all its elif/else clauses). If point is on a
+   decorated function, send the decorator as well.
 
 .. command:: elpy-shell-send-statement-and-step
    :kbd: C-c C-y C-e

--- a/elpy-shell.el
+++ b/elpy-shell.el
@@ -388,8 +388,8 @@ BEGIN and END refer to the region of the current buffer containing the code bein
   (eq (string-match-p "^\\s-*@[A-Za-z]" (thing-at-point 'line)) 0))
 
 (defun elpy-shell--current-line-decorated-defun-p ()
-  (save-excursion (and (python-nav-backward-statement)
-                       (elpy-shell--current-line-decorator-p))))
+  (save-excursion  (python-nav-backward-statement)
+                   (elpy-shell--current-line-decorator-p)))
 
 (defun elpy-shell--current-line-indented-p ()
   (eq (string-match-p "\\s-+[^\\s-]+" (thing-at-point 'line)) 0))

--- a/test/elpy-shell-send-defun-test.el
+++ b/test/elpy-shell-send-defun-test.el
@@ -1,4 +1,4 @@
-(ert-deftest elpy-shell-send-statement-should-send-statement-at-point ()
+(ert-deftest elpy-shell-send-defun-should-send-defun-at-point ()
   (elpy-testcase ()
     (python-mode)
     (elpy-mode)
@@ -16,37 +16,35 @@
     ;; on "a = 2+2"
     (goto-char 52)
     (elpy-shell-kill t)
-    (elpy-shell-send-statement)
-    (python-shell-send-string "print(a)\n")
-    (python-shell-send-string "print('OK')\n")
-    (should (string-match ">>> 4"
-                          (with-current-buffer "*Python*"
-                            (elpy/wait-for-output "OK" 30)
-                            (buffer-string))))
-    ;; on "for i in range(10):"
-    (goto-char 30)
-    (elpy-shell-kill t)
-    (elpy-shell-send-statement)
-    (python-shell-send-string "print(b)\n")
-    (python-shell-send-string "print('OK')\n")
-    (should (string-match ">>> 13"
-                          (with-current-buffer "*Python*"
-                            (elpy/wait-for-output "OK" 30)
-                            (buffer-string))))
-    (python-shell-send-string "del b")
-    ;; on "def foo():"
-    (goto-char 6)
-    (elpy-shell-kill t)
-    (elpy-shell-send-statement)
+    (elpy-shell-send-defun)
     (python-shell-send-string "foo()\n")
     (python-shell-send-string "print('OK')\n")
     (should (string-match ">>> 13"
                           (with-current-buffer "*Python*"
                             (elpy/wait-for-output "OK" 30)
                             (buffer-string))))
-    ))
+    ;; on "for i in range(10):"
+    (goto-char 30)
+    (elpy-shell-kill t)
+    (elpy-shell-send-defun)
+    (python-shell-send-string "foo()\n")
+    (python-shell-send-string "print('OK')\n")
+    (should (string-match ">>> 13"
+                          (with-current-buffer "*Python*"
+                            (elpy/wait-for-output "OK" 30)
+                            (buffer-string))))
+    ;; on "def foo():"
+    (goto-char 6)
+    (elpy-shell-kill t)
+    (elpy-shell-send-defun)
+    (python-shell-send-string "foo()\n")
+    (python-shell-send-string "print('OK')\n")
+    (should (string-match ">>> 13"
+                          (with-current-buffer "*Python*"
+                            (elpy/wait-for-output "OK" 30)
+                            (buffer-string))))))
 
-(ert-deftest elpy-shell-send-statement-should-send-statement-and-decorator ()
+(ert-deftest elpy-shell-send-defun-should-send-defun-and-decorator ()
   (elpy-testcase ()
     (python-mode)
     (elpy-mode)
@@ -68,13 +66,39 @@ def foo():
     print(b)
 ")
 
-    ;; on "foo"
+    ;; on "a = 2+2"
     (elpy-shell-kill t)
     ;; send deco definition
     (goto-char 4)
-    (elpy-shell-send-statement)
+    (elpy-shell-send-defun)
+    (goto-char 145)
+    (elpy-shell-send-defun)
+    (python-shell-send-string "foo()\n")
+    (python-shell-send-string "print('OK')\n")
+    (should (string-match "in decorator"
+                          (with-current-buffer "*Python*"
+                            (elpy/wait-for-output "OK" 30)
+                            (buffer-string))))
+    ;; on "for i in range(10):"
+    (elpy-shell-kill t)
+    ;; send deco definition
+    (goto-char 4)
+    (elpy-shell-send-defun)
+    (goto-char 119)
+    (elpy-shell-send-defun)
+    (python-shell-send-string "foo()\n")
+    (python-shell-send-string "print('OK')\n")
+    (should (string-match "in decorator"
+                          (with-current-buffer "*Python*"
+                            (elpy/wait-for-output "OK" 30)
+                            (buffer-string))))
+    ;; on "def foo():"
+    (elpy-shell-kill t)
+    ;; send deco definition
+    (goto-char 4)
+    (elpy-shell-send-defun)
     (goto-char 96)
-    (elpy-shell-send-statement)
+    (elpy-shell-send-defun)
     (python-shell-send-string "foo()\n")
     (python-shell-send-string "print('OK')\n")
     (should (string-match "in decorator"
@@ -86,7 +110,7 @@ def foo():
     ;; send deco definition
     (goto-char 4)
     (elpy-shell-send-statement)
-    (goto-char 86)
+    (goto-char 87)
     (elpy-shell-send-statement)
     (python-shell-send-string "foo()\n")
     (python-shell-send-string "print('OK')\n")


### PR DESCRIPTION
# PR Summary

Follow #1704.

At the moment, `elpy-shell-send-statement` and `elpy-shell-send-defun` do not send the decorators of decorated functions.

This PR make those functions aware of decorators so that they are properly send to the shell with their function definition.

# PR checklist

- [x] Commits respect our [guidelines](../CONTRIBUTING.rst)
- [x] Tests are passing properly (see [here](https://elpy.readthedocs.io/en/latest/extending.html#running-tests) on how to run Elpy's tests)
- [x] Tests has been added to cover the change
- [x] The documentation has been updated
