### PR TITLE
Avoid accumulating jedi processes

### DIFF
--- a/elpy/jedibackend.py
+++ b/elpy/jedibackend.py
@@ -9,6 +9,7 @@ https://github.com/davidhalter/jedi
 import sys
 import traceback
 import re
+import gc
 
 import jedi
 
@@ -326,6 +327,10 @@ def run_with_debug(jedi, name, *args, **kwargs):
     re_raise = kwargs.pop('re_raise', ())
     try:
         script = jedi.Script(*args, **kwargs)
+        # Explicitly call the garbage collector to avoid
+        # accumulating jedi processes
+        # (see https://github.com/jorgenschaefer/elpy/issues/1481)
+        gc.collect()
         return getattr(script, name)()
     except Exception as e:
         if isinstance(e, re_raise):


### PR DESCRIPTION
# PR Summary
 Follow #1481.

Explicitly run the garbage collector after jedi calls.
Apparently it is not done properly on some platforms/configs (see related issue),
which result in an accumulation of jedi processes eating up the ram.

This is just a workaround, as the garbage collector should be run from time to time automatically.
We need to assess the impact on completion speed before merging.


# PR checklist

- [ ] Commits respect our [guidelines](../CONTRIBUTING.rst)
- [ ] Tests are passing properly (see [here](https://elpy.readthedocs.io/en/latest/extending.html#running-tests) on how to run Elpy's tests)

