### PR TITLE
Update the documentation on `elpy-rpc-python-command`

### DIFF
--- a/docs/concepts.rst
+++ b/docs/concepts.rst
@@ -39,11 +39,15 @@ There are a few options and commands related to the RPC process.
 .. option:: elpy-rpc-python-command
 
    The Python interpreter Elpy should use to run the RPC process. This
-   defaults to ``"python"``, which should be correct for most cases,
-   as a virtual env should make that the right interpreter.
+   defaults to ``"python"``, which should be correct for most cases.
 
    Please do note that this is *not* an interactive interpreter, so do
-   not set this to ``"ipython"`` or similar.
+   not set this to ``"ipython"``, ``"jupyter"`` or similar.
+
+   As the RPC should be independent of any virtual environment, Elpy
+   will try to use the system interpreter if it exists. If you wish
+   to use a specific python interpreter (from a virtual environment
+   for example), set this to the full interpreter path.
 
 .. option:: elpy-rpc-virtualenv-path
 

--- a/elpy-rpc.el
+++ b/elpy-rpc.el
@@ -74,8 +74,12 @@ this to prevent this from happening."
                                      "python")
   "The Python interpreter for the RPC backend.
 
-This should be the same interpreter the project will be run with,
-and not an interactive shell like ipython."
+This should NOT be an interactive shell like ipython or jupyter.
+
+As the RPC should be independent of any virtual environment, Elpy
+will try to use the system interpreter if it exists. If you wish
+to use a specific python interpreter (from a virtual environment
+for example), set this to the full interpreter path."
   :type '(choice (const :tag "python" "python")
                  (const :tag "python2" "python2")
                  (const :tag "python3" "python3")


### PR DESCRIPTION
# PR Summary

Follow #1713 .

The way the RPC virtualenv is created has been modified lately in #1699.
Elpy now try to use the system python interpreter to create the virtualenv.

It has been done for two reasons:
- virtualenvs created by `venv` keep a link with the environment they have been created from, which is notably a problem when using pip in them.
- the python interpreters for the RPC and the interactive shells don't have to be the same, so most of the time, it doesn't really matters which interpreter is used for the RPC.

This PR just update the documentation of `elpy-rpc-python-command` to reflect those changes.

