### PR TITLE
Install flake8 in the current env instead of the rpc venv

### DIFF
--- a/elpy.el
+++ b/elpy.el
@@ -856,7 +856,7 @@ item in another window.\n\n")
        "\n")
       (insert "\n")
       (widget-create 'elpy-insert--pip-button
-                     :package python-shell-interpreter)
+                     :package python-shell-interpreter :norpc t)
       (insert "\n\n"))
 
     ;; Pip not available in the rpc virtualenv
@@ -970,7 +970,7 @@ item in another window.\n\n")
        "program to provide syntax checks of your programs, so you might "
        "want to install one. Elpy by default uses flake8.\n")
       (insert "\n")
-      (widget-create 'elpy-insert--pip-button :package "flake8")
+      (widget-create 'elpy-insert--pip-button :package "flake8" :norpc t)
       (insert "\n\n"))
 
     ))
@@ -1285,8 +1285,12 @@ PyPI, or nil if that's VERSION."
 
 (defun elpy-insert--pip-button-action (widget &optional _event)
   "The :action option for the pip button widget."
-  (with-elpy-rpc-virtualenv-activated
-   (async-shell-command (widget-get widget :command))))
+  (let ((command (widget-get widget :command))
+        (norpc (widget-get widget :norpc)))
+    (if norpc
+        (async-shell-command command)
+      (with-elpy-rpc-virtualenv-activated
+       (async-shell-command command)))))
 
 ;;;;;;;;;;;;
 ;;; Projects


### PR DESCRIPTION
# PR Summary
Follow #1740 (thanks for @yoricksijsling for the investigation).

Currently, in `elpy-config`, Elpy tries to install flake8 in the rpc venv.
This PR fixes this and Elpy now properly installs flake8 in the current environment.

# PR checklist

Please make sure that the following things have been addressed (and check the relevant checkboxes):

- [x] Commits respect our [guidelines](../CONTRIBUTING.rst)
- [x] Tests are passing properly (see [here](https://elpy.readthedocs.io/en/latest/extending.html#running-tests) on how to run Elpy's tests)
