### PR TITLE
Fix a fatal typo in elpy-format-code

### DIFF
--- a/elpy.el
+++ b/elpy.el
@@ -2279,10 +2279,10 @@ prefix argument is given, prompt for a symbol from the user."
     (when (interactive-p) (message "Autoformatting code with yapf."))
     (elpy-yapf-fix-code))
    ((elpy-config--package-available-p "autopep8")
-    ((when (interactive-p) message "Autoformatting code with autopep8."))
+    (when (interactive-p) (message "Autoformatting code with autopep8."))
     (elpy-autopep8-fix-code))
    ((elpy-config--package-available-p "black")
-    ((when (interactive-p) message "Autoformatting code with black."))
+    (when (interactive-p) (message "Autoformatting code with black."))
     (elpy-black-fix-code))
    (t
     (message "Install yapf/autopep8 to format code."))))


### PR DESCRIPTION
# PR Summary

Fix a fatal typo in elpy-format-code

# PR checklist

Please make sure that the following things have been addressed (and check the relevant checkboxes):

- [x] Commits respect our [guidelines](../CONTRIBUTING.rst)
- [x] Tests are passing properly (see [here](https://elpy.readthedocs.io/en/latest/extending.html#running-tests) on how to run Elpy's tests)
