### PR TITLE
Make eldoc faster (and slightly smarter)

### DIFF
--- a/elpy-rpc.el
+++ b/elpy-rpc.el
@@ -1051,6 +1051,19 @@ Returns a calltip string for the function call at point."
               success error)))
 
 
+(defun elpy-rpc-get-calltip-or-oneline-docstring (&optional success error)
+  "Call the get_calltip_or_oneline_doc API function.
+
+Returns a calltip string or a oneline docstring for the function call at point."
+  (when (< (buffer-size) elpy-rpc-ignored-buffer-size)
+    (elpy-rpc "get_calltip_or_oneline_docstring"
+              (list buffer-file-name
+                    (elpy-rpc--buffer-contents)
+                    (- (point)
+                       (point-min)))
+              success error)))
+
+
 (defun elpy-rpc-get-oneline-docstring (&optional success error)
   "Call the get_oneline_docstring API function.
 

--- a/elpy/server.py
+++ b/elpy/server.py
@@ -79,6 +79,14 @@ class ElpyRPCServer(JSONRPCServer):
         return self._call_backend("rpc_get_oneline_docstring", None, filename,
                                   get_source(source), offset)
 
+    def rpc_get_calltip_or_oneline_docstring(self, filename, source, offset):
+        """Get a calltip or a oneline docstring for the symbol at the offset.
+
+        """
+        return self._call_backend("rpc_get_calltip_or_oneline_docstring",
+                                  None, filename,
+                                  get_source(source), offset)
+
     def rpc_get_completions(self, filename, source, offset):
         """Get a list of completion candidates for the symbol at offset.
 

--- a/elpy/tests/test_server.py
+++ b/elpy/tests/test_server.py
@@ -211,6 +211,18 @@ class TestRPCGetOnelineDocstring(BackendCallTestCase):
                                                              "offset"))
 
 
+class TestRPCGetCalltipOrOnelineDocstring(BackendCallTestCase):
+    def test_should_call_backend(self):
+        self.assert_calls_backend("rpc_get_calltip_or_oneline_docstring")
+
+    def test_should_handle_no_backend(self):
+        self.srv.backend = None
+        self.assertIsNone(
+            self.srv.rpc_get_calltip_or_oneline_docstring("filname",
+                                                          "source",
+                                                          "offset"))
+
+
 class TestRPCGetPydocCompletions(ServerTestCase):
     @mock.patch.object(server, 'get_pydoc_completions')
     def test_should_call_pydoc_completions(self, get_pydoc_completions):

--- a/test/elpy-eldoc-documentation-test.el
+++ b/test/elpy-eldoc-documentation-test.el
@@ -9,7 +9,7 @@
 ;; Calltip available: display that
 (ert-deftest elpy-eldoc-documentation-should-show-string-calltip ()
   (elpy-testcase ()
-    (mletf* ((elpy-rpc-get-calltip
+    (mletf* ((elpy-rpc-get-calltip-or-oneline-docstring
               (callback)
               (funcall callback "Queue.cancel_join_thread()"))
              (calltip nil)
@@ -21,10 +21,11 @@
 
 (ert-deftest elpy-eldoc-documentation-should-show-object-calltip ()
   (elpy-testcase ()
-    (mletf* ((elpy-rpc-get-calltip
+    (mletf* ((elpy-rpc-get-calltip-or-oneline-docstring
               (callback)
               (funcall callback '((name . "cancel_join_thread")
                                   (index . 0)
+                                  (kind . "calltip")
                                   (params "foo" "bar"))))
              (calltip nil)
              (eldoc-message (tip) (setq calltip tip)))
@@ -40,10 +41,11 @@
 
 (ert-deftest elpy-eldoc-documentation-should-not-fail-for-index-nil ()
   (elpy-testcase ()
-    (mletf* ((elpy-rpc-get-calltip
+    (mletf* ((elpy-rpc-get-calltip-or-oneline-docstring
               (callback)
               (funcall callback '((name . "cancel_join_thread")
                                   (index . nil)
+                                  (kind . "calltip")
                                   (params . nil))))
              (calltip nil)
              ;; without UI, the minibuffer width is only 9,
@@ -59,12 +61,10 @@
 ;; No calltip: display function oneline docstring
 (ert-deftest elpy-eldoc-documentation-should-show-object-onelinedoc ()
   (elpy-testcase ()
-    (mletf* ((elpy-rpc-get-calltip
-              (callback)
-              (funcall callback nil))
-             (elpy-rpc-get-oneline-docstring
+    (mletf* ((elpy-rpc-get-calltip-or-oneline-docstring
               (callback)
               (funcall callback '((name . "cancel_join_thread()")
+                                  (kind . "oneline_doc")
                                   (doc . "This function does things."))))
              (doc nil)
              (window-width (buff) 100000000)
@@ -84,8 +84,8 @@
 ;; No calltip and docstring: display current edited function
 (ert-deftest elpy-eldoc-documentation-should-use-current-defun-if-nothing-else ()
   (elpy-testcase ()
-    (mletf* ((elpy-rpc-get-calltip (callback) (funcall callback nil))
-             (elpy-rpc-get-oneline-docstring (callback) (funcall callback nil))
+    (mletf* ((elpy-rpc-get-calltip-or-oneline-docstring (callback)
+                                                        (funcall callback nil))
              (calltip nil)
              (eldoc-message (tip) (setq calltip tip))
              (python-info-current-defun () "FooClass.method"))
@@ -97,8 +97,8 @@
 ;; No calltip, docstring or current function: display nothing
 (ert-deftest elpy-eldoc-documentation-should-return-nil-without-defun ()
   (elpy-testcase ()
-    (mletf* ((elpy-rpc-get-calltip (callback) (funcall callback nil))
-             (elpy-rpc-get-oneline-docstring (callback) (funcall callback nil))
+    (mletf* ((elpy-rpc-get-calltip-or-oneline-docstring (callback)
+                                                        (funcall callback nil))
              (calltip nil)
              (eldoc-message (tip) (setq calltip tip))
              (python-info-current-defun () nil))


### PR DESCRIPTION
# PR Summary
Make eldoc display faster by avoiding multiple calls to the RPC.
Also enhance a bit the kind of information eldoc displays:
- Avoid displaying infos about basic builtins  
- In case we can display a calltip and a function at the same time, favour the function if the doc is available.

# PR checklist

Please make sure that the following things have been addressed (and check the relevant checkboxes):

- [x] Commits respect our [guidelines](../CONTRIBUTING.rst)
- [x] Tests are passing properly (see [here](https://elpy.readthedocs.io/en/latest/extending.html#running-tests) on how to run Elpy's tests)

