### PR TITLE
Fix typo in elpy-shell-add-to-shell-history docstring & enhance flow

### DIFF
--- a/elpy-shell.el
+++ b/elpy-shell.el
@@ -155,10 +155,11 @@ the code cell beginnings defined here."
   :group 'elpy)
 
 (defcustom elpy-shell-add-to-shell-history nil
-  "If Elpy should make the code sent to the shell available in the
-shell history. This allows to use `comint-previous-input' in the
-python shell to get back the pieces of code sent by Elpy. This affects
-the following functions:
+  "Toggle that affects whether Elpy makes the code that is sent
+to the Python shell available in the shell's history.  If
+enabled, use `comint-previous-input' in the Python shell to get
+back the pieces of code sent by Elpy. This affects the following
+functions:
 - `elpy-shell-send-statement'
 - `elpy-shell-send-top-statement'
 - `elpy-shell-send-group'


### PR DESCRIPTION
Post-edits, this docstring makes it sound like this toggle enables a
kill-ring or clipboard history for the Python shell, which sounds like
it's always a good thing.  That said, it's disabled by default.  I
believe it would be useful to let the user know why it's disabled by
default.

Also, I think it would be useful to have a follow up commit that
explains how it "affects the following functions:…".

# PR checklist

Please make sure that the following things have been addressed (and check the relevant checkboxes):

- [x] Commits respect our [guidelines](../CONTRIBUTING.rst)
- [x] Tests are passing properly (see [here](https://elpy.readthedocs.io/en/latest/extending.html#running-tests) on how to run Elpy's tests)

## For new features only:
- [ ] Tests has been added to cover the change
- [x] The documentation has been updated
