### PR TITLE
Completion type hints

### DIFF
--- a/elpy/jedibackend.py
+++ b/elpy/jedibackend.py
@@ -369,7 +369,7 @@ def linecol_to_pos(text, line, col):
 
 
 def get_annotation(proposal):
-    if proposal.type in ("instance", "statement", "param"):
+    if proposal.type in ("instance", "statement", "param", "function"):
         try:
             hint = " ({})".format(proposal.get_type_hint())
         except AttributeError:

--- a/elpy/jedibackend.py
+++ b/elpy/jedibackend.py
@@ -371,10 +371,10 @@ def linecol_to_pos(text, line, col):
 def get_annotation(proposal):
     if proposal.type in ("instance", "statement", "param"):
         try:
-            hint = proposal.get_type_hint()
+            hint = " ({})".format(proposal.get_type_hint())
         except AttributeError:
             hint = ""
-        return "{} ({})".format(proposal.type, hint)
+        return proposal.type + hint
     else:
         return proposal.type
 

--- a/test/elpy-rpc-get-completions-test.el
+++ b/test/elpy-rpc-get-completions-test.el
@@ -33,6 +33,22 @@
           (should (string= (alist-get 'meta compl2) "def addition2"))
           (should (string= (alist-get 'annotation compl2) "function")))))
 
+(ert-deftest elpy-rpc-get-completions-should-include-type-hints ()
+    (elpy-testcase ((:project project-root "test.py")
+                    (:emacs-required "25.1"))
+        (find-file (f-join project-root "test.py"))
+        (elpy-enable)
+        (python-mode)
+        (insert "test_var: int = 3\n"
+                "test_")
+        (let* ((compls (elpy-rpc-get-completions))
+               (compl1 (car compls))
+               (compl2 (car (cdr compls))))
+          (should (string= (alist-get 'name compl1) "test_var"))
+          (should (string= (alist-get 'suffix compl1) "var"))
+          (should (string= (alist-get 'meta compl1) "test_var: int = 3"))
+          (should (string= (alist-get 'annotation compl1) "statement (int)")))))
+
 (ert-deftest elpy-rpc-get-completions-should-not-return-completion-for-numbers ()
     (elpy-testcase ((:project project-root "test.py")
                     (:emacs-required "25.1"))


### PR DESCRIPTION
# PR Summary

See #1773

This adds support for use of the `get_type_hint` method for Jedi completions that was added 0.17.0. For appropriate proposals type hints are added as part of the completion annotation.

Please let me know if there are any other locations where `get_type_hint` could be useful and I'll happily take a look.

For completion candidates of functions the type hints can be quite long so it might be sensible to introduce a truncation. Let me know any thoughts.

# PR checklist

Please make sure that the following things have been addressed (and check the relevant checkboxes):

- [ ] Commits respect our [guidelines](../CONTRIBUTING.rst)
- [ ] Tests are passing properly (see [here](https://elpy.readthedocs.io/en/latest/extending.html#running-tests) on how to run Elpy's tests)

## For new features only:
- [ ] Tests has been added to cover the change
- [ ] The documentation has been updated
