### PR TITLE
Make removal ElDoc from modeline conditional #1788

### DIFF
--- a/elpy.el
+++ b/elpy.el
@@ -3095,7 +3095,7 @@ and return the list."
   (pcase command
     (`global-init
      (require 'eldoc)
-     (setq eldoc-minor-mode-string nil))
+     (elpy-modules-remove-modeline-lighter 'eldoc-minor-mode))
     (`buffer-init
      ;; avoid eldoc message flickering when using eldoc and company modules jointly
      (eldoc-add-command-completions "company-")


### PR DESCRIPTION
# PR Summary

Fix for #1788 

Instead of unconditionally removing ElDoc from modeline, use `elpy-modules-remove-modeline-lighter` to respect user's setting when `elpy-remove-modeline-lighter` set to `nil`.

6 unexpected failures, but they are not related to the proposed changes.

# PR checklist

Please make sure that the following things have been addressed (and check the relevant checkboxes):

- [x] Commits respect our [guidelines](../CONTRIBUTING.rst)
- [ ] Tests are passing properly (see [here](https://elpy.readthedocs.io/en/latest/extending.html#running-tests) on how to run Elpy's tests)

## For new features only:
- [ ] Tests has been added to cover the change
- [ ] The documentation has been updated
