### PR TITLE
Add warning when Elpy not properly enabled

### DIFF
--- a/elpy.el
+++ b/elpy.el
@@ -535,12 +535,13 @@ This option need to bet set through `customize' or `customize-set-variable' to b
     (add-hook 'inferior-python-mode-hook 'elpy-shell--enable-output-filter)
     (add-hook 'python-shell-first-prompt-hook 'elpy-shell--send-setup-code t)
     ;; Enable Elpy-mode in the opened python buffer
+    (setq elpy-enabled-p t)
     (dolist (buffer (buffer-list))
       (and (not (string-match "^ ?\\*" (buffer-name buffer)))
            (with-current-buffer buffer
              (when (string= major-mode 'python-mode)
                (elpy-mode t)))))
-    (setq elpy-enabled-p t)))
+    ))
 
 (defun elpy-disable ()
   "Disable Elpy in all future Python buffers."
@@ -567,6 +568,8 @@ virtualenv.
   :lighter " Elpy"
   (unless (derived-mode-p 'python-mode)
     (error "Elpy only works with `python-mode'"))
+  (unless elpy-enabled-p
+    (error "Please enable Elpy with `(elpy-enable)` before using it"))
   (when (boundp 'xref-backend-functions)
     (add-hook 'xref-backend-functions #'elpy--xref-backend nil t))
   (cond

--- a/test/elpy-folding-fold-all-comments-test.el
+++ b/test/elpy-folding-fold-all-comments-test.el
@@ -20,8 +20,8 @@
      "# Another comment on"
      "# two lines !"
      "var2 = foo(var1, 4)")
+    (elpy-enable)
     (python-mode)
-    (elpy-mode)
     ;; Fold all comments
     (elpy-folding-toggle-comments)
     (let* ((overlays (overlays-in (point-min) (point-max)))

--- a/test/elpy-folding-fold-all-docstrings-test.el
+++ b/test/elpy-folding-fold-all-docstrings-test.el
@@ -29,8 +29,8 @@
      "    print(mess)"
      ""
      "var2 = foo(var1, 4)")
+    (elpy-enable)
     (python-mode)
-    (elpy-mode)
     (elpy-folding-toggle-docstrings)
     (let* ((overlays (overlays-in (point-min) (point-max)))
            overlay)

--- a/test/elpy-folding-fold-blocks-test.el
+++ b/test/elpy-folding-fold-blocks-test.el
@@ -6,8 +6,8 @@
      "def foo(_|_a, b):"
      "  c = a + b"
      "var2 = foo(var1, 4)")
+    (elpy-enable)
     (python-mode)
-    (elpy-mode)
     (elpy-folding-toggle-at-point)
     (let* ((overlays (apply 'nconc (overlay-lists)))
            overlay)
@@ -31,8 +31,8 @@
      "def foo(a, b):"
      "  c = _|_a + b"
      "var2 = foo(var1, 4)")
+    (elpy-enable)
     (python-mode)
-    (elpy-mode)
     (elpy-folding-toggle-at-point)
     (let* ((overlays (apply 'nconc (overlay-lists)))
            overlay)
@@ -58,8 +58,8 @@
      "  return c"
      "_|_"
      "var2 = foo(var1, 4)")
+    (elpy-enable)
     (python-mode)
-    (elpy-mode)
     (elpy-folding-toggle-at-point)
     ;; Position
     (should (= (point) 49))))
@@ -76,8 +76,8 @@
      "    print(mess)"
      "    return _|_mess"
      "var2 = foo(var1, 4)")
+    (elpy-enable)
     (python-mode)
-    (elpy-mode)
     (elpy-folding-toggle-at-point)
     (let* ((overlays (apply 'nconc (overlay-lists)))
            overlay)
@@ -107,8 +107,8 @@
      "    print(mess)"
      "    return _|_mess"
      "var2 = foo(var1, 4)")
+    (elpy-enable)
     (python-mode)
-    (elpy-mode)
     (elpy-folding-toggle-at-point)
     (let* ((overlays (apply 'nconc (overlay-lists)))
            overlay)
@@ -138,8 +138,8 @@
      "    print(mess)"
      "    return mess"
      "var2 = foo(var1, 4)")
+    (elpy-enable)
     (python-mode)
-    (elpy-mode)
     (elpy-folding-toggle-at-point)
     (let* ((overlays (apply 'nconc (overlay-lists)))
            overlay)

--- a/test/elpy-folding-fold-comments-test.el
+++ b/test/elpy-folding-fold-comments-test.el
@@ -15,8 +15,8 @@
      "    print(mess)"
      "    return mess"
      "var2 = foo(var1, 4)")
+    (elpy-enable)
     (python-mode)
-    (elpy-mode)
     (elpy-folding-toggle-at-point)
     (let* ((overlays (overlays-in (point-min) (point-max)))
            overlay)
@@ -46,7 +46,7 @@
      "    print(mess)"
      "    return mess"
      "var2 = foo(var1, 4)")
+    (elpy-enable)
     (python-mode)
-    (elpy-mode)
     (elpy-folding-toggle-at-point)
     (should (= (point) 112))))

--- a/test/elpy-folding-fold-docstrings-test.el
+++ b/test/elpy-folding-fold-docstrings-test.el
@@ -18,8 +18,8 @@
      "    print(mess)"
      "    return mess"
      "var2 = foo(var1, 4)")
+    (elpy-enable)
     (python-mode)
-    (elpy-mode)
     (elpy-folding-toggle-at-point)
     (let* ((overlays (overlays-in (point-min) (point-max)))
            overlay)
@@ -55,8 +55,8 @@
      "    print(mess)"
      "    return mess"
      "var2 = foo(var1, 4)")
+    (elpy-enable)
     (python-mode)
-    (elpy-mode)
     (elpy-folding-toggle-at-point)
     (let* ((overlays (overlays-in (point-min) (point-max)))
            overlay)
@@ -86,8 +86,8 @@
      "    print(mess)"
      "    return mess"
      "var2 = foo(var1, 4)")
+    (elpy-enable)
     (python-mode)
-    (elpy-mode)
     (elpy-folding-toggle-at-point)
     (let* ((overlays (overlays-in (point-min) (point-max))))
       (dolist (overlay overlays)
@@ -108,8 +108,8 @@
      "    print(mess)"
      "    return mess"
      "var2 = foo(var1, 4)")
+    (elpy-enable)
     (python-mode)
-    (elpy-mode)
     (let ((nmb-overlays (length (overlays-in (point-min) (point-max)))))
       (elpy-folding-toggle-at-point)
       (let* ((overlays (overlays-in (point-min) (point-max)))
@@ -132,8 +132,8 @@
      "    print(mess)"
      "    return mess"
      "var2 = foo(var1, 4)")
+    (elpy-enable)
     (python-mode)
-    (elpy-mode)
     (let ((nmb-overlays (length (overlays-in (point-min) (point-max)))))
       (elpy-folding-toggle-at-point)
       (let* ((overlays (overlays-in (point-min) (point-max)))
@@ -156,8 +156,8 @@
      "    print(mess)"
      "    return mess"
      "var2 = foo(var1, 4)")
+    (elpy-enable)
     (python-mode)
-    (elpy-mode)
     (elpy-folding-toggle-at-point)
     (let* ((overlays (overlays-in (point-min) (point-max)))
            overlay)
@@ -188,8 +188,8 @@
      "    print(mess)"
      "    return mess"
      "var2 = foo(var1, 4)")
+    (elpy-enable)
     (python-mode)
-    (elpy-mode)
     (elpy-folding-toggle-at-point)
     (let* ((overlays (overlays-in (point-min) (point-max)))
            overlay)

--- a/test/elpy-folding-fold-leafs-test.el
+++ b/test/elpy-folding-fold-leafs-test.el
@@ -14,8 +14,8 @@
      "      print(_|_mess)"
      "    return mess"
      "var2 = foo(var1, 4)")
+    (elpy-enable)
     (python-mode)
-    (elpy-mode)
     (elpy-folding-hide-leafs)
     (let* ((overlays (overlays-in (point-min) (point-max)))
            overlay)

--- a/test/elpy-folding-fold-on-click-test.el
+++ b/test/elpy-folding-fold-on-click-test.el
@@ -6,8 +6,8 @@
      "def foo(_|_a, b):"
      "  c = a + b"
      "var2 = foo(var1, 4)")
+    (elpy-enable)
     (python-mode)
-    (elpy-mode)
     (mletf* ((mouse-set-point (event) (goto-char (point))))
       (elpy-folding--click-fringe nil))
     (let* ((overlays (apply 'nconc (overlay-lists)))
@@ -33,8 +33,8 @@
      "def foo(_|_a, b):"
      "  c = a + b"
      "var2 = foo(var1, 4)")
+    (elpy-enable)
     (python-mode)
-    (elpy-mode)
     (mletf* ((mouse-set-point (event) (goto-char (point))))
       (elpy-folding--click-fringe nil))
     (let* ((overlays (apply 'nconc (overlay-lists)))

--- a/test/elpy-folding-should-mark-foldable-lines-test.el
+++ b/test/elpy-folding-should-mark-foldable-lines-test.el
@@ -18,8 +18,8 @@
      "    print(mess)"
      "    return mess"
      "var2 = foo(var1, 4)")
+    (elpy-enable)
     (python-mode)
-    (elpy-mode)
     (let* ((overlays (overlays-in (point-min) (point-max)))
            overlay)
       (should (= 3 (length overlays)))

--- a/test/elpy-mode-test.el
+++ b/test/elpy-mode-test.el
@@ -3,10 +3,16 @@
     (let ((major-mode 'not-python-mode))
       (should-error (elpy-mode)))))
 
+(ert-deftest elpy-mode-should-fail-when-elpy-not-activated ()
+  (elpy-testcase ()
+    (python-mode)
+    (should-error (elpy-mode))))
+
 (ert-deftest elpy-mode-should-run-buffer-init-on-start ()
   (elpy-testcase ()
     (python-mode)
     (mletf* ((buffer-init-called nil)
+             (elpy-enabled-p t)
              (elpy-modules-buffer-init
               ()
               (setq buffer-init-called t)))
@@ -17,6 +23,7 @@
 
 (ert-deftest elpy-mode-should-run-buffer-stop-on-stop ()
   (elpy-testcase ()
+    (elpy-enable)
     (python-mode)
     (mletf* ((buffer-stop-called nil)
              (elpy-modules-buffer-stop

--- a/test/elpy-open-and-indent-line-above-test.el
+++ b/test/elpy-open-and-indent-line-above-test.el
@@ -3,8 +3,8 @@
 
 ;; (ert-deftest elpy-open-and-indent-line-below ()
 ;;   (elpy-testcase ()
+;;     (elpy-enable)
 ;;     (python-mode)
-;;     (elpy-mode 1)
 ;;     (insert-source
 ;;      "def foo():"
 ;;      "    x = 5")

--- a/test/elpy-open-and-indent-line-below-test.el
+++ b/test/elpy-open-and-indent-line-below-test.el
@@ -3,8 +3,8 @@
 
 ;; (ert-deftest elpy-open-and-indent-line-below ()
 ;;   (elpy-testcase ()
+;;     (elpy-enable)
 ;;     (python-mode)
-;;     (elpy-mode 1)
 ;;     (insert "def foo():\n")
 ;;     (goto-char 2)
 ;;     (elpy-open-and-indent-line-below)


### PR DESCRIPTION
# PR Summary
Elpy needs to be activated with `(elpy-enable)`.
Starting directly `elpy-mode` (which is more intuitive) will only partially work.

This PR adds a warning message in case a user start directly `elpy-mode` without having enabled it.

# PR checklist

Please make sure that the following things have been addressed (and check the relevant checkboxes):

- [x] Commits respect our [guidelines](../CONTRIBUTING.rst)
- [x] Tests are passing properly (see [here](https://elpy.readthedocs.io/en/latest/extending.html#running-tests) on how to run Elpy's tests)
- [x] Tests has been added to cover the change
