### PR TITLE
change elpy-rpc-pythonpath to support native-comp

### DIFF
--- a/elpy-rpc.el
+++ b/elpy-rpc.el
@@ -96,7 +96,7 @@ for example), set this to the full interpreter path."
            (elpy-rpc-restart)))
   :group 'elpy)
 
-(defcustom elpy-rpc-pythonpath (file-name-directory (locate-library "elpy"))
+(defcustom elpy-rpc-pythonpath (file-name-directory (locate-library "elpy.el"))
   "A directory to add to the PYTHONPATH for the RPC process.
 
 This should be a directory where the elpy module can be found. If

--- a/elpy-rpc.el
+++ b/elpy-rpc.el
@@ -96,7 +96,7 @@ for example), set this to the full interpreter path."
            (elpy-rpc-restart)))
   :group 'elpy)
 
-(defcustom elpy-rpc-pythonpath (file-name-directory (locate-library "elpy.el"))
+(defcustom elpy-rpc-pythonpath (file-name-directory load-file-name)
   "A directory to add to the PYTHONPATH for the RPC process.
 
 This should be a directory where the elpy module can be found. If


### PR DESCRIPTION
# PR Summary
The `.eln` files created by the native compile feature are not located in the same folder as the `.el` and `.elc` files they are derived from. This means that using `(locate-library "elpy")` to find the right folder for `elpy-rpc-pythonpath` breaks because it returns something like `"/home/tom/.emacs.d/elpa/elpy-20200527.2021/eln-x86_64-pc-linux-gnu-2ca71878e862259e/"` instead of `"/home/tom/.emacs.d/elpa/elpy-20200527.2021/"`. Using `(locate-library "elpy.el")` instead fixes the issue.

@AndreaCorallo Do you have an idea of the extent to which this will be an issue? In other words, how many codebases make use of `locate-library` in ways that will cause bugs that are similar to this? Probably just something to keep an eye on for the changelog for emacs 28, but might be worth starting some community awareness if it turns out to affect multiple packages.

# PR checklist

Please make sure that the following things have been addressed (and check the relevant checkboxes):

- [x] Commits respect our [guidelines](../CONTRIBUTING.rst)
- [x] Tests are passing properly (see [here](https://elpy.readthedocs.io/en/latest/extending.html#running-tests) on how to run Elpy's tests)