### PR TITLE
docs: migrate away from functions removed in Sphinx 3.0

### DIFF
--- a/docs/elispdomain.py
+++ b/docs/elispdomain.py
@@ -8,7 +8,7 @@ Copyright 2014-2019 by Jorgen Schäfer
 
 from sphinx import addnodes
 from sphinx.domains import Domain, ObjType
-from sphinx.locale import l_
+from sphinx.locale import _
 from sphinx.directives import ObjectDescription
 from sphinx.roles import XRefRole
 from sphinx.util.nodes import make_refnode
@@ -106,10 +106,10 @@ class ELispDomain(Domain):
     label = 'ELisp'
 
     object_types = {
-        'function': ObjType(l_('function'), 'function'),
-        'variable': ObjType(l_('variable'), 'variable'),
-        'command': ObjType(l_('function'), 'command'),
-        'option': ObjType(l_('variable'), 'option'),
+        'function': ObjType(_('function'), 'function'),
+        'variable': ObjType(_('variable'), 'variable'),
+        'command': ObjType(_('function'), 'command'),
+        'option': ObjType(_('variable'), 'option'),
     }
     directives = {
         'function': ELispFunction,


### PR DESCRIPTION
Closes: #1816

I decided to try the naïve approach, and it appears to work.  There may be dependencies on other deprecated functions, but I haven't yet learned how to lint Sphinx docs.  I've tested with Sphinx 1.8.4, and am currently setting up a test with 3.1.1, and results will follow shortly.

# PR checklist

Please make sure that the following things have been addressed (and check the relevant checkboxes):

- [x] Commits respect our [guidelines](../CONTRIBUTING.rst)
- [x] Tests are passing properly (see [here](https://elpy.readthedocs.io/en/latest/extending.html#running-tests) on how to run Elpy's tests)

## For new features only:
- [x] Tests has been added to cover the change NA
- [x] The documentation has been updated NA
