### PR TITLE
Fix #1823: support newer eldoc protocol

### DIFF
--- a/elpy.el
+++ b/elpy.el
@@ -3103,22 +3103,40 @@ and return the list."
      (eldoc-add-command-completions "python-indent-dedent-line-backspace")
      (set (make-local-variable 'company-frontends)
           (remq 'company-echo-metadata-frontend company-frontends))
-     (set (make-local-variable 'eldoc-documentation-function)
-          'elpy-eldoc-documentation)
+     (if (boundp 'eldoc-documentation-functions)
+         (add-hook 'eldoc-documentation-functions
+                   'elpy-eldoc-documentation
+                   nil t))
+         (set (make-local-variable 'eldoc-documentation-function)
+              'elpy-eldoc-documentation))
      (eldoc-mode 1))
     (`buffer-stop
      (eldoc-mode -1)
      (kill-local-variable 'eldoc-documentation-function))))
 
-(defun elpy-eldoc-documentation ()
+(defun elpy-eldoc-documentation (&optional callback &rest _more)
   "Return some interesting information for the code at point.
+
+This function is good to place in
+`eldoc-documentation-functions' (plural), (for newer Emacsen) and
+also `eldoc-documentation-function' (for older Emacsen).
 
 This will return flymake errors for the line at point if there
 are any. If not, this will do an asynchronous call to the RPC
 backend to get a call tip, and display that using
 `eldoc-message'. If the backend has no call tip, this will
 display the current class and method instead."
-  (let ((flymake-error (elpy-flymake-error-at-point)))
+  (let ((cb (or callback
+                (lambda (doc &rest plist)
+                  (let ((thing (plist-get plist :thing))
+                        (face (plist-get plist :face)))
+                    (when thing
+                      (setq doc
+                            (if (version<= emacs-version "25")
+                                (format "%s%s" thing doc)
+                              (eldoc-docstring-format-sym-doc thing doc face))))
+                    (eldoc-message doc)))))
+        (flymake-error (elpy-flymake-error-at-point)))
     (if flymake-error
         flymake-error
       (elpy-rpc-get-calltip-or-oneline-docstring
@@ -3126,7 +3144,7 @@ display the current class and method instead."
          (cond
           ;; INFO is a string, just display it
           ((stringp info)
-           (eldoc-message info))
+           (funcall callback info))
           ;; INFO is a calltip
           ((string= (cdr (assq 'kind info)) "calltip")
            (let ((name (cdr (assq 'name info)))
@@ -3140,22 +3158,12 @@ display the current class and method instead."
              (let ((prefix (propertize name 'face
                                        'font-lock-function-name-face))
                    (args (format "(%s)" (mapconcat #'identity params ", "))))
-               (eldoc-message
-                (if (version<= emacs-version "25")
-                    (format "%s%s" prefix args)
-                  (eldoc-docstring-format-sym-doc prefix args nil))))))
+               (funcall callback args :thing prefix))))
           ;; INFO is a oneline docstring
           ((string= (cdr (assq 'kind info)) "oneline_doc")
            (let ((name (cdr (assq 'name info)))
                  (docs (cdr (assq 'doc info))))
-             (let ((prefix (propertize (format "%s: " name)
-                                       'face
-                                       'font-lock-function-name-face)))
-               (eldoc-message
-                (if (version<= emacs-version "25")
-                    (format "%s%s" prefix docs)
-                  (let ((eldoc-echo-area-use-multiline-p nil))
-                    (eldoc-docstring-format-sym-doc prefix docs nil)))))))
+             (funcall cb docs :thing name)))
           ;; INFO is nil, maybe display the current function
           (t
            (if elpy-eldoc-show-current-function
@@ -3167,8 +3175,11 @@ display the current class and method instead."
                              (format "%s()" current-defun)
                              'face 'font-lock-function-name-face)))))
              (eldoc-message ""))))))
-      ;; Return the last message until we're done
-      eldoc-last-message)))
+      (if callback
+          ;; New protocol: return non-nil, non-string
+          t
+        ;; Old protocol: return the last message until we're done
+        eldoc-last-message))))
 
 
 ;;;;;;;;;;;;;;;;;;;

--- a/test/elpy-eldoc-documentation-test.el
+++ b/test/elpy-eldoc-documentation-test.el
@@ -28,6 +28,7 @@
                                   (kind . "calltip")
                                   (params "foo" "bar"))))
              (calltip nil)
+             (window-width (buff) 100000000)
              (eldoc-message (tip) (setq calltip tip)))
 
       (elpy-eldoc-documentation)


### PR DESCRIPTION
This UNTESTED commit should hint at how to fix the issue without
resorting to `eldoc-docstring-format-sym-doc', which is gone in Emacs
28 (ElDoc 1.1.0).

Beyond the ideas delineated in this commit, the new ElDoc protocol
would also easily obviate the need to have "flymake-specific" ElDoc
code in ElPy (this is now default in stock Flymake), as well as being
forced to choose between different types of ElPy docstrings.

* elpy.el (elpy-module-eldoc): Add to eldoc-documentation-functions.
(elpy-eldoc-documentation): Rework to support
eldoc-documentation-functions.

# PR Summary


# PR checklist

Please make sure that the following things have been addressed (and check the relevant checkboxes):

- [ ] Commits respect our [guidelines](../CONTRIBUTING.rst)
- [ ] Tests are passing properly (see [here](https://elpy.readthedocs.io/en/latest/extending.html#running-tests) on how to run Elpy's tests)

## For new features only:
- [ ] Tests has been added to cover the change
- [ ] The documentation has been updated
