### PR TITLE
Allow to select autoformatter

### DIFF
--- a/docs/ide.rst
+++ b/docs/ide.rst
@@ -781,13 +781,17 @@ Refactoring
 
    Format code using the available formatter.
 
-   This command formats code using the first formatter found amongst
-   `yapf`_ , `autopep8`_ and `black`_.
    If a region is selected, only that region is formatted.
    Otherwise current buffer is formatted.
 
+.. option:: elpy-formatter
+
+   Allow to select the formatter you want to use amongst
+   `yapf`_ , `autopep8`_ and `black`_.
+
    `yapf`_ and `autopep8`_ can be configured with style files placed in
    the project root directory (determined by ``elpy-project-root``).
+   `black`_ can be configured in the ``pyproject.toml`` file of your project.
 
 .. _autopep8: https://github.com/hhatto/autopep8
 .. _yapf: https://github.com/google/yapf

--- a/elpy.el
+++ b/elpy.el
@@ -280,6 +280,18 @@ option is `pdb'."
   :type 'boolean
   :group 'elpy)
 
+
+(defcustom elpy-formatter nil
+  "Auto formatter used by `elpy-format-code'.
+
+if nil, use the first formatter found amongst
+`yapf' , `autopep8' and `black'."
+  :type '(choice (const :tag "First one found" nil)
+                 (const :tag "Yapf" yapf)
+                 (const :tag "autopep8" autopep8)
+                 (const :tag "Black" black))
+  :group 'elpy)
+
 (defcustom elpy-syntax-check-command "flake8"
   "The command to use for `elpy-check'."
   :type 'string
@@ -2281,21 +2293,25 @@ prefix argument is given, prompt for a symbol from the user."
 ;;;;;;;;;;;;;;;;;;;;;
 ;;; Code reformatting
 
+
 (defun elpy-format-code ()
   "Format code using the available formatter."
   (interactive)
-  (cond
-   ((elpy-config--package-available-p "yapf")
-    (when (interactive-p) (message "Autoformatting code with yapf."))
-    (elpy-yapf-fix-code))
-   ((elpy-config--package-available-p "autopep8")
-    (when (interactive-p) (message "Autoformatting code with autopep8."))
-    (elpy-autopep8-fix-code))
-   ((elpy-config--package-available-p "black")
-    (when (interactive-p) (message "Autoformatting code with black."))
-    (elpy-black-fix-code))
-   (t
-    (message "Install yapf/autopep8 to format code."))))
+  (let ((elpy-formatter (or elpy-formatter
+                            (catch 'available
+                              (dolist (formatter '(yapf autopep8 black))
+                                (when (elpy-config--package-available-p
+                                       formatter)
+                                  (throw 'available formatter)))))))
+    (unless elpy-formatter
+      (error "No formatter installed, please install one using `elpy-config'"))
+    (unless (elpy-config--package-available-p elpy-formatter)
+      (error "The '%s' formatter is not installed, please install it using `elpy-config' or choose another one using `elpy-formatter'"
+             elpy-formatter))
+    (when (interactive-p) (message "Autoformatting code with %s."
+                                   elpy-formatter))
+    (funcall (intern (format "elpy-%s-fix-code" elpy-formatter)))))
+
 
 (defun elpy-yapf-fix-code ()
   "Automatically formats Python code with yapf.

--- a/test/elpy-format-code-test.el
+++ b/test/elpy-format-code-test.el
@@ -1,0 +1,63 @@
+(ert-deftest elpy-should-format-code-with-default-formatter ()
+  (elpy-testcase ()
+     (set-buffer-string-with-point
+      "_|_y=  2"
+      "z=3"
+      "x  = 3")
+
+     (elpy-format-code)
+
+     (should
+      (buffer-be
+       "_|_y = 2"
+       "z = 3"
+       "x = 3"
+       ))))
+
+(ert-deftest elpy-should-format-code-with-yapf-formatter ()
+      (let ((elpy-formatter 'yapf)
+            backend-called)
+        (elpy-testcase ()
+           (set-buffer-string-with-point
+            "_|_y=  2"
+            "z=3"
+            "x  = 3")
+
+           (mletf* ((elpy-yapf-fix-code ()
+                      (setq backend-called "yapf")))
+             (call-interactively 'elpy-format-code))
+
+           (should (string= backend-called "yapf"))
+           )))
+
+(ert-deftest elpy-should-format-code-with-autopep8-formatter ()
+  (let ((elpy-formatter 'autopep8)
+        backend-called)
+    (elpy-testcase ()
+       (set-buffer-string-with-point
+        "_|_y=  2"
+        "z=3"
+        "x  = 3")
+
+       (mletf* ((elpy-autopep8-fix-code ()
+                   (setq backend-called "autopep8")))
+         (call-interactively 'elpy-format-code))
+
+       (should (string= backend-called "autopep8"))
+       )))
+
+(ert-deftest elpy-should-format-code-with-autopep8-formatter ()
+  (let ((elpy-formatter 'black)
+        backend-called)
+    (elpy-testcase ()
+       (set-buffer-string-with-point
+        "_|_y=  2"
+        "z=3"
+        "x  = 3")
+
+       (mletf* ((elpy-black-fix-code ()
+                   (setq backend-called "black")))
+         (call-interactively 'elpy-format-code))
+
+       (should (string= backend-called "black"))
+       )))


### PR DESCRIPTION
# PR Summary
This PR allow the user to select the autoformatter used by `elpy-format-code`.
Until now, Elpy was using the first one it could found.

# PR checklist

- [x] Commits respect our [guidelines](../CONTRIBUTING.rst)
- [x] Tests are passing properly (see [here](https://elpy.readthedocs.io/en/latest/extending.html#running-tests) on how to run Elpy's tests)

## For new features only:
- [x] Tests has been added to cover the change
- [x] The documentation has been updated