### PR TITLE
Preinstall emacs 25 instead of emacs 24 during test preparation

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,0 +1,52 @@
+name: CI
+
+on: [push, pull_request]
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        emacs_version:
+          - 24.1
+          - 24.2
+          - 24.3
+          - 24.4
+          - 24.5
+          - 25.1
+          - 25.2
+          - 25.3
+          - 26.1
+          - 26.2
+          - 26.3
+          - 27.1
+          - snapshot
+        # include:
+        #   - emacs_version: 24.1
+        #     lint_ignore: 1
+        #   - emacs_version: 24.2
+        #     lint_ignore: 1
+        python_version:
+          - 2.7
+          - 3.5
+          - 3.6
+          - 3.7
+          - 3.8
+    # env:
+    #   EMACS_LINT_IGNORE: ${{ matrix.lint_ignore }}
+    steps:
+    - uses: actions/checkout@v2
+    - name: Set up Emacs ${{ matrix.emacs_version }}
+      uses: purcell/setup-emacs@master
+      with:
+        version: ${{ matrix.emacs_version }}
+
+    - name: Set up Python ${{ matrix.python_version }}
+      uses: actions/setup-python@v2
+      with:
+        python-version : ${{ matrix.python_version }}
+
+    - name: Set up Cask
+    - uses: conao3/setup-cask@master
+    # - name: Run tests
+    #   run: './run-tests.sh'

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,37 +2,38 @@ language: python
 
 sudo: false
 
-# needed for emacs26 to work
 dist: trusty
 
 python:
-  - 2.7
-  - 3.5
+  # - 2.7
+  # - 3.5
   - 3.6
+  # - 3.7
+  # - 3.8
 
-# While python3.7 is not supported by default dist...
-matrix:
-    include:
-      # - sudo: required
-      #   dist: xenial
-      #   python: 3.7
-      #   env: EVM_EMACS=emacs-24.4-travis
-      - sudo: required
-        dist: xenial
-        python: 3.7
-        env: EVM_EMACS=emacs-24.5-travis
-      - sudo: required
-        dist: xenial
-        python: 3.7
-        env: EVM_EMACS=emacs-25.1-travis
-      - sudo: required
-        dist: xenial
-        python: 3.7
-        env: EVM_EMACS=emacs-25.2-travis
-      - sudo: required
-        dist: xenial
-        python: 3.7
-        env: EVM_EMACS=emacs-25.3-travis
+# # While python3.7 is not supported by default dist...
+# matrix:
+#     include:
+#       # - sudo: required
+#       #   dist: xenial
+#       #   python: 3.7
+#       #   env: EVM_EMACS=emacs-24.4-travis
+#       - sudo: required
+#         dist: xenial
+#         python: 3.7
+#         env: EVM_EMACS=emacs-24.5-travis
+#       - sudo: required
+#         dist: xenial
+#         python: 3.7
+#         env: EVM_EMACS=emacs-25.1-travis
+#       - sudo: required
+#         dist: xenial
+#         python: 3.7
+#         env: EVM_EMACS=emacs-25.2-travis
+#       - sudo: required
+#         dist: xenial
+#         python: 3.7
+#         env: EVM_EMACS=emacs-25.3-travis
       # - sudo: required
       #   dist: xenial
       #   python: 3.7
@@ -49,16 +50,19 @@ matrix:
 env:
   # - EVM_EMACS=emacs-24.4-travis
   - EVM_EMACS=emacs-24.5-travis
-  - EVM_EMACS=emacs-25.1-travis
-  - EVM_EMACS=emacs-25.2-travis
+  # - EVM_EMACS=emacs-25.1-travis
+  # - EVM_EMACS=emacs-25.2-travis
   - EVM_EMACS=emacs-25.3-travis
-  - EVM_EMACS=emacs-26.1-travis
-  - EVM_EMACS=emacs-26.2-travis
+  # - EVM_EMACS=emacs-26.1-travis
+  # - EVM_EMACS=emacs-26.2-travis
   - EVM_EMACS=emacs-26.3-travis
+  # - EVM_EMACS=emacs-27.1-travis
+
 before_install:
   - source ./travis-evm-cask.sh
   - evm install $EVM_EMACS --use --skip
   - cask --verbose        # verbose only needed because of cask bug
+
 install:
   - pip install -r requirements.txt --upgrade
   - pip install -r requirements-rpc.txt --upgrade
@@ -71,9 +75,11 @@ install:
     fi
   - pip install coveralls
   - virtualenv ~/.virtualenvs/elpy-test-venv
+
 script:
   - nosetests
   - PYTHONPATH="`pwd`" cask exec ert-runner --reporter ert+duration
+
 after_success:
   - coverage run -m nose.__main__
   - coveralls

--- a/travis-evm-cask.sh
+++ b/travis-evm-cask.sh
@@ -9,8 +9,8 @@
 #
 #  - curl -fsSkL https://gist.github.com/rejeep/ebcd57c3af83b049833b/raw > x.sh && source ./x.sh
 #
-# Emacs 24.3 is installed in the above script because Cask requires
-# Emacs 24 to be installed. Because of this, when installing other
+# Emacs 25.3 is installed in the above script because Cask requires
+# Emacs to be installed. Because of this, when installing other
 # environments in the .travis.yml configuration, use the --skip
 # option, for example:
 #
@@ -21,6 +21,6 @@ export PATH="/home/travis/.cask/bin:$PATH"
 
 git clone https://github.com/rejeep/evm.git /home/travis/.evm
 evm config path /tmp
-evm install emacs-24.3-travis --use --skip
+evm install emacs-25.3-travis --use --skip
 
 curl -fsSkL https://raw.github.com/cask/cask/master/go | python

--- a/travis-evm-cask.sh
+++ b/travis-evm-cask.sh
@@ -9,7 +9,7 @@
 #
 #  - curl -fsSkL https://gist.github.com/rejeep/ebcd57c3af83b049833b/raw > x.sh && source ./x.sh
 #
-# Emacs 25.3 is installed in the above script because Cask requires
+# Emacs 26.3 is installed in the above script because Cask requires
 # Emacs to be installed. Because of this, when installing other
 # environments in the .travis.yml configuration, use the --skip
 # option, for example:


### PR DESCRIPTION
# PR Summary
During test preparation on Travis, emacs need to be installed prior to running cask.
This PR update the version of Emacs installed from 24 to 25, as cask does not seem to support Emacs 24 anymore.