### PR TITLE
Path to str fixes jedibackend tests and skipIf jedi < 0.17.0

### DIFF
--- a/elpy/jedibackend.py
+++ b/elpy/jedibackend.py
@@ -99,7 +99,7 @@ class JediBackend(object):
         if proposal is None:
             return None
         else:
-            return (proposal.module_path, proposal.line)
+            return (str(proposal.module_path), proposal.line)
 
     def rpc_get_docstring(self, filename, source, offset):
         line, column = pos_to_linecol(source, offset)
@@ -165,18 +165,18 @@ class JediBackend(object):
             return None
         loc = locations[-1]
         try:
-            if loc.module_path == filename:
+            if str(loc.module_path) == filename:
                 offset = linecol_to_pos(source,
                                         loc.line,
                                         loc.column)
             else:
-                with open(loc.module_path) as f:
+                with open(str(loc.module_path)) as f:
                     offset = linecol_to_pos(f.read(),
                                             loc.line,
                                             loc.column)
         except IOError:  # pragma: no cover
             return None
-        return (loc.module_path, offset)
+        return (str(loc.module_path), offset)
 
     def rpc_get_definition_jedi16(self, filename, source, offset): # pragma: no cover
         # Backward compatibility to jedi<17
@@ -206,12 +206,12 @@ class JediBackend(object):
             loc = locations[-1]
             try:
                 if loc.module_path:
-                    if loc.module_path == filename:
+                    if str(loc.module_path) == filename:
                         offset = linecol_to_pos(source,
                                                 loc.line,
                                                 loc.column)
                     else:
-                        with open(loc.module_path) as f:
+                        with open(str(loc.module_path)) as f:
                             offset = linecol_to_pos(f.read(),
                                                     loc.line,
                                                     loc.column)
@@ -238,12 +238,12 @@ class JediBackend(object):
             loc = locations[-1]
             try:
                 if loc.module_path:
-                    if loc.module_path == filename:
+                    if str(loc.module_path) == filename:
                         offset = linecol_to_pos(source,
                                                 loc.line,
                                                 loc.column)
                     else:
-                        with open(loc.module_path) as f:
+                        with open(str(loc.module_path)) as f:
                             offset = linecol_to_pos(f.read(),
                                                     loc.line,
                                                     loc.column)
@@ -466,11 +466,14 @@ class JediBackend(object):
             return None
         result = []
         for use in uses:
-            if use.module_path == filename:
+            if str(use.module_path) == filename:
                 offset = linecol_to_pos(source, use.line, use.column)
             elif use.module_path is not None:
-                with open(use.module_path) as f:
-                    text = f.read()
+                try:
+                    with open(str(use.module_path)) as f:
+                        text = f.read()
+                except FileNotFoundError:
+                    text = source
                 offset = linecol_to_pos(text, use.line, use.column)
             result.append({"name": use.name,
                            "filename": use.module_path,
@@ -494,17 +497,18 @@ class JediBackend(object):
             return None
         result = []
         for use in uses:
-            if use.module_path == filename:
+            if str(use.module_path) == filename:
                 offset = linecol_to_pos(source, use.line, use.column)
             elif use.module_path is not None:
-                with open(use.module_path) as f:
-                    text = f.read()
+                try:
+                    with open(str(use.module_path)) as f:
+                        text = f.read()
+                except FileNotFoundError:
+                    text = source
                 offset = linecol_to_pos(text, use.line, use.column)
-
             result.append({"name": use.name,
                            "filename": use.module_path,
                            "offset": offset})
-
         return result
 
     def rpc_get_names(self, filename, source, offset):
@@ -518,11 +522,14 @@ class JediBackend(object):
                                            'references': True})
         result = []
         for name in names:
-            if name.module_path == filename:
+            if str(name.module_path) == filename:
                 offset = linecol_to_pos(source, name.line, name.column)
             elif name.module_path is not None:
-                with open(name.module_path) as f:
-                    text = f.read()
+                try:
+                    with open(str(name.module_path)) as f:
+                        text = f.read()
+                except FileNotFoundError:
+                    text = source
                 offset = linecol_to_pos(text, name.line, name.column)
             result.append({"name": name.name,
                            "filename": name.module_path,
@@ -540,11 +547,14 @@ class JediBackend(object):
 
         result = []
         for name in names:
-            if name.module_path == filename:
+            if str(name.module_path) == filename:
                 offset = linecol_to_pos(source, name.line, name.column)
             elif name.module_path is not None:
-                with open(name.module_path) as f:
-                    text = f.read()
+                try:
+                    with open(str(name.module_path)) as f:
+                        text = f.read()
+                except FileNotFoundError:
+                    text = source
                 offset = linecol_to_pos(text, name.line, name.column)
             result.append({"name": name.name,
                            "filename": name.module_path,

--- a/elpy/rpc.py
+++ b/elpy/rpc.py
@@ -10,6 +10,7 @@ See the documentation of the JSONRPCServer class for further details.
 import json
 import sys
 import traceback
+from pathlib import Path
 
 
 class JSONRPCServer(object):
@@ -67,6 +68,10 @@ class JSONRPCServer(object):
             raise EOFError()
         return json.loads(line)
 
+    def json_defaults(self, x):
+        if isinstance(x, Path):
+            return str(x)
+
     def write_json(self, **kwargs):
         """Write an JSON object on a single line.
 
@@ -74,7 +79,7 @@ class JSONRPCServer(object):
         It's not possible with this method to write non-objects.
 
         """
-        self.stdout.write(json.dumps(kwargs) + "\n")
+        self.stdout.write(json.dumps(kwargs, default=self.json_defaults) + "\n")
         self.stdout.flush()
 
     def handle_request(self):

--- a/elpy/tests/support.py
+++ b/elpy/tests/support.py
@@ -451,6 +451,7 @@ class RPCGetCompletionsTests(GenericRPCTests):
         self.assertEqual([], self.backend.rpc_get_completions("test.py",
                                                               source, offset))
 
+    @unittest.skipIf(jedibackend.JEDISUP17, "Jedi verison > '0.17.0'")
     def test_should_handle_jedi16(self):
         backup = self.backend.rpc_get_completions
         self.backend.rpc_get_completions = self.backend.rpc_get_completions_jedi16
@@ -488,6 +489,7 @@ class RPCGetCompletionDocstringTests(object):
                                                      offset)
         self.assertIsNone(completions)
 
+    @unittest.skipIf(jedibackend.JEDISUP17, "Jedi verison > '0.17.0'")
     def test_should_handle_jedi16(self):
         backup = self.backend.rpc_get_docstring
         self.backend.rpc_get_docstring = self.backend.rpc_get_docstring_jedi16
@@ -624,6 +626,7 @@ class RPCGetDefinitionTests(GenericRPCTests):
                                                          offset),
                          (filename, 0))
 
+    @unittest.skipIf(jedibackend.JEDISUP17, "Jedi verison > '0.17.0'")
     def test_should_handle_jedi16(self):
         backup = self.backend.rpc_get_definition
         self.backend.rpc_get_definition = self.backend.rpc_get_definition_jedi16
@@ -639,6 +642,7 @@ class RPCGetAssignmentTests():
             with self.assertRaises(Fault):
                 self.backend.rpc_get_assignment("test.py", "dummy code", 1)
 
+    @unittest.skipIf(jedibackend.JEDISUP17, "Jedi verison > '0.17.0'")
     def test_should_handle_jedi16(self):
         backup = self.backend.rpc_get_assignment
         self.backend.rpc_get_assignment = self.backend.rpc_get_assignment_jedi16
@@ -804,6 +808,7 @@ class RPCGetCalltipTests(GenericRPCTests):
         self.assertEqual(calltip['kind'], 'oneline_doc')
         self.assertEqual(calltip['doc'], 'No documentation')
 
+    @unittest.skipIf(jedibackend.JEDISUP17, "Jedi verison > '0.17.0'")
     def test_should_handle_jedi16(self):
         backup = self.backend.rpc_get_calltip
         self.backend.rpc_get_calltip = self.backend.rpc_get_calltip_jedi16
@@ -840,6 +845,7 @@ class RPCGetDocstringTests(GenericRPCTests):
                                                    offset)
         self.assertIsNone(docstring)
 
+    @unittest.skipIf(jedibackend.JEDISUP17, "Jedi verison > '0.17.0'")
     def test_should_handle_jedi16(self):
         backup = self.backend.rpc_get_docstring
         self.backend.rpc_get_docstring = self.backend.rpc_get_docstring_jedi16
@@ -901,6 +907,7 @@ class RPCGetOnelineDocstringTests(GenericRPCTests):
                                                                       offset)
         self.assertIsNone(docstring)
 
+    @unittest.skipIf(jedibackend.JEDISUP17, "Jedi verison > '0.17.0'")
     def test_should_handle_jedi16(self):
         backup = self.backend.rpc_get_oneline_docstring
         self.backend.rpc_get_oneline_docstring = self.backend.rpc_get_oneline_docstring_jedi16
@@ -1028,6 +1035,8 @@ class RPCGetNamesTests(GenericRPCTests):
                                            source,
                                            offset)
 
+        for i, name in enumerate(names):
+            names[i]["filename"] = str(names[i]["filename"])
         self.assertEqual(names,
                          [{'name': 'foo',
                            'filename': filename,
@@ -1060,6 +1069,7 @@ class RPCGetNamesTests(GenericRPCTests):
 
         self.assertEqual(names, [])
 
+    @unittest.skipIf(jedibackend.JEDISUP17, "Jedi verison > '0.17.0'")
     def test_should_handle_jedi16(self):
         backup = self.backend.rpc_get_names
         self.backend.rpc_get_names = self.backend.rpc_get_names_jedi16
@@ -1080,7 +1090,8 @@ class RPCGetUsagesTests(GenericRPCTests):
         usages = self.backend.rpc_get_usages(filename,
                                              source,
                                              offset)
-
+        for i, usage in enumerate(usages):
+            usages[i]["filename"] = str(usages[i]["filename"])
         self.assertEqual(usages,
                          [{'name': 'x',
                            'offset': 8,
@@ -1103,6 +1114,8 @@ class RPCGetUsagesTests(GenericRPCTests):
                                              source,
                                              offset)
 
+        for i, usage in enumerate(usages):
+            usages[i]["filename"] = str(usages[i]["filename"])
         self.assertEqual(usages,
                          [{'name': 'x',
                            'filename': file1,
@@ -1120,6 +1133,7 @@ class RPCGetUsagesTests(GenericRPCTests):
 
         self.assertEqual(usages, [])
 
+    @unittest.skipIf(jedibackend.JEDISUP17, "Jedi verison > '0.17.0'")
     def test_should_handle_jedi16(self):
         backup = self.backend.rpc_get_usages
         self.backend.rpc_get_usages = self.backend.rpc_get_usages_jedi16


### PR DESCRIPTION
# PR Summary

Fixes python tests on emacs 27.1 jedi 0.18.0 (possibly with jedi 0.17.x also) with the major change being `jedi` returning type `pathlib.Path` being converted to `str` for `open` and `==`. Have not run lisp tests.

# PR checklist

Please make sure that the following things have been addressed (and check the relevant checkboxes):

- [x] Commits respect our [guidelines](../CONTRIBUTING.rst)
- [x] Tests are passing properly (see [here](https://elpy.readthedocs.io/en/latest/extending.html#running-tests) on how to run Elpy's tests)

## For new features only:
- [ ] Tests has been added to cover the change
- [ ] The documentation has been updated
