### PR TITLE
Update ffip-project-search arguments for ffip >= 6.0.0

### DIFF
--- a/Cask
+++ b/Cask
@@ -12,4 +12,4 @@
 (development
  (depends-on "f")
  (depends-on "ert-runner")
- (depends-on "find-file-in-project"))
+ (depends-on "find-file-in-project" "6.0.0"))

--- a/elpy.el
+++ b/elpy.el
@@ -1627,7 +1627,7 @@ A test file is named test_<name>.py if the current file is
             (let ((projectile-project-root project-root))
               (projectile-current-project-files)))
            ((fboundp 'find-file-in-project)
-            (cl-map 'list 'cdr (ffip-project-search nil nil project-root)))
+            (cl-map 'list 'cdr (ffip-project-search nil nil)))
            (t '())))
          (file (if impl-file
                     (cl-remove-if (lambda (file)

--- a/elpy.el
+++ b/elpy.el
@@ -1627,7 +1627,8 @@ A test file is named test_<name>.py if the current file is
             (let ((projectile-project-root project-root))
               (projectile-current-project-files)))
            ((fboundp 'find-file-in-project)
-            (cl-map 'list 'cdr (ffip-project-search nil nil)))
+            (let ((ffip-project-root project-root))
+              (cl-map 'list 'cdr (ffip-project-search nil nil))))
            (t '())))
          (file (if impl-file
                     (cl-remove-if (lambda (file)


### PR DESCRIPTION
# PR Summary

Simple patch to adapt to an incompatibility introduced by ffip ≥ 6.0.0.  `project-root` appears to be default now, and support for filtering by subdir within project-root appears to have been dropped.

# PR checklist

Please make sure that the following things have been addressed (and check the relevant checkboxes):

- [x] Commits respect our [guidelines](../CONTRIBUTING.rst)
- [x] Tests are passing properly (see [here](https://elpy.readthedocs.io/en/latest/extending.html#running-tests) on how to run Elpy's tests)
  * Tests broken by ffip-project-search's changed arguments now pass, but numerous unrelated issues exist elsewhere.

## For new features only:
- [ ] Tests has been added to cover the change
- [ ] The documentation has been updated
