### PR TITLE
Fix typo in docstring

### DIFF
--- a/elpy-django.el
+++ b/elpy-django.el
@@ -205,7 +205,7 @@ The result is memoized on project root and `DJANGO_SETTINGS_MODULE'"
 
 
 (defun elpy-django--get-test-format ()
-  "When running a Django test, some test runners require a different format that others.
+  "When running a Django test, some test runners require a different format than others.
 Return the correct string format here."
   (let ((runner (elpy-django--get-test-runner))
         (found nil)


### PR DESCRIPTION
# PR Summary
Fixes a typo in the docstring for `elpy-django--get-test-format`

# PR checklist

Please make sure that the following things have been addressed (and check the relevant checkboxes):

- [X] Commits respect our [guidelines](../CONTRIBUTING.rst)
- [X] Tests are passing properly (see [here](https://elpy.readthedocs.io/en/latest/extending.html#running-tests) on how to run Elpy's tests)

## For new features only:
- [ ] Tests has been added to cover the change
- [ ] The documentation has been updated
