### PR TITLE
Fix #1868: elpy-goto-definition breaks with python 3.9

### DIFF
--- a/elpy/rpc.py
+++ b/elpy/rpc.py
@@ -10,6 +10,8 @@ See the documentation of the JSONRPCServer class for further details.
 import json
 import sys
 import traceback
+from pathlib import Path
+
 
 
 class JSONRPCServer(object):

--- a/elpy/rpc.py
+++ b/elpy/rpc.py
@@ -67,6 +67,10 @@ class JSONRPCServer(object):
             raise EOFError()
         return json.loads(line)
 
+    def json_defaults(self, x):
+        if isinstance(x, Path):
+            return str(x)
+
     def write_json(self, **kwargs):
         """Write an JSON object on a single line.
 
@@ -74,7 +78,7 @@ class JSONRPCServer(object):
         It's not possible with this method to write non-objects.
 
         """
-        self.stdout.write(json.dumps(kwargs) + "\n")
+        self.stdout.write(json.dumps(kwargs, default=self.json_defaults) + "\n")
         self.stdout.flush()
 
     def handle_request(self):


### PR DESCRIPTION
Original solution from @akshaybadola here: https://github.com/jorgenschaefer/elpy/issues/1868
