### PR TITLE
Implement rudimentary compatibility with jedi 18.0

### DIFF
--- a/elpy/json_encoder.py
+++ b/elpy/json_encoder.py
@@ -1,0 +1,10 @@
+import json
+import pathlib
+
+
+class JSONEncoder(json.JSONEncoder):
+    def default(self, o):
+        if isinstance(o, pathlib.Path):
+            return str(o)
+        else:
+            return super().default(o)

--- a/elpy/rpc.py
+++ b/elpy/rpc.py
@@ -10,6 +10,7 @@ See the documentation of the JSONRPCServer class for further details.
 import json
 import sys
 import traceback
+from .json_encoder import JSONEncoder
 
 
 class JSONRPCServer(object):
@@ -74,7 +75,8 @@ class JSONRPCServer(object):
         It's not possible with this method to write non-objects.
 
         """
-        self.stdout.write(json.dumps(kwargs) + "\n")
+        serialized_value = JSONEncoder().encode(kwargs)
+        self.stdout.write(serialized_value + "\n")
         self.stdout.flush()
 
     def handle_request(self):

--- a/elpy/tests/support.py
+++ b/elpy/tests/support.py
@@ -13,15 +13,16 @@ discovery would find them there and try to run them, which would fail.
 """
 
 import os
+import pathlib
+import re
 import shutil
 import sys
 import tempfile
 import unittest
-import re
 
-from elpy.tests import compat
-from elpy.rpc import Fault
 from elpy import jedibackend
+from elpy.rpc import Fault
+from elpy.tests import compat
 
 
 class BackendTestCase(unittest.TestCase):
@@ -55,7 +56,7 @@ class BackendTestCase(unittest.TestCase):
             fobj = open(full_name, "w")
         with fobj as f:
             f.write(contents)
-        return full_name
+        return pathlib.Path(full_name)
 
 
 class GenericRPCTests(object):

--- a/requirements-rpc.txt
+++ b/requirements-rpc.txt
@@ -1,4 +1,4 @@
-jedi==0.17.2
+jedi==0.18.0
 rope==0.17.0
 autopep8==1.5.4
 yapf==0.30


### PR DESCRIPTION
# PR Summary

This PR implements basic compatibility with jedi 18.0.  The issue was that the default json serializer used by python json.dumps could not handle `pathlib.Path` objects. This PR addresses the issue by extending the default JSONEncoder class. `pathlib.Path` objects are converted to str before encoding them to json.

# PR checklist

Please make sure that the following things have been addressed (and check the relevant checkboxes):

- [x] Commits respect our [guidelines](../CONTRIBUTING.rst)
- [x] Tests are passing properly (see [here](https://elpy.readthedocs.io/en/latest/extending.html#running-tests) on how to run Elpy's tests)

Test are not really passing BUT the tests were not passing before this change anyway. At least some more tests are passing now.
