### PR TITLE
elpy-refactor: use the symbol to be renamed for initial input when prompting for new name

### DIFF
--- a/elpy-refactor.el
+++ b/elpy-refactor.el
@@ -192,7 +192,8 @@ do not display the diff before applying."
                       (error "No symbol at point")
                     (read-string
                      (format "New name for '%s': "
-                             (thing-at-point 'symbol)))))))
+                             (thing-at-point 'symbol))
+                     (thing-at-point 'symbol))))))
   (unless (and new-name
                (elpy-refactor--is-valid-symbol-p new-name))
     (error "'%s' is not a valid python symbol"))


### PR DESCRIPTION
elpy-refactor: use the symbol to be renamed for initial input when prompting for new name

# PR Summary


# PR checklist

Please make sure that the following things have been addressed (and check the relevant checkboxes):

- [X] Commits respect our [guidelines](../CONTRIBUTING.rst)
- [X] Tests are passing properly (see [here](https://elpy.readthedocs.io/en/latest/extending.html#running-tests) on how to run Elpy's tests)
