### PR TITLE
Customization tips: allow `rgrep` to search properly for the symbols

### DIFF
--- a/docs/customization_tips.rst
+++ b/docs/customization_tips.rst
@@ -73,7 +73,7 @@ You may sometimes find when you try to navigate to a function/class definition w
         (ring-insert find-tag-marker-ring (point-marker))
         (condition-case nil (elpy-goto-definition)
             (error (elpy-rgrep-symbol
-                       (concat "\\(def\\|class\\)\s" (thing-at-point 'symbol) "(")))))
+                       (concat "\\(def\\|class\\)\s" (thing-at-point 'symbol) "\\((\\|:\\)")))))
 
 This function will try to find the definition of the symbol at point using ``elpy-goto-definition``, but will do elpy-rgrep-symbol_  instead, if the former function fails to return a result. You can bind this function to the key combination of your choice, or you can bind it to ``M-.`` to use it as a replacement for the the default ``goto-definition`` function:
 


### PR DESCRIPTION
# PR Summary

This commit aims to introduce proper mechanism of seeking for symbol
in `elpy` mode while `elpy-goto-definition` fails at finding given
symbol.

`rgrep` although works properly in cases like:

```python
class Dog(Animal):
    ...
```

but fails at:

```python
class Dog:
    ...
```

where class has no parentheses after its name definition.

# PR checklist

Please make sure that the following things have been addressed (and check the relevant checkboxes):

- [X] Commits respect our [guidelines](../CONTRIBUTING.rst)
- [X] Tests are passing properly (see [here](https://elpy.readthedocs.io/en/latest/extending.html#running-tests) on how to run Elpy's tests)

## For new features only:
- [ ] Tests has been added to cover the change
- [ ] The documentation has been updated
