### PR TITLE
fixes https://github.com/jorgenschaefer/elpy/issues/1940, tests

### DIFF
--- a/elpy-rpc.el
+++ b/elpy-rpc.el
@@ -71,7 +71,11 @@ this to prevent this from happening."
                                        (or (executable-find "py")
                                            (executable-find "pythonw")
                                            "python")
-                                     "python")
+                                     (if (executable-find "python")
+					 "python"
+				       ;; Fallback on systems where python is not
+				       ;; symlinked to python3.
+				       "python3"))
   "The Python interpreter for the RPC backend.
 
 This should NOT be an interactive shell like ipython or jupyter.

--- a/scripts/setup
+++ b/scripts/setup
@@ -15,7 +15,7 @@ pip install -r requirements.txt --upgrade
 pip install -r requirements-rpc.txt --upgrade
 pip install -r requirements-dev.txt --upgrade
 # For python2
-if python -c 'import sys ; exit(sys.version_info < (3, 0))'
+if python -c 'import sys ; exit(not sys.version_info < (3, 0))'
 then
     pip install -r requirements-dev2.txt --upgrade
 fi


### PR DESCRIPTION
# PR Summary

On a fresh install of Ubuntu Server 20.04, python is not symlinked to python3, so elpy does not work out of the box. See https://github.com/jorgenschaefer/elpy/issues/1940 for details. Changes to elpy-rpc.el fix this.

Tests using python3 did not pass in my environment. Changes to scripts/test fix this.

# PR checklist

Please make sure that the following things have been addressed (and check the relevant checkboxes):

- [x] Commits respect our [guidelines](../CONTRIBUTING.rst)
- [X] Tests are passing properly (see [here](https://elpy.readthedocs.io/en/latest/extending.html#running-tests) on how to run Elpy's tests)

## For new features only:
N/A. This PR contains no new features.
