### PR TITLE
fix #1824 & other hs-life-goes-on related errors when folding

### DIFF
--- a/elpy.el
+++ b/elpy.el
@@ -39,6 +39,7 @@
 (require 'etags)
 (require 'files-x)
 (require 'grep)
+(require 'hideshow)
 (require 'ido)
 (require 'json)
 (require 'python)


### PR DESCRIPTION
# PR Summary

Added `(require 'hideshow')` to elpy .py since `hs-life-goes-on` is a macro, so its definition has to be available when the code using it is being loaded or byte-compiled.
fixes
- https://github.com/jorgenschaefer/elpy/issues/1824
- https://emacs.stackexchange.com/questions/58956/unable-to-fold-code-in-elpy
- https://emacs.stackexchange.com/questions/54213/code-folding-in-elpy-not-working

# PR checklist

Please make sure that the following things have been addressed (and check the relevant checkboxes):

- [x] Commits respect our [guidelines](../CONTRIBUTING.rst)
- [x] Tests are passing properly (see [here](https://elpy.readthedocs.io/en/latest/extending.html#running-tests) on how to run Elpy's tests)

All tests that pass in master pass in in the PR.