### PR TITLE
FIXES REGRESSION - Accommodates black.files.find_pyproject_toml returning None

### DIFF
--- a/elpy/blackutil.py
+++ b/elpy/blackutil.py
@@ -55,7 +55,7 @@ def fix_code(code, directory):
         pyproject_path = find_pyproject_toml((directory,))
     else:
         pyproject_path = os.path.join(directory, "pyproject.toml")
-    if toml is not None and os.path.exists(pyproject_path):
+    if toml and pyproject_path and os.path.exists(pyproject_path):
         pyproject_config = toml.load(pyproject_path)
         black_config = pyproject_config.get("tool", {}).get("black", {})
         if "line-length" in black_config:


### PR DESCRIPTION
# PR Summary

Prior to this, the return value of `black.files.find_pyproject_toml` was passed directly
to `os.path.exists`. This was fine where `black` could find a `pyproject.toml` file.
However, when one cannot be located, `find_pyproject_toml` returns `None`, which results
in an uncaught exception from `os.path.exists`. This adds an additional check for when
`find_project_toml` returns `None`.

Fixes #1955 (introduced by #1950).

# PR checklist

Please make sure that the following things have been addressed (and check the relevant checkboxes):

- [X] Commits respect our [guidelines](../CONTRIBUTING.rst)
- [X] ~~Tests are passing properly (see [here](https://elpy.readthedocs.io/en/latest/extending.html#running-tests) on how to run Elpy's tests)~~
_**I have only run Python-based tests, which were not passing before I submitted this PR. I have verified that this PR introduces no new Python test failures. In fact it fixes three of the four existing failures in my local testing. (See [this comment](#issuecomment-1011735002) below for detail.)**_