### PR TITLE
Fix #1968 - test_should_get_docstring fails for Python 3.6+

### DIFF
--- a/elpy/tests/test_jedibackend.py
+++ b/elpy/tests/test_jedibackend.py
@@ -68,7 +68,7 @@ class TestRPCGetDocstring(RPCGetDocstringTests,
     def __init__(self, *args, **kwargs):
         super(TestRPCGetDocstring, self).__init__(*args, **kwargs)
         self.JSON_LOADS_REGEX = (
-            r'loads\(s.*, encoding.*, cls.*, object_hook.*, parse_float.*, '
+            r'loads\(s.*, cls.*, object_hook.*, parse_float.*, '
             r'parse_int.*, .*\)'
             )
 


### PR DESCRIPTION
This commit changes the regex string that matches against the arguments
of `json.loads` in the Python library. It removes the explicit
reference to the "encoding" keyword argument that was removed in
Python 3.6+.

# PR Summary
This commit fixes issue #1968. The test `RPCGetDocstringTests.test_should_get_docstring` in elpy/tests/support.py now passes for versions (3.6+) of Python where the "encoding" keyword has been removed from the signature of `json.loads`. 

Since the "encoding.\* " portion of the regex was preceded by a greedy wildcard, the new version of the regex will work regardless of whether this keyword is present in the `json.loads` signature.

# PR checklist

Please make sure that the following things have been addressed (and check the relevant checkboxes):

- [ X ] Commits respect our [guidelines](../CONTRIBUTING.rst)
- [ X ] Tests are passing properly (see [here](https://elpy.readthedocs.io/en/latest/extending.html#running-tests) on how to run Elpy's tests)

## For new features only:
- [ ] Tests has been added to cover the change
- [ ] The documentation has been updated
