### PR TITLE
Fix #1867 - allow MacOS users to choose pty or pipe for Python shell

### DIFF
--- a/elpy-shell.el
+++ b/elpy-shell.el
@@ -175,6 +175,22 @@ the following functions:
   :type 'boolean
   :group 'elpy)
 
+(defcustom elpy-shell-darwin-use-pty nil
+  "Whether to connect to the Python shell through pty on MacOS.
+
+If nil, Elpy will connect to Python through a pipe. Any non-nil
+value will cause Elpy use a pseudo-terminal (pty) instead. This
+value should be set to nil when using a Python interpreter that
+uses the libedit version of Readline, such as the default MacOS
+Python interpreters. This value can be safely be set to true when
+using a version of Python that uses GNU Readline.
+
+This value is only used when `elpy-shell-get-or-create-process'
+creates a new Python process."
+  :type 'boolean
+  :group 'elpy)
+
+
 ;;;;;;;;;;;;;;;;;;
 ;;; Shell commands
 
@@ -280,7 +296,7 @@ REMOVE THIS when Elpy no longer supports Emacs 26."
 If SIT is non-nil, sit for that many seconds after creating a
 Python process. This allows the process to start up."
   (let* ((process-connection-type
-          (if (string-equal system-type "darwin") nil t))  ;; see https://github.com/jorgenschaefer/elpy/pull/1671
+          (if (string-equal system-type "darwin") elpy-shell-darwin-use-pty t))  ;; see https://github.com/jorgenschaefer/elpy/pull/1671
          (bufname (format "*%s*" (python-shell-get-process-name nil)))
          (proc (get-buffer-process bufname)))
     (if proc


### PR DESCRIPTION
This change creates a custom variable that allows MacOS users to decide
whether to use a pipe or a pseudo-terminal (pty) to connect to the Python
shell when `elpy-shell-get-or-create-process` is called. Before this commit,
all Mac users are forced to use a pipe if the Python shell is created using
this function, even though this is not necessary for all users.

Some MacOS users experience issues connecting to the Python shell using a
pty. One of major problems is the inability to send greater than 1024
characters to the shell at one time. These issues are caused by versions of
Python that use the libedit version of Readline rather than the GNU
version. By default, MacOS does not have GNU Readline installed, so it instead
uses the libedit version for the versions of Python built into the OS. This
may also be the case for other versions installed on a Mac if GNU Readline was
not installed first. Using a pipe instead a pty alleviates all of these issues
at the expense of creating a few smaller issues (e.g. sending an EOF signal
into pdb causes the entire shell to exit).

However, many MacOS users use versions of Python that are built with GNU
Readline which means that the pty will work properly for them. It is
unnecessary for them to connect via a pipe. Additionally, users may
run into confusing behavior where the Python shell created via `run-python`
(which uses a pty unless `process-connection-type` is set to nil) acts
differently than one that is created via an Elpy command.

Since a pipe connection to the Python shell works for users with and without
versions of Python installed with GNU readline, this continues to be a sane
default for Mac users. Creating this custom variable provides an easy, if
somewhat difficult to discover, way to allow Mac users to decide which process
type they want to use.

In the future, it may be best to ask Mac users on their first usage of Elpy
whether to use a pipe or pty. Alternatively, this could be automatically
detected and a message could be sent to the Python interpreter to suggest that
they change this variable's value.

In addition to #1867, this change is also a fix for #1907 and #1948.

Other related issues and commits include: #887, #1550, #1838, and #1671.

# PR Summary
Several issues have been caused by forcing MacOS users to use a pipe instead of a pty to connect to the Python shell. The issues with using a pty (see #1550) only appear when Mac users use a version of Python that uses the libedit version of Readline rather than the GNU version (e.g. the default system installations of Python). It makes more sense to allow Mac users to choose whether to connect to the Python shell via a pty or via a pipe, so I created a custom variable that allows them to do this. 

I did not add any tests since writing good tests for this would be somewhat labor-intensive and this change only involves substituting a boolean-valued variable in the place of a nil value. **Edit to add:** I don't think I phrased this well. Since the main issues here depend on whether Python is built without an external library, this seems like this may be challenging to test with the current automated testing framework.

Issue #1966 is likely related as well.

# PR checklist

Please make sure that the following things have been addressed (and check the relevant checkboxes):

- [X] Commits respect our [guidelines](../CONTRIBUTING.rst)
- [X] Tests are passing properly (see [here](https://elpy.readthedocs.io/en/latest/extending.html#running-tests) on how to run Elpy's tests)

## For new features only:
- [ ] Tests has been added to cover the change
- [X] The documentation has been updated
