### PR TITLE
Fix potential bug in test_black.py

### DIFF
--- a/elpy/tests/test_black.py
+++ b/elpy/tests/test_black.py
@@ -15,6 +15,10 @@ class BLACKTestCase(BackendTestCase):
     def setUp(self):
         if blackutil.BLACK_NOT_SUPPORTED:
             raise unittest.SkipTest
+        self._original_black = blackutil.black
+
+    def tearDown(self):
+        blackutil.black = self._original_black
 
     def test_fix_code_should_throw_error_for_invalid_code(self):
         src = 'x = '


### PR DESCRIPTION
# PR Summary

The test test_fix_code_should_throw_error_without_black_installed was
not considering that "blackutil.fix_code" could raise another
exception then the desired "Fault" exception. This would lead to a
failure in the following tests since "blackutil.black would be reset
to its original value, and thus producing a false negative in the
process.


# PR checklist

Please make sure that the following things have been addressed (and check the relevant checkboxes):

- [x] Commits respect our [guidelines](../CONTRIBUTING.rst)
- [ ] Tests are passing properly (see [here](https://elpy.readthedocs.io/en/latest/extending.html#running-tests) on how to run Elpy's tests)
