### PR TITLE
Replace find-tag-marker-ring with xref-push-marker-stack.

### DIFF
--- a/docs/customization_tips.rst
+++ b/docs/customization_tips.rst
@@ -70,7 +70,7 @@ You may sometimes find when you try to navigate to a function/class definition w
     (defun elpy-goto-definition-or-rgrep ()
       "Go to the definition of the symbol at point, if found. Otherwise, run `elpy-rgrep-symbol'."
         (interactive)
-        (ring-insert find-tag-marker-ring (point-marker))
+        (xref-push-marker-stack)
         (condition-case nil (elpy-goto-definition)
             (error (elpy-rgrep-symbol
                        (concat "\\(def\\|class\\)\s" (thing-at-point 'symbol) "(")))))

--- a/elpy.el
+++ b/elpy.el
@@ -451,7 +451,7 @@ This option need to bet set through `customize' or `customize-set-variable' to b
     ["Go to Definition" elpy-goto-definition
      :help "Go to the definition of the symbol at point"]
     ["Go to previous definition" pop-tag-mark
-     :active (not (ring-empty-p find-tag-marker-ring))
+     :active (> xref-marker-ring-length 0)
      :help "Return to the position"]
     ["Complete" elpy-company-backend
      :keys "M-TAB"
@@ -1756,7 +1756,7 @@ with a prefix argument)."
   "Show FILENAME at OFFSET to the user.
 
 If OTHER-WINDOW-P is non-nil, show the same in other window."
-  (ring-insert find-tag-marker-ring (point-marker))
+  (xref-push-marker-stack)
   (let ((buffer (find-file-noselect filename)))
     (if other-window-p
         (pop-to-buffer buffer t)


### PR DESCRIPTION
`find-tag-marker-ring` is obsolete as of Emacs 25.1 and I can't find it in 27.

# PR Summary


# PR checklist

Please make sure that the following things have been addressed (and check the relevant checkboxes):

- [x] Commits respect our [guidelines](../CONTRIBUTING.rst)
- [x] Tests are passing properly (see [here](https://elpy.readthedocs.io/en/latest/extending.html#running-tests) on how to run Elpy's tests)

## For new features only:
- [ ] Tests has been added to cover the change
- [ ] The documentation has been updated
