### PR TITLE
Fix issue with eldoc when elpy-eldoc-show-current-function is nil

### DIFF
--- a/elpy.el
+++ b/elpy.el
@@ -3186,15 +3186,14 @@ documentation (only used for Emacs >= 28)."
                       :face 'font-lock-function-name-face)))
           ;; INFO is nil, maybe display the current function
           (t
-           (if elpy-eldoc-show-current-function
+           (when elpy-eldoc-show-current-function
                (let ((current-defun (python-info-current-defun)))
                  (when current-defun
                    (eldoc-message
                     (concat "In: "
                             (propertize
                              (format "%s()" current-defun)
-                             'face 'font-lock-function-name-face)))))
-             (eldoc-message ""))))))
+                             'face 'font-lock-function-name-face))))))))))
       (if callback
           ;; New protocol: return non-nil, non-string
           t


### PR DESCRIPTION
# PR Summary
If using flycheck or some message utility while in a function,
having elpy-eldoc-show-current-function set to nil will cause
eldoc to delete any visible message in the echo area.

# PR checklist

- [x] Commits respect our [guidelines](../CONTRIBUTING.rst)
- [ ] Tests are passing properly (see [here](https://elpy.readthedocs.io/en/latest/extending.html#running-tests) on how to run Elpy's tests)

