### PR TITLE
Recognize Breakpoints in Multiple Buffers

### DIFF
--- a/docs/ide.rst
+++ b/docs/ide.rst
@@ -676,7 +676,8 @@ Note that this interface is only available for Emacs 25 and above.
 .. command:: elpy-pdb-debug-buffer
    :kbd: C-c C-u d
 
-   Run pdb on the current buffer. If no breakpoints has been set using
+   Run pdb on the current buffer. If no breakpoints has been set in any
+   open buffer with elpy mode using 
    :command:`elpy-pdb-toggle-breakpoint-at-point`, the debugger will
    pause at the beginning of the buffer. Else, the debugger will pause
    at the first breakpoint. Once pdb is started, the `pdb commands`_


### PR DESCRIPTION
With this feature debugger will not just interrupt execution at breakpoints in the buffer it was called on (main buffer) but also on breakpoints that were set in other buffers that whose code has been executed by main buffer.

Thus when we set a breakpoint in` main.py` buffer and one in `submodule/mod.py `buffer starting the debugger in main will interrupt on execution of main but recognize the breakpoint in `submodule/mod.py` and interrupt execution. 
```
 main.py
 -- submodule/mod.py
```
