### PR TITLE
Remove support for Python 2.7 and fix broken CI setup flow

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -50,6 +50,7 @@ jobs:
       uses: actions/setup-python@v4
       with:
         python-version : ${{ matrix.python_version }}
+        check-latest: true
     - name: Install Python dependencies
       run: |
         python -m pip install --upgrade pip

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -8,7 +8,9 @@ on:
 
 jobs:
   build:
-    runs-on: ubuntu-latest
+    # As long as we want to test old versions of Python here in the test, we can only use up to Ubuntu 20.
+    # https://github.com/rwth-i6/returnn/issues/1226
+    runs-on: ubuntu-20.04
     # continue-on-error: true
     strategy:
       fail-fast: false

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -28,7 +28,6 @@ jobs:
           - 27.1
           # - snapshot
         python_version:
-          - 2.7
           - 3.5
           - 3.6
           - 3.7

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -34,7 +34,7 @@ jobs:
           - 3.8
     steps:
     # Checkout
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
     # Emacs
     - name: Set up Emacs ${{ matrix.emacs_version }}
       uses: purcell/setup-emacs@master
@@ -47,7 +47,7 @@ jobs:
           version: 'snapshot'
      # Python
     - name: Set up Python ${{ matrix.python_version }}
-      uses: actions/setup-python@v2
+      uses: actions/setup-python@v4
       with:
         python-version : ${{ matrix.python_version }}
     - name: Install Python dependencies


### PR DESCRIPTION
Issue: https://github.com/actions/setup-python/issues/672

Also fixes CI to get it to actually start running the tests again and not fail on setup