### PR TITLE
Document need of toml with black formatter

### DIFF
--- a/elpy.el
+++ b/elpy.el
@@ -2319,7 +2319,8 @@ root directory."
   (elpy--fix-code-with-formatter "fix_code"))
 
 (defun elpy-black-fix-code ()
-  "Automatically formats Python code with black."
+  "Automatically formats Python code with black.
+Note: Requires 'toml' to be installed due to legacy reasons."
   (interactive)
   (elpy--fix-code-with-formatter "fix_code_with_black"))
 


### PR DESCRIPTION
Adds a note about the requirement of 'toml' to be installed for the use of the `elpy-black-fix-code` function.

Closes #2004 and #2008