### PR TITLE
fix the error when pdb.Pdb() has .run instead of ._runscript method

### DIFF
--- a/elpy-shell.el
+++ b/elpy-shell.el
@@ -1228,7 +1228,9 @@ switches focus to Python shell buffer."
     "Start pdb on the current script.
 
 if OUTPUT is non-nil, display the prompt after execution."
-    (let ((string (format "__pdbi._runscript('''%s''')" (buffer-file-name))))
+    (let ((declare-file-name (format "file_name='''%s'''" (buffer-file-name) ))
+	  (string "if hasattr(__pdbi,'_runscript'):\n    __pdbi._runscript(file_name)\nelif hasattr(__pdbi,'run'):\n    __pdbi.run(compile(open(file_name).read(),file_name,'exec'))\nelse:    print('pdb.Pdb() Object error!')"))
+      (python-shell-send-string declare-file-name)
       (if output
           (python-shell-send-string string)
         (python-shell-send-string-no-output string))))


### PR DESCRIPTION
# PR Summary

There is "no _runscript error" with new version of Python where Python's debug module pdb removed _runscript method from object created by pdb.Pdb(). 
The changed codes use pdb.Pdb().run when there is no _runscript to do debuging.

# PR checklist

Please make sure that the following things have been addressed (and check the relevant checkboxes):

- Commits respect our [guidelines](../CONTRIBUTING.rst)
- Tests are passing properly (see [here](https://elpy.readthedocs.io/en/latest/extending.html#running-tests) on how to run Elpy's tests)
