### PR TITLE
FIX: add setuptools to rpc venv

### DIFF
--- a/elpy-rpc.el
+++ b/elpy-rpc.el
@@ -234,7 +234,7 @@ needed packages from `elpy-rpc--get-package-list'."
   (let ((rpc-python-version (elpy-rpc--get-python-version)))
     (if (version< rpc-python-version "3.6.0")
         '("jedi" "flake8" "autopep8" "yapf")
-      '("jedi" "flake8" "autopep8" "yapf" "black"))))
+      '("jedi" "flake8" "autopep8" "yapf" "black" "setuptools"))))
 
 (defun elpy-rpc--get-python-version ()
   "Return the RPC python version."


### PR DESCRIPTION
Closes #2033 

Required for py312 but should be safe on any version of Pyhon (setuptools was previously a transitive dependency).

# PR Summary


# PR checklist

Please make sure that the following things have been addressed (and check the relevant checkboxes):

- [x] Commits respect our [guidelines](../CONTRIBUTING.rst)
- [ ] Tests are passing properly (see [here](https://elpy.readthedocs.io/en/latest/extending.html#running-tests) on how to run Elpy's tests)

## For new features only:
- [ ] Tests has been added to cover the change
- [ ] The documentation has been updated
