### PR TITLE
Replace pkg_resources.parse_version by packaging.version.Version

### DIFF
--- a/elpy/blackutil.py
+++ b/elpy/blackutil.py
@@ -7,8 +7,10 @@ import sys
 from elpy.rpc import Fault
 # in case pkg_resources is not properly installed
 # (see https://github.com/jorgenschaefer/elpy/issues/1674).
+# in case pkg_resources is not properly installed
+# (see https://github.com/jorgenschaefer/elpy/issues/1674).
 try:
-    from pkg_resources import parse_version
+    from packaging.version import Version as parse_version
 except ImportError:  # pragma: no cover
     def parse_version(*arg, **kwargs):
         raise Fault("`pkg_resources` could not be imported, "

--- a/elpy/blackutil.py
+++ b/elpy/blackutil.py
@@ -12,10 +12,13 @@ from elpy.rpc import Fault
 try:
     from packaging.version import Version as parse_version
 except ImportError:  # pragma: no cover
-    def parse_version(*arg, **kwargs):
-        raise Fault("`pkg_resources` could not be imported, "
-                    "please reinstall Elpy RPC virtualenv with"
-                    " `M-x elpy-rpc-reinstall-virtualenv`", code=400)
+    try:
+        from pkg_resources import parse_version
+    except ImportError:  # pragma: no cover
+        def parse_version(*arg, **kwargs):
+            raise Fault("`pkg_resources` could not be imported, "
+                        "please reinstall Elpy RPC virtualenv with"
+                        " `M-x elpy-rpc-reinstall-virtualenv`", code=400)
 
 import os
 

--- a/elpy/jedibackend.py
+++ b/elpy/jedibackend.py
@@ -20,10 +20,13 @@ from elpy.rpc import Fault
 try:
     from packaging.version import Version as parse_version
 except ImportError:  # pragma: no cover
-    def parse_version(*arg, **kwargs):
-        raise Fault("`pkg_resources` could not be imported, "
-                    "please reinstall Elpy RPC virtualenv with"
-                    " `M-x elpy-rpc-reinstall-virtualenv`", code=400)
+    try:
+        from pkg_resources import parse_version
+    except ImportError:  # pragma: no cover
+        def parse_version(*arg, **kwargs):
+            raise Fault("`pkg_resources` could not be imported, "
+                        "please reinstall Elpy RPC virtualenv with"
+                        " `M-x elpy-rpc-reinstall-virtualenv`", code=400)
 JEDISUP17 = parse_version(jedi.__version__) >= parse_version("0.17.0")
 JEDISUP18 = parse_version(jedi.__version__) >= parse_version("0.18.0")
 

--- a/elpy/jedibackend.py
+++ b/elpy/jedibackend.py
@@ -18,7 +18,7 @@ from elpy.rpc import Fault
 # in case pkg_resources is not properly installed
 # (see https://github.com/jorgenschaefer/elpy/issues/1674).
 try:
-    from pkg_resources import parse_version
+    from packaging.version import Version as parse_version
 except ImportError:  # pragma: no cover
     def parse_version(*arg, **kwargs):
         raise Fault("`pkg_resources` could not be imported, "


### PR DESCRIPTION
# PR Summary


# PR checklist

Please make sure that the following things have been addressed (and check the relevant checkboxes):

- [x] Commits respect our [guidelines](../CONTRIBUTING.rst)
- [x] Tests are passing properly (see [here](https://elpy.readthedocs.io/en/latest/extending.html#running-tests) on how to run Elpy's tests)
  running `./scripts/test python` reports the following problems:

  ```
  ======================================================================
  ERROR: test_fix_code (tests.test_yapf.YAPFTestCase.test_fix_code)
  ----------------------------------------------------------------------
  Traceback (most recent call last):
    File "/home/hoel/work/code-root/github.com/elpy/elpy/yapfutil.py", line 31, in fix_code
      reformatted_source, _ = yapf_api.FormatCode(code,
                              ^^^^^^^^^^^^^^^^^^^^^^^^^
  TypeError: FormatCode() got an unexpected keyword argument 'verify'
  
  During handling of the above exception, another exception occurred:
  
  Traceback (most recent call last):
    File "/home/hoel/work/code-root/github.com/elpy/elpy/tests/test_yapf.py", line 37, in test_fix_code
      self._assert_format(src, expected)
    File "/home/hoel/work/code-root/github.com/elpy/elpy/tests/test_yapf.py", line 40, in _assert_format
      new_block = yapfutil.fix_code(src, os.getcwd())
                  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    File "/home/hoel/work/code-root/github.com/elpy/elpy/yapfutil.py", line 37, in fix_code
      raise Fault("Error during formatting: {}".format(e),
  elpy.rpc.Fault: Error during formatting: FormatCode() got an unexpected keyword argument 'verify'
  
  ======================================================================
  FAIL: test_should_complete_top_level_modules_for_import (tests.test_jedibackend.TestRPCGetCompletions.test_should_complete_top_level_modules_for_import)
  ----------------------------------------------------------------------
  Traceback (most recent call last):
    File "/home/hoel/work/code-root/github.com/elpy/elpy/tests/support.py", line 382, in test_should_complete_top_level_modules_for_import
      self.assertEqual(sorted([cand['suffix'] for cand in completions]),
  AssertionError: Lists differ: ['dict', 'processing'] != ['processing']
  
  First differing element 0:
  'dict'
  'processing'
  
  First list contains 1 additional elements.
  First extra element 1:
  'processing'
  
  - ['dict', 'processing']
  ?  --------
  
  + ['processing']
  
  ======================================================================
  FAIL: test_should_get_oneline_docstring_for_modules (tests.test_jedibackend.TestRPCGetOnelineDocstring.test_should_get_oneline_docstring_for_modules)
  ----------------------------------------------------------------------
  Traceback (most recent call last):
    File "/home/hoel/work/code-root/github.com/elpy/elpy/tests/support.py", line 842, in test_should_get_oneline_docstring_for_modules
      self.check_module_docstring(docstring)
    File "/home/hoel/work/code-root/github.com/elpy/elpy/tests/support.py", line 818, in check_module_docstring
      self.assertEqual(docstring['doc'],
  AssertionError: 'JSON[30 chars]<https://json.org> is a subset of JavaScript s[71 chars]mat.' != 'JSON[30 chars]<http://json.org> is a subset of JavaScript sy[70 chars]mat.'
  - JSON (JavaScript Object Notation) <https://json.org> is a subset of JavaScript syntax (ECMA-262 3rd edition) used as a lightweight data interchange format.
  ?                                        -
  + JSON (JavaScript Object Notation) <http://json.org> is a subset of JavaScript syntax (ECMA-262 3rd edition) used as a lightweight data interchange format.
  
  
  ----------------------------------------------------------------------
  Ran 317 tests in 18.319s
  
  FAILED (failures=2, errors=1)
  ```
None of these seems to be related to my changes, in fact I get exact these error messages with the latest upstream code.

## For new features only:
- [ ] Tests has been added to cover the change
- [ ] The documentation has been updated
