### PR TITLE
Fix duplicate names in test library.

### DIFF
--- a/test/elpy-config--insert-help-test.el
+++ b/test/elpy-config--insert-help-test.el
@@ -2,6 +2,6 @@
 ;; with output. We will test its constituent functions later, and just
 ;; make sure it doesn't throw an error here.
 
-(ert-deftest elpy-config-should-not-fail ()
+(ert-deftest elpy-config-should-not-fail-with-insert-help ()
   (elpy-testcase ()
     (elpy-config--insert-help)))

--- a/test/elpy-library-root-test.el
+++ b/test/elpy-library-root-test.el
@@ -4,7 +4,7 @@
     (should (f-equal? (elpy-library-root)
                       project-root))))
 
-(ert-deftest elpy-library-root-should-find-current-directory ()
+(ert-deftest elpy-library-root-should-find-current-directory-2 ()
   (elpy-testcase ((:project project-root
                             "p1/p2/test.py"
                             "p1/p2/__init__.py"

--- a/test/elpy-open-and-indent-line-above-test.el
+++ b/test/elpy-open-and-indent-line-above-test.el
@@ -1,4 +1,4 @@
-(ert-deftest elpy-open-and-indent-line-below ()
+(ert-deftest elpy-open-and-indent-line-above ()
   (elpy-testcase ()
     (elpy-enable)
     (python-mode)

--- a/test/elpy-rpc-get-usages-test.el
+++ b/test/elpy-rpc-get-usages-test.el
@@ -1,4 +1,4 @@
-(ert-deftest elpy-rpc-get-completions ()
+(ert-deftest elpy-rpc-get-usages ()
   (elpy-testcase ()
     (mletf* ((called-args nil)
              (elpy-rpc (&rest args) (setq called-args args)))

--- a/test/elpy-rpc-test.el
+++ b/test/elpy-rpc-test.el
@@ -17,7 +17,7 @@
               (should (equal error 'elpy-rpc--default-error-callback))))
       (elpy-rpc "test-method" nil 'success))))
 
-(ert-deftest elpy-rpc-should-use-default-without-error-callback ()
+(ert-deftest elpy-rpc-should-use-default-without-error-callback-blocking ()
   (elpy-testcase ()
     (mletf* ((elpy-rpc--call-blocking
               (method params)


### PR DESCRIPTION
# PR Summary

Fix tests with duplicate names.  When I tried to run the ert tests, they failed repeatedly, giving errors from tests which had duplicate names. I have tracked these down and replaced them with unique names.

This would be a necessary first step to getting the tests to run again, and generally updating elpy.

# PR checklist

Please make sure that the following things have been addressed (and check the relevant checkboxes):

- [ ] Commits respect our [guidelines](../CONTRIBUTING.rst)
- [ ] Tests are passing properly (see [here](https://elpy.readthedocs.io/en/latest/extending.html#running-tests) on how to run Elpy's tests)

Tests do not pass properly, but they do not pass on `master`, either.  Failing tests are:

```
23 unexpected results:
   FAILED  elpy-company-backend-should-add-shell-candidates
   FAILED  elpy-company-backend-should-find-full-prefix-string
   FAILED  elpy-company-backend-should-find-simple-prefix-string
   FAILED  elpy-config--get-config-should-return-keys
   FAILED  elpy-config--get-config-should-set-pythonpath
   FAILED  elpy-eldoc-documentation-should-show-object-onelinedoc
   FAILED  elpy-fold-at-point-should-NOT-fold-and-unfold-functions-from-after
   FAILED  elpy-multiedit-python-symbol-at-point-should-save-some-buffers
   FAILED  elpy-pdb-break-at-point-should-break-at-point
   FAILED  elpy-pdb-debug-buffer-and-break-at-point-should-ignore-breakpoints
   FAILED  elpy-pdb-debug-buffer-from-beginning-should-enter-pdb
   FAILED  elpy-pdb-debug-buffer-should-always-begin-at-first-line
   FAILED  elpy-pdb-debug-buffer-should-continue-with-second-breakpoint
   FAILED  elpy-pdb-debug-buffer-should-enter-pdb
   FAILED  elpy-pdb-debug-buffer-should-forget-previous-breakpoints
   FAILED  elpy-pdb-debug-buffer-should-stop-at-the-first-breakpoint
   FAILED  elpy-pdb-debug-last-exception-should-debug-last-exception
   FAILED  elpy-pdb-debug-last-exception-should-ignore-breakpoints
   FAILED  elpy-pdb-toggle-breakpoint-at-point-should-add-breakpoints
   FAILED  elpy-rpc-get-virtualenv-path-should-return-current-venv-path
   FAILED  elpy-shell-send-file-should-accept-large-strings
   FAILED  elpy-shell-should-echo-outputs
   FAILED  elpy-should-format-code-with-default-formatter
```


