### PR TITLE
Remove outdated `elpy-pkg.el`

### DIFF
--- a/elpy-pkg.el
+++ b/elpy-pkg.el
@@ -1,9 +1,0 @@
-(define-package "elpy" "1.35.0"
-                "Emacs Python Development Environment"
-                '((company "0.9.2")
-                  (emacs "24.4")
-                  (highlight-indentation "0.5.0")
-                  (pyvenv "1.3")
-                  (yasnippet "0.8.0")
-                  (s "1.11.0"))
-                )


### PR DESCRIPTION
# PR Summary

The information in `<name>-pkg.el` did not agree with the information in `<name>.el`.  This pull-requests addresses that be removing the outdated `<name>-pkg.el`.

While the end-user package manager `package.el` expects a file `<name>-pkg.el`, this should only be generate by the package archive (such as GNU ELPA and MELPA), instead of being tracked in the upstream repository.

The tools used maintain the various *ELPA, do *not* use `<name>-pkg.el` as a data *source*, they only generate it it.

- `elpa-admin.el`, the tool used for GNU ELPA and NonGNU ELPA, does *not* use `<name>-pkg.el` as a data source and it never has.

- `package-build.el`, the tool used for Melpa, prefers `<name>.el` but *currently* falls back to get information missing from there from `<name>-pkg.el` instead. I am goint to change that; soon `<name>-pkg.el` will be ignored as a data source by this tool too.

# PR checklist

- [x] Commits respect our [guidelines](../CONTRIBUTING.rst)
- [x] Tests are passing properly (see [here](https://elpy.readthedocs.io/en/latest/extending.html#running-tests) on how to run Elpy's tests)