### PR TITLE
fix(rpc): add support for Python 3.12 and later

### DIFF
--- a/elpy-rpc.el
+++ b/elpy-rpc.el
@@ -229,12 +229,21 @@ needed packages from `elpy-rpc--get-package-list'."
    (t
     (error "Invalid value for `elpy-rpc-virtualenv-path', please set it to a proper value using customize"))))
 
+(defun elpy-rpc--get-pip-dependencies (python-version)
+  "Return a list of RPC dependencies, based on the current PYTHON-VERSION."
+  (let*
+      ((basic-py-deps '("jedi" "flake8" "autopep8" "yapf"))
+       (common-py-deps (cons "black" basic-py-deps))
+       (modern-py-deps (cons "setuptools" common-py-deps)))
+
+    (cond ((version< python-version "3.6") basic-py-deps)
+          ((version< python-version "3.12") common-py-deps)
+          (t modern-py-deps))))
+
 (defun elpy-rpc--get-package-list ()
   "Return the list of packages to be installed in the RPC virtualenv."
   (let ((rpc-python-version (elpy-rpc--get-python-version)))
-    (if (version< rpc-python-version "3.6.0")
-        '("jedi" "flake8" "autopep8" "yapf")
-      '("jedi" "flake8" "autopep8" "yapf" "black"))))
+    (elpy-rpc--get-pip-dependencies rpc-python-version)))
 
 (defun elpy-rpc--get-python-version ()
   "Return the RPC python version."

--- a/test/elpy-rpc--get-pip-dependencies-test.el
+++ b/test/elpy-rpc--get-pip-dependencies-test.el
@@ -1,0 +1,7 @@
+;;; -*-coding: utf-8-*-
+
+(ert-deftest elpy-rpc-get-pip-dependencies-should-return-packages-dependent-on-current-python-version ()
+  (elpy-testcase ()
+                 (should (equal '("jedi" "flake8" "autopep8" "yapf") (elpy-rpc--get-pip-dependencies "3.5.0")))
+                 (should (equal '("black" "jedi" "flake8" "autopep8" "yapf") (elpy-rpc--get-pip-dependencies "3.6.0")))
+                 (should (equal '("setuptools" "black" "jedi" "flake8" "autopep8" "yapf") (elpy-rpc--get-pip-dependencies "3.12.0")))))


### PR DESCRIPTION
# PR Summary
In Python 3.12 (and later), the `distutils` module has been removed. This causes the _rpc_ environment to fail.  By installing `setuptools` as a third-party dependency for Python 3.12 and later, the currently missing dependencies will be added and the `elpy` Python code will work as expected.

Output from `elpy-config` for an `rpc-venv` created with Python 3.12:
```shell
There was an unexpected problem starting the RPC process. Please check
the following output to see if this makes sense to you. To me, it
doesn't.

Traceback (most recent call last):
  File "<string>", line 9, in <module>
ModuleNotFoundError: No module named 'distutils'
```

As an alternative to the changes, there are workarounds such as:
```shell
# install setuptools to the elpy rpc-venv manually
~/.emacs.d/elpy/rpc-venv/bin/pip install setuptools 
```

fixes #2051 
fixes #2039 
fixes #2033 

# PR checklist

Please make sure that the following things have been addressed (and check the relevant checkboxes):

- [x] Commits respect our [guidelines](../CONTRIBUTING.rst)
- [ ] Tests are passing properly (see [here](https://elpy.readthedocs.io/en/latest/extending.html#running-tests) on how to run Elpy's tests)

NOTE: several tests are failing, also when running them from the master branch (where there are no changes). I have installed `cask`, created an empty virtual environment, and run the `/test/setup` script before running the tests.

However, I have run the new unit test I added in this feature branch and verified that it passes.

These tests fails for me in the `master` branch:

```shell
Ran 482 tests in 311.138 seconds
20 unexpected results:
   FAILED  elpy-company-backend-should-add-shell-candidates
   FAILED  elpy-company-backend-should-find-full-prefix-string
   FAILED  elpy-company-backend-should-find-simple-prefix-string
   FAILED  elpy-eldoc-documentation-should-show-object-onelinedoc
   FAILED  elpy-fold-at-point-should-NOT-fold-and-unfold-functions-from-after
   FAILED  elpy-pdb-break-at-point-should-break-at-point
   FAILED  elpy-pdb-debug-buffer-and-break-at-point-should-ignore-breakpoints
   FAILED  elpy-pdb-debug-buffer-from-beginning-should-enter-pdb
   FAILED  elpy-pdb-debug-buffer-should-always-begin-at-first-line
   FAILED  elpy-pdb-debug-buffer-should-continue-with-second-breakpoint
   FAILED  elpy-pdb-debug-buffer-should-enter-pdb
   FAILED  elpy-pdb-debug-buffer-should-forget-previous-breakpoints
   FAILED  elpy-pdb-debug-buffer-should-stop-at-the-first-breakpoint
   FAILED  elpy-pdb-debug-last-exception-should-debug-last-exception
   FAILED  elpy-pdb-debug-last-exception-should-ignore-breakpoints
   FAILED  elpy-pdb-toggle-breakpoint-at-point-should-add-breakpoints
   FAILED  elpy-shell-get-or-create-process-should-add-project-root-to-path
   FAILED  elpy-shell-send-file-should-accept-large-strings
   FAILED  elpy-shell-should-echo-outputs
   FAILED  elpy-should-format-code-with-default-formatter
```

From the feature branch (same failed tests):
```shell
Ran 483 tests in 311.680 seconds
20 unexpected results:
   FAILED  elpy-company-backend-should-add-shell-candidates
   FAILED  elpy-company-backend-should-find-full-prefix-string
   FAILED  elpy-company-backend-should-find-simple-prefix-string
   FAILED  elpy-eldoc-documentation-should-show-object-onelinedoc
   FAILED  elpy-fold-at-point-should-NOT-fold-and-unfold-functions-from-after
   FAILED  elpy-pdb-break-at-point-should-break-at-point
   FAILED  elpy-pdb-debug-buffer-and-break-at-point-should-ignore-breakpoints
   FAILED  elpy-pdb-debug-buffer-from-beginning-should-enter-pdb
   FAILED  elpy-pdb-debug-buffer-should-always-begin-at-first-line
   FAILED  elpy-pdb-debug-buffer-should-continue-with-second-breakpoint
   FAILED  elpy-pdb-debug-buffer-should-enter-pdb
   FAILED  elpy-pdb-debug-buffer-should-forget-previous-breakpoints
   FAILED  elpy-pdb-debug-buffer-should-stop-at-the-first-breakpoint
   FAILED  elpy-pdb-debug-last-exception-should-debug-last-exception
   FAILED  elpy-pdb-debug-last-exception-should-ignore-breakpoints
   FAILED  elpy-pdb-toggle-breakpoint-at-point-should-add-breakpoints
   FAILED  elpy-shell-get-or-create-process-should-add-project-root-to-path
   FAILED  elpy-shell-send-file-should-accept-large-strings
   FAILED  elpy-shell-should-echo-outputs
   FAILED  elpy-should-format-code-with-default-formatter
```

## For new features only:
- [x] Tests has been added to cover the change
- [ ] The documentation has been updated
