### PR TITLE
A number of additional fixes for newer python versions

### DIFF
--- a/elpy.el
+++ b/elpy.el
@@ -640,7 +640,10 @@ warnings.filterwarnings('ignore', category=FutureWarning)
 warnings.filterwarnings('ignore', category=DeprecationWarning)
 warnings.filterwarnings('ignore', category=PendingDeprecationWarning)
 
-from distutils.version import LooseVersion
+try:
+    from distutils.version import LooseVersion
+except ModuleNotFoundError:
+    from packaging.version import parse as LooseVersion
 
 try:
     import urllib2 as urllib

--- a/elpy/blackutil.py
+++ b/elpy/blackutil.py
@@ -5,18 +5,18 @@
 import sys
 
 from elpy.rpc import Fault
-# in case pkg_resources is not properly installed
-# (see https://github.com/jorgenschaefer/elpy/issues/1674).
-# in case pkg_resources is not properly installed
-# (see https://github.com/jorgenschaefer/elpy/issues/1674).
+
+# Fix from Christopher Genovese
+# https://github.com/jorgenschaefer/elpy/issues/2051#issuecomment-2472286571
+# see also https://github.com/jorgenschaefer/elpy/issues/2051
 try:
-    from packaging.version import Version as parse_version
+    from pkg_resources import parse_version
 except ImportError:  # pragma: no cover
     try:
-        from pkg_resources import parse_version
+        from packaging.version import parse as parse_version
     except ImportError:  # pragma: no cover
         def parse_version(*arg, **kwargs):
-            raise Fault("`pkg_resources` could not be imported, "
+            raise Fault("Neither `packaging` nor`pkg_resources` could be imported, "
                         "please reinstall Elpy RPC virtualenv with"
                         " `M-x elpy-rpc-reinstall-virtualenv`", code=400)
 

--- a/elpy/jedibackend.py
+++ b/elpy/jedibackend.py
@@ -15,16 +15,17 @@ import jedi
 from elpy import rpc
 from elpy.rpc import Fault
 
-# in case pkg_resources is not properly installed
-# (see https://github.com/jorgenschaefer/elpy/issues/1674).
+# Fix from Christopher Genovese
+# https://github.com/jorgenschaefer/elpy/issues/2051#issuecomment-2472286571
+# see also https://github.com/jorgenschaefer/elpy/issues/2051
 try:
-    from packaging.version import Version as parse_version
+    from pkg_resources import parse_version
 except ImportError:  # pragma: no cover
     try:
-        from pkg_resources import parse_version
+        from packaging.version import parse as parse_version
     except ImportError:  # pragma: no cover
         def parse_version(*arg, **kwargs):
-            raise Fault("`pkg_resources` could not be imported, "
+            raise Fault("Neither `packaging` nor`pkg_resources` could be imported, "
                         "please reinstall Elpy RPC virtualenv with"
                         " `M-x elpy-rpc-reinstall-virtualenv`", code=400)
 JEDISUP17 = parse_version(jedi.__version__) >= parse_version("0.17.0")

--- a/requirements-rpc.txt
+++ b/requirements-rpc.txt
@@ -1,5 +1,5 @@
 jedi
 autopep8
 yapf
-setuptools; python_version<3.12
-packaging; python_version>=3.12
+setuptools; python_version<"3.12"
+packaging; python_version>="3.12"

--- a/requirements-rpc.txt
+++ b/requirements-rpc.txt
@@ -1,4 +1,5 @@
 jedi
 autopep8
 yapf
-setuptools
+setuptools; python_version<3.12
+packaging; python_version>=3.12


### PR DESCRIPTION
Most of these are actually due to Christopher Genovese in discussion of #2051 

The most recent pull request fixes some of the 3.12 incompatibilities but some remain.

This fixes the startup python string in `elpy.el` and also some fixes to the `black` and `jedi` interfaces.  Finally, it updates `requirements.txt` with a conditional load of `distutils` or `packaging`.

# PR checklist

Please make sure that the following things have been addressed (and check the relevant checkboxes):

- [x] Commits respect our [guidelines](../CONTRIBUTING.rst)
- [ ] Tests are passing properly (see [here](https://elpy.readthedocs.io/en/latest/extending.html#running-tests) on how to run Elpy's tests)

Tests are broken beyond my ability to fix them.
