### PR TITLE
add choice for rpc for large buffers

### DIFF
--- a/elpy.el
+++ b/elpy.el
@@ -2831,7 +2831,9 @@ If you need your modeline, you can set the variable `elpy-remove-modeline-lighte
        (message
         (concat "Buffer %s larger than elpy-rpc-ignored-buffer-size (%d)."
                 " Elpy will turn off completion.")
-        (buffer-name) elpy-rpc-ignored-buffer-size)))
+        (buffer-name) elpy-rpc-ignored-buffer-size)
+       (when (yes-or-no-p "Buffer size is bigger than maximum size allowed, enabling completetion may slow Emacs down. proceed?")
+           (setq elpy-rpc-ignored-buffer-size (+ (buffer-size) 1)))))
     (`buffer-stop
      (company-mode -1)
      (kill-local-variable 'company-idle-delay)


### PR DESCRIPTION
Prompts user for using rpc api if buffer is too large

# PR Summary
I regularly work with python files over 100Kb, I have found that the Emacs performance drop for large buffer sizes are rather negligible. So I think it could benefit from leaving the choice up to user if buffer is large.
