### PR TITLE
Remove duplicated test block

### DIFF
--- a/test/elpy-black-fix-code-test.el
+++ b/test/elpy-black-fix-code-test.el
@@ -69,29 +69,6 @@
                      "x = 3"
                      )))))
 
-(when (elpy-black-fix-code--black-supported)
-  (ert-deftest elpy-black-fix-code-should-do-nothing-if-already-formatted ()
-    (elpy-testcase ()
-                   (set-buffer-string-with-point
-                    "_|_y =  2"
-                    "z = 3"
-                    "x = 3"
-                    )
-                   (elpy-black-fix-code)
-                   (should
-                    (buffer-be
-                     "_|_y = 2"
-                     "z = 3"
-                     "x = 3"
-                     ))
-                   (elpy-black-fix-code)
-                   (should
-                    (buffer-be
-                     "_|_y = 2"
-                     "z = 3"
-                     "x = 3"
-                     )))))
-
 ;; TODO: Not ideal, but unable to find source of issue. Debugging to not delay future work
 ;; when seeing a failing CI
 ;; (when (elpy-black-fix-code--black-supported)


### PR DESCRIPTION
For some reason the full body of
elpy-black-fix-code-should-do-nothing-if-already-formatted was duplicated identically and the github test runner action is generating a stack trace for the error.

If you look directly above the deleted code you'll see an identical copy of the conditional code block.

```
  Error: error ("Test ‘elpy-black-fix-code-should-do-nothing-if-already-formatted’ redefined (or loaded twice)")
    mapbacktrace(#f(compiled-function (evald func args flags) #<bytecode 0x1f93647adbae8641>))
    debug-early-backtrace()
    debug-early(error (error "Test ‘elpy-black-fix-code-should-do-nothing-if-already-formatted’ redefined (or loaded twice)"))
    signal(error ("Test ‘elpy-black-fix-code-should-do-nothing-if-already-formatted’ redefined (or loaded twice)"))
    error("Test `%s' redefined (or loaded twice)" elpy-black-fix-code-should-do-nothing-if-already-formatted)
```
# PR Summary


# PR checklist

Please make sure that the following things have been addressed (and check the relevant checkboxes):

- [X] Commits respect our [guidelines](../CONTRIBUTING.rst)
- [?] Tests are passing properly (see [here](https://elpy.readthedocs.io/en/latest/extending.html#running-tests) on how to run Elpy's tests)

One more test failure fixed.

I couldn't duplicate it with running ert directly, so I pushed it to the master branch of my fork where the github workflow ran and after the patch, the test `elpy-black-fix-code-should-do-nothing-if-already-formatted` passed