### PR TITLE
Drop support for old python versions and remove/update related tests

### DIFF
--- a/elpy-rpc.el
+++ b/elpy-rpc.el
@@ -236,9 +236,8 @@ needed packages from `elpy-rpc--get-package-list'."
        (common-py-deps (cons "black" basic-py-deps))
        (modern-py-deps (cons "setuptools" common-py-deps)))
 
-    (cond ((version< python-version "3.6") basic-py-deps)
-          ((version< python-version "3.12") common-py-deps)
-          (t modern-py-deps))))
+    (if (version< python-version "3.12") common-py-deps
+      modern-py-deps)))
 
 (defun elpy-rpc--get-package-list ()
   "Return the list of packages to be installed in the RPC virtualenv."

--- a/elpy-shell.el
+++ b/elpy-shell.el
@@ -517,12 +517,9 @@ Return non-nil is the shell is running and not busy, nil otherwise."
 ;; Echoing
 
 (defmacro elpy-shell--with-maybe-echo (body)
-  ;; Echoing is apparently buggy for emacs < 25...
-  (if (<= 25 emacs-major-version)
-      `(elpy-shell--with-maybe-echo-output
-        (elpy-shell--with-maybe-echo-input
-         ,body))
-    body))
+  `(elpy-shell--with-maybe-echo-output
+    (elpy-shell--with-maybe-echo-input
+     ,body)))
 
 
 (defmacro elpy-shell--with-maybe-echo-input (body)
@@ -1213,9 +1210,7 @@ switches focus to Python shell buffer."
 ;;;;;;;;;;;;;;;;;;;;;;;
 ;; Debugging features
 
-(when (version<= "25" emacs-version)
-
-  (defun elpy-pdb--refresh-breakpoints (lines)
+(defun elpy-pdb--refresh-breakpoints (lines)
     "Add new breakpoints at lines LINES of the current buffer."
     ;; Forget old breakpoints
     (python-shell-send-string-no-output "import bdb as __bdb; __bdb.Breakpoint.bplist={}; __bdb.Breakpoint.next=1;__bdb.Breakpoint.bpbynumber=[None]")
@@ -1367,7 +1362,7 @@ region or buffer."
     "Remove the breakpoints in the current region or buffer."
     (if (use-region-p)
         (remove-overlays (region-beginning) (region-end) 'elpy-breakpoint t)
-      (remove-overlays (point-min) (point-max) 'elpy-breakpoint t))))
+      (remove-overlays (point-min) (point-max) 'elpy-breakpoint t)))
 
 
 ;;;;;;;;;;;;;;;;;;;;;;;

--- a/elpy.el
+++ b/elpy.el
@@ -365,13 +365,8 @@ if nil, use the first formatter found amongst
     (define-key map (kbd "<M-left>") 'elpy-nav-indent-shift-left)
     (define-key map (kbd "<M-right>") 'elpy-nav-indent-shift-right)
 
-    (unless (fboundp 'xref-find-definitions)
-        (define-key map (kbd "M-.") 'elpy-goto-definition))
-    (if (not (fboundp 'xref-find-definitions-other-window))
-        (define-key map (kbd "C-x 4 M-.") 'elpy-goto-definition-other-window)
-      (define-key map (kbd "C-x 4 M-.") 'xref-find-definitions-other-window))
-    (when (fboundp 'xref-pop-marker-stack)
-        (define-key map (kbd "M-*") 'xref-pop-marker-stack))
+    (define-key map (kbd "C-x 4 M-.") 'xref-find-definitions-other-window)
+    (define-key map (kbd "M-*") 'xref-pop-marker-stack)
 
     (define-key map (kbd "M-TAB") 'elpy-company-backend)
 
@@ -451,9 +446,7 @@ This option need to bet set through `customize' or `customize-set-variable' to b
     ["Go to Definition" elpy-goto-definition
      :help "Go to the definition of the symbol at point"]
     ["Go to previous definition" pop-tag-mark
-     :active (if (version< emacs-version "25.1")
-                 (not (ring-empty-p find-tag-marker-ring))
-               (> xref-marker-ring-length 0))
+     :active (> xref-marker-ring-length 0)
      :help "Return to the position"]
     ["Complete" elpy-company-backend
      :keys "M-TAB"
@@ -640,15 +633,9 @@ warnings.filterwarnings('ignore', category=FutureWarning)
 warnings.filterwarnings('ignore', category=DeprecationWarning)
 warnings.filterwarnings('ignore', category=PendingDeprecationWarning)
 
-try:
-    from distutils.version import LooseVersion
-except ModuleNotFoundError:
-    from packaging.version import parse as LooseVersion
+from packaging.version import parse as LooseVersion
 
-try:
-    import urllib2 as urllib
-except ImportError:
-    import urllib.request as urllib
+import urllib.request as urllib
 
 
 # Check if we can connect to pypi quickly enough
@@ -1762,11 +1749,8 @@ with a prefix argument)."
 
 If OTHER-WINDOW-P is non-nil, show the same in other window."
 
-  ;; `find-tag-marker-ring' is marked as obsolete in 25.1
-  ;; and not available in 27.
-  (if (version< emacs-version "25.1")
-      (ring-insert find-tag-marker-ring (point-marker))
-    (xref-push-marker-stack))
+  ;; `find-tag-marker-ring' was removed in Emacs 27.
+  (xref-push-marker-stack)
   (let ((buffer (find-file-noselect filename)))
     (if other-window-p
         (pop-to-buffer buffer t)
@@ -3357,15 +3341,14 @@ Meant to be used as a hook to `after-change-functions'."
                    (ov (make-overlay beg end))
                    (marker-string "*fringe-dummy*")
                    (marker-length (length marker-string)))
-              (when (version<= "25.2" emacs-version)
-                (put-text-property 0 marker-length
+              (put-text-property 0 marker-length
                                    'display
                                    (list
                                     'left-fringe
                                     'elpy-folding-fringe-foldable-marker
                                     'elpy-folding-fringe-face)
                                    marker-string)
-                (overlay-put ov 'before-string marker-string))
+              (overlay-put ov 'before-string marker-string)
               (overlay-put ov 'elpy-hs-foldable t))))))))
 
 ;; Mouse interaction
@@ -3628,13 +3611,8 @@ If a region is selected, fold that region."
   (pcase command
     (`global-init
      (require 'flymake)
-     ;; flymake modeline is quite useful for emacs > 26.1
-     (when (version< emacs-version "26.1")
-       (elpy-modules-remove-modeline-lighter 'flymake-mode))
-     ;; Add our initializer function.
-     (unless (version<= "26.1" emacs-version)
-       (add-to-list 'flymake-allowed-file-name-masks
-                    '("\\.py\\'" elpy-flymake-python-init))))
+     ;; flymake modeline is quite useful
+     )
 
     (`buffer-init
      ;; Avoid fringes clash between flymake and folding indicators
@@ -3642,15 +3620,14 @@ If a region is selected, fold that region."
               elpy-folding-fringe-indicators)
          (setq-local flymake-fringe-indicator-position 'right-fringe)
        (setq-local flymake-fringe-indicator-position 'left-fringe))
-     ;; For emacs > 26.1, python.el natively supports flymake,
+     ;; python.el natively supports flymake,
      ;; so we just tell python.el to use the wanted syntax checker
-     (when (version<= "26.1" emacs-version)
-       (setq-local python-flymake-command
-                   (let ((command (split-string elpy-syntax-check-command)))
-                     (if (string= (file-name-nondirectory (car command))
-                                  "flake8")
-                         (append command '("-"))
-                       command))))
+     (setq-local python-flymake-command
+                 (let ((command (split-string elpy-syntax-check-command)))
+                   (if (string= (file-name-nondirectory (car command))
+                                "flake8")
+                       (append command '("-"))
+                     command)))
 
      ;; `flymake-no-changes-timeout': The original value of 0.5 is too
      ;; short for Python code, as that will result in the current line
@@ -3668,37 +3645,16 @@ If a region is selected, fold that region."
           nil)
 
      ;; Enable warning faces for flake8 output.
-     ;; Useless for emacs >= 26.1, as warning are handled fine
-     ;; COMPAT: Obsolete variable as of 24.4
-     (cond
-      ((version<= "26.1" emacs-version)
-       (setq-default python-flymake-msg-alist
-                     '(("^W[0-9]+" . :warning)
-                       ("^E[0-9]+" . :error))))
-      ((boundp 'flymake-warning-predicate)
-       (set (make-local-variable 'flymake-warning-predicate) "^W[0-9]"))
-      (t
-       (set (make-local-variable 'flymake-warning-re) "^W[0-9]")))
+     (setq-default python-flymake-msg-alist
+                   '(("^W[0-9]+" . :warning)
+                     ("^E[0-9]+" . :error)))
 
-     ;; for emacs >= 26.1, elpy relies on `python-flymake-command`, and
-     ;; doesn't need `python-check-command` anymore.
-     (when (and (buffer-file-name)
-                (or (version<= "26.1" emacs-version)
-                    (executable-find python-check-command)))
+     (when (buffer-file-name)
        (flymake-mode 1)))
     (`buffer-stop
      (flymake-mode -1)
      (kill-local-variable 'flymake-no-changes-timeout)
-     (kill-local-variable 'flymake-start-syntax-check-on-newline)
-     ;; Disable warning faces for flake8 output.
-     ;; Useless for emacs >= 26.1, as warning are handled fine
-     ;; COMPAT: Obsolete variable as of 24.4
-     (cond
-      ((version<= "26.1" emacs-version) t)
-      ((boundp 'flymake-warning-predicate)
-       (kill-local-variable 'flymake-warning-predicate))
-      (t
-       (kill-local-variable 'flymake-warning-re))))))
+     (kill-local-variable 'flymake-start-syntax-check-on-newline))))
 
 
 (defun elpy-flymake-python-init ()
@@ -3898,106 +3854,6 @@ If a region is selected, fold that region."
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;;; Backwards compatibility
 
-;; TODO Some/most of this compatibility code can now go, as minimum required
-;; Emacs version is 24.4.
-
-;; Functions for Emacs 24 before 24.3
-(unless (fboundp 'python-info-current-defun)
-  (defalias 'python-info-current-defun 'python-current-defun))
-
-(unless (fboundp 'python-nav-forward-statement)
-  (defun python-nav-forward-statement (&rest ignored)
-    "Function added in Emacs 24.3"
-    (error "Enhanced Python navigation only available in Emacs 24.3+")))
-
-(unless (fboundp 'python-nav-backward-up-list)
-  (defun python-nav-backward-up-list ()
-    "Compatibility function for older Emacsen"
-    (ignore-errors
-      (backward-up-list))))
-
-(unless (fboundp 'python-shell-calculate-exec-path)
-  (defun python-shell-calculate-exec-path ()
-    "Compatibility function for older Emacsen."
-    exec-path))
-
-(unless (fboundp 'python-shell-calculate-process-environment)
-  (defun python-shell-calculate-process-environment ()
-    "Compatibility function for older Emacsen."
-    process-environment))
-
-(unless (fboundp 'python-shell-get-process-name)
-  (defun python-shell-get-process-name (_dedicated)
-    "Compatibility function for older Emacsen."
-    "Python"))
-
-(unless (fboundp 'python-shell-parse-command)
-  (defun python-shell-parse-command ()
-    "Compatibility function for older Emacsen."
-    python-python-command))
-
-(unless (fboundp 'python-shell-send-buffer)
-  (defun python-shell-send-buffer (&optional _arg)
-    (python-send-buffer)))
-
-(unless (fboundp 'python-shell-send-string)
-  (defalias 'python-shell-send-string 'python-send-string))
-
-(unless (fboundp 'python-indent-shift-right)
-  (defalias 'python-indent-shift-right 'python-shift-right))
-
-(unless (fboundp 'python-indent-shift-left)
-  (defalias 'python-indent-shift-left 'python-shift-left))
-
-;; Emacs 24.2 made `locate-dominating-file' accept a predicate instead
-;; of a string. Simply overwrite the current one, it's
-;; backwards-compatible. The code below is taken from Emacs 24.3.
-(when (or (< emacs-major-version 24)
-          (and (= emacs-major-version 24)
-               (<= emacs-minor-version 2)))
-  (defun locate-dominating-file (file name)
-    "Look up the directory hierarchy from FILE for a directory containing NAME.
-Stop at the first parent directory containing a file NAME,
-and return the directory.  Return nil if not found.
-Instead of a string, NAME can also be a predicate taking one argument
-\(a directory) and returning a non-nil value if that directory is the one for
-which we're looking."
-    ;; We used to use the above locate-dominating-files code, but the
-    ;; directory-files call is very costly, so we're much better off doing
-    ;; multiple calls using the code in here.
-    ;;
-    ;; Represent /home/luser/foo as ~/foo so that we don't try to look for
-    ;; `name' in /home or in /.
-    (setq file (abbreviate-file-name file))
-    (let ((root nil)
-          ;; `user' is not initialized outside the loop because
-          ;; `file' may not exist, so we may have to walk up part of the
-          ;; hierarchy before we find the "initial UID".  Note: currently unused
-          ;; (user nil)
-          try)
-      (while (not (or root
-                      (null file)
-                      ;; FIXME: Disabled this heuristic because it is sometimes
-                      ;; inappropriate.
-                      ;; As a heuristic, we stop looking up the hierarchy of
-                      ;; directories as soon as we find a directory belonging
-                      ;; to another user.  This should save us from looking in
-                      ;; things like /net and /afs.  This assumes that all the
-                      ;; files inside a project belong to the same user.
-                      ;; (let ((prev-user user))
-                      ;;   (setq user (nth 2 (file-attributes file)))
-                      ;;   (and prev-user (not (equal user prev-user))))
-                      (string-match locate-dominating-stop-dir-regexp file)))
-        (setq try (if (stringp name)
-                      (file-exists-p (expand-file-name name file))
-                    (funcall name file)))
-        (cond (try (setq root file))
-              ((equal file (setq file (file-name-directory
-                                       (directory-file-name file))))
-               (setq file nil))))
-      (if root (file-name-as-directory root))))
-  )
-
 ;; highlight-indentation 0.5 does not use modes yet
 (unless (fboundp 'highlight-indentation-mode)
   (defun highlight-indentation-mode (on-or-off)
@@ -4008,69 +3864,6 @@ which we're looking."
      ((and (<= on-or-off 0)
            highlight-indent-active)
       (highlight-indentation)))))
-
-;; https://debbugs.gnu.org/cgi/bugreport.cgi?bug=25753#44
-(when (version< emacs-version "25.2")
-  (defun python-shell-completion-native-try ()
-    "Return non-nil if can trigger native completion."
-    (let ((python-shell-completion-native-enable t)
-          (python-shell-completion-native-output-timeout
-           python-shell-completion-native-try-output-timeout))
-      (python-shell-completion-native-get-completions
-       (get-buffer-process (current-buffer))
-       nil "_"))))
-
-;; python.el in Emacs 24 does not have functions to determine buffer encoding.
-;; In these versions, we fix the encoding to utf-8 (safe choice when no encoding
-;; is defined since Python 2 uses ASCII and Python 3 UTF-8).
-(unless (fboundp 'python-info-encoding)
-  (defun python-info-encoding ()
-    'utf-8))
-
-;; first-prompt-hook has been added in emacs 25.
-;; for earlier versions, make sure Elpy's setup code is
-;; still send to the python shell.
-(unless (boundp 'python-shell-first-prompt-hook)
-  (add-hook 'inferior-python-mode-hook
-            (lambda ()
-              (when (elpy-project-root)
-                (let ((process (get-buffer-process (current-buffer))))
-                  (python-shell-send-string
-                   (format "import sys;sys.path.append('%s');del sys"
-                           (elpy-project-root))
-                   process))))))
-
-
-
-;; Added in Emacs 25
-(unless (fboundp 'python-shell-comint-end-of-output-p)
-  (defun python-shell-comint-end-of-output-p (output)
-    "Return non-nil if OUTPUT is ends with input prompt."
-    (string-match
-     ;; XXX: It seems on macOS an extra carriage return is attached
-     ;; at the end of output, this handles that too.
-     (concat
-      "\r?\n?"
-      ;; Remove initial caret from calculated regexp
-      (replace-regexp-in-string
-       (rx string-start ?^) ""
-       python-shell--prompt-calculated-input-regexp)
-      (rx eos))
-     output)))
-
-(unless (fboundp 'python-info-docstring-p)
-  (defun python-info-docstring-p (&optional syntax-ppss)
-    "Return non-nil if point is in a docstring."
-    (save-excursion
-      (and (progn (python-nav-beginning-of-statement)
-                  (looking-at "\\(\"\\|'\\)"))
-           (progn (forward-line -1)
-                  (beginning-of-line)
-                  (python-info-looking-at-beginning-of-defun))))))
-
-(unless (fboundp 'alist-get)
-  (defun alist-get (key alist &rest rest)
-    (cdr (assoc key alist))))
 
 (provide 'elpy)
 ;;; elpy.el ends here

--- a/elpy/blackutil.py
+++ b/elpy/blackutil.py
@@ -2,46 +2,22 @@
 
 """
 
-import sys
+import os
+import tomllib
+
+from packaging.version import parse as parse_version
 
 from elpy.rpc import Fault
 
-# Fix from Christopher Genovese
-# https://github.com/jorgenschaefer/elpy/issues/2051#issuecomment-2472286571
-# see also https://github.com/jorgenschaefer/elpy/issues/2051
 try:
-    from pkg_resources import parse_version
-except ImportError:  # pragma: no cover
-    try:
-        from packaging.version import parse as parse_version
-    except ImportError:  # pragma: no cover
-        def parse_version(*arg, **kwargs):
-            raise Fault("Neither `packaging` nor`pkg_resources` could be imported, "
-                        "please reinstall Elpy RPC virtualenv with"
-                        " `M-x elpy-rpc-reinstall-virtualenv`", code=400)
-
-import os
-
-try:
-    import toml
-except ImportError:
-    toml = None
-
-
-BLACK_NOT_SUPPORTED = sys.version_info < (3, 6)
-
-try:
-    if BLACK_NOT_SUPPORTED:  # pragma: no cover
-        black = None
+    import black
+    current_version = parse_version(black.__version__)
+    if current_version >= parse_version("21.5b1"):
+        from black.files import find_pyproject_toml
+    elif current_version >= parse_version("20.8b0"):
+        from black import find_pyproject_toml
     else:
-        import black
-        current_version = parse_version(black.__version__)
-        if current_version >= parse_version("21.5b1"):
-            from black.files import find_pyproject_toml
-        elif current_version >= parse_version("20.8b0"):
-            from black import find_pyproject_toml
-        else:
-            find_pyproject_toml = None
+        find_pyproject_toml = None
 
 except ImportError:  # pragma: no cover
     black = None
@@ -60,23 +36,20 @@ def fix_code(code, directory):
         pyproject_path = find_pyproject_toml((directory,))
     else:
         pyproject_path = os.path.join(directory, "pyproject.toml")
-    if toml and pyproject_path and os.path.exists(pyproject_path):
-        pyproject_config = toml.load(pyproject_path)
+    if pyproject_path and os.path.exists(pyproject_path):
+        with open(pyproject_path, "rb") as f:
+            pyproject_config = tomllib.load(f)
         black_config = pyproject_config.get("tool", {}).get("black", {})
         if "line-length" in black_config:
             line_length = black_config["line-length"]
         if "skip-string-normalization" in black_config:
             string_normalization = not black_config["skip-string-normalization"]
     try:
-        if parse_version(black.__version__) < parse_version("19.0"):
-            reformatted_source = black.format_file_contents(
-                src_contents=code, line_length=line_length, fast=False)
-        else:
-            fm = black.FileMode(
-                line_length=line_length,
-                string_normalization=string_normalization)
-            reformatted_source = black.format_file_contents(
-                src_contents=code, fast=False, mode=fm)
+        fm = black.FileMode(
+            line_length=line_length,
+            string_normalization=string_normalization)
+        reformatted_source = black.format_file_contents(
+            src_contents=code, fast=False, mode=fm)
         return reformatted_source
     except black.NothingChanged:
         return code

--- a/elpy/compat.py
+++ b/elpy/compat.py
@@ -1,33 +1,14 @@
-"""Python 2/3 compatibility definitions.
+"""Compatibility definitions.
 
-These are used by the rest of Elpy to keep compatibility definitions
-in one place.
-
+This module previously held Python 2/3 shims.  With Python 3.11+ as the
+minimum supported version, most of them are gone.  The remaining public
+names are kept so that in-tree (and possibly out-of-tree) code that
+already imports them keeps working.
 """
 
-import sys
+from io import StringIO  # noqa: F401
 
 
-if sys.version_info >= (3, 0):
-    PYTHON3 = True
-
-    from io import StringIO
-
-    def ensure_not_unicode(obj):
-        return obj
-else:
-    PYTHON3 = False
-
-    from StringIO import StringIO  # noqa
-
-    def ensure_not_unicode(obj):
-        """Return obj. If it's a unicode string, convert it to str first.
-
-        Pydoc functions simply don't find anything for unicode
-        strings. No idea why.
-
-        """
-        if isinstance(obj, unicode):
-            return obj.encode("utf-8")
-        else:
-            return obj
+def ensure_not_unicode(obj):
+    """Identity function -- kept for call-site compatibility."""
+    return obj

--- a/elpy/jedibackend.py
+++ b/elpy/jedibackend.py
@@ -15,19 +15,7 @@ import jedi
 from elpy import rpc
 from elpy.rpc import Fault
 
-# Fix from Christopher Genovese
-# https://github.com/jorgenschaefer/elpy/issues/2051#issuecomment-2472286571
-# see also https://github.com/jorgenschaefer/elpy/issues/2051
-try:
-    from pkg_resources import parse_version
-except ImportError:  # pragma: no cover
-    try:
-        from packaging.version import parse as parse_version
-    except ImportError:  # pragma: no cover
-        def parse_version(*arg, **kwargs):
-            raise Fault("Neither `packaging` nor`pkg_resources` could be imported, "
-                        "please reinstall Elpy RPC virtualenv with"
-                        " `M-x elpy-rpc-reinstall-virtualenv`", code=400)
+from packaging.version import parse as parse_version
 JEDISUP17 = parse_version(jedi.__version__) >= parse_version("0.17.0")
 JEDISUP18 = parse_version(jedi.__version__) >= parse_version("0.18.0")
 JEDISUP19 = parse_version(jedi.__version__) >= parse_version("0.19.0")

--- a/elpy/pydocutils.py
+++ b/elpy/pydocutils.py
@@ -4,8 +4,6 @@ import types
 from pydoc import safeimport, resolve, ErrorDuringImport
 from pkgutil import iter_modules
 
-from elpy import compat
-
 # Types we want to recurse into (nodes).
 CONTAINER_TYPES = (type, types.ModuleType)
 # Types of attributes we can get documentation for (leaves).
@@ -15,10 +13,6 @@ PYDOC_TYPES = (type,
                types.BuiltinMethodType,
                types.MethodType,
                types.ModuleType)
-if not compat.PYTHON3:  # pragma: nocover
-    # Python 2 old style classes
-    CONTAINER_TYPES = tuple(list(CONTAINER_TYPES) + [types.ClassType])
-    PYDOC_TYPES = tuple(list(PYDOC_TYPES) + [types.ClassType])
 
 
 def get_pydoc_completions(modulename):
@@ -27,7 +21,6 @@ def get_pydoc_completions(modulename):
     Returns a list of possible values to be passed to pydoc.
 
     """
-    modulename = compat.ensure_not_unicode(modulename)
     modulename = modulename.rstrip(".")
     if modulename == "":
         return sorted(get_modules())
@@ -68,7 +61,6 @@ def get_modules(modulename=None):
     and packages.
 
     """
-    modulename = compat.ensure_not_unicode(modulename)
     if not modulename:
         try:
             return ([modname for (importer, modname, ispkg)
@@ -76,7 +68,6 @@ def get_modules(modulename=None):
                      if not modname.startswith("_")] +
                     list(sys.builtin_module_names))
         except OSError:
-            # Bug in Python 2.6, see #275
             return list(sys.builtin_module_names)
     try:
         module = safeimport(modulename)

--- a/elpy/tests/compat.py
+++ b/elpy/tests/compat.py
@@ -1,18 +1,9 @@
-"""Python 2/3 compatibility definitions.
+"""Compatibility definitions for test code.
 
-These are used by the rest of Elpy to keep compatibility definitions
-in one place.
-
+This module previously held Python 2/3 shims.  With Python 3.11+ as the
+minimum supported version, they are no longer needed.  The remaining
+public names are kept for import compatibility.
 """
 
-import sys
-
-
-if sys.version_info >= (3, 0):
-    PYTHON3 = True
-    import builtins
-    from io import StringIO
-else:
-    PYTHON3 = False
-    import __builtin__ as builtins  # noqa
-    from StringIO import StringIO  # noqa
+import builtins  # noqa: F401
+from io import StringIO  # noqa: F401

--- a/elpy/tests/support.py
+++ b/elpy/tests/support.py
@@ -21,7 +21,6 @@ import unittest
 
 from elpy import jedibackend
 from elpy.rpc import Fault
-from elpy.tests import compat
 
 if jedibackend.JEDISUP18:
     import pathlib
@@ -52,11 +51,7 @@ class BackendTestCase(unittest.TestCase):
             os.makedirs(os.path.dirname(full_name))
         except OSError:
             pass
-        if compat.PYTHON3:
-            fobj = open(full_name, "w", encoding="utf-8")
-        else:
-            fobj = open(full_name, "w")
-        with fobj as f:
+        with open(full_name, "w", encoding="utf-8") as f:
             f.write(contents)
         # return full_name
         if jedibackend.JEDISUP18:
@@ -353,10 +348,7 @@ class RPCGetCompletionsTests(GenericRPCTests):
         for candidate in expected:
             self.assertIn(candidate, actual)
 
-    if sys.version_info >= (3, 5) or sys.version_info < (3, 0):
-        JSON_COMPLETIONS = ["SONDecoder", "SONEncoder", "SONDecodeError"]
-    else:
-        JSON_COMPLETIONS = ["SONDecoder", "SONEncoder"]
+    JSON_COMPLETIONS = ["SONDecoder", "SONEncoder", "SONDecodeError"]
 
     def test_should_complete_imports(self):
         source, offset = source_and_offset("import json\n"
@@ -375,10 +367,7 @@ class RPCGetCompletionsTests(GenericRPCTests):
         completions = self.backend.rpc_get_completions(filename,
                                                        source,
                                                        offset)
-        if compat.PYTHON3:
-            expected = ["processing"]
-        else:
-            expected = ["file", "processing"]
+        expected = ["processing"]
         self.assertEqual(sorted([cand['suffix'] for cand in completions]),
                          sorted(expected))
 
@@ -388,10 +377,7 @@ class RPCGetCompletionsTests(GenericRPCTests):
         completions = self.backend.rpc_get_completions(filename,
                                                        source,
                                                        offset)
-        if sys.version_info < (3, 0):
-            compl = [u'me', u'METext']
-        else:
-            compl = ['me']
+        compl = ['me']
         self.assertEqual([cand['suffix'] for cand in completions],
                          compl)
 
@@ -862,8 +848,6 @@ class RPCGetOnelineDocstringTests(GenericRPCTests):
 
 @unittest.skipIf(not jedibackend.JEDISUP17,
                  "Refactoring not available with jedi<17")
-@unittest.skipIf(sys.version_info < (3, 6),
-                 "Jedi refactoring not available for python < 3.6")
 class RPCGetRenameDiffTests(object):
     METHOD = "rpc_get_rename_diff"
 
@@ -893,8 +877,6 @@ class RPCGetRenameDiffTests(object):
 
 @unittest.skipIf(not jedibackend.JEDISUP17,
                  "Refactoring not available with jedi<17")
-@unittest.skipIf(sys.version_info < (3, 6),
-                 "Jedi refactoring not available for python < 3.6")
 class RPCGetExtractFunctionDiffTests(object):
     METHOD = "rpc_get_extract_function_diff"
 
@@ -918,8 +900,6 @@ class RPCGetExtractFunctionDiffTests(object):
 
 @unittest.skipIf(not jedibackend.JEDISUP17,
                  "Refactoring not available with jedi<17")
-@unittest.skipIf(sys.version_info < (3, 6),
-                 "Jedi refactoring not available for python < 3.6")
 class RPCGetExtractVariableDiffTests(object):
     METHOD = "rpc_get_extract_variable_diff"
 
@@ -940,8 +920,6 @@ class RPCGetExtractVariableDiffTests(object):
 
 @unittest.skipIf(not jedibackend.JEDISUP17,
                  "Refactoring not available with jedi<17")
-@unittest.skipIf(sys.version_info < (3, 6),
-                 "Jedi refactoring not available for python < 3.6")
 class RPCGetInlineDiffTests(object):
     METHOD = "rpc_get_inline_diff"
 

--- a/elpy/tests/test_black.py
+++ b/elpy/tests/test_black.py
@@ -9,12 +9,9 @@ from elpy.rpc import Fault
 from elpy.tests.support import BackendTestCase
 
 
-@unittest.skipIf(blackutil.BLACK_NOT_SUPPORTED,
-                 'black not supported for current python version')
 class BLACKTestCase(BackendTestCase):
     def setUp(self):
-        if blackutil.BLACK_NOT_SUPPORTED:
-            raise unittest.SkipTest
+        super().setUp()
 
     def test_fix_code_should_throw_error_for_invalid_code(self):
         src = 'x = '

--- a/elpy/tests/test_jedibackend.py
+++ b/elpy/tests/test_jedibackend.py
@@ -4,15 +4,11 @@ import sys
 import unittest
 
 import jedi
-try:
-    from unittest import mock
-except ImportError:
-    import mock
+from unittest import mock
 import re
 
 from elpy import jedibackend
 from elpy import rpc
-from elpy.tests import compat
 from elpy.tests.support import BackendTestCase
 from elpy.tests.support import RPCGetCompletionsTests
 from elpy.tests.support import RPCGetCompletionDocstringTests
@@ -94,36 +90,17 @@ class TestRPCGetOnelineDocstring(RPCGetOnelineDocstringTests,
 
     def __init__(self, *args, **kwargs):
         super(TestRPCGetOnelineDocstring, self).__init__(*args, **kwargs)
-        if sys.version_info >= (3, 6):
-            self.JSON_LOADS_DOCSTRING = (
-                'Deserialize ``s`` (a ``str``, ``bytes`` or'
-                ' ``bytearray`` instance containing a JSON'
-                ' document) to a Python object.'
-            )
-            if sys.version_info >= (3, 12):
-                self.JSON_DOCSTRING = (
-                    "JSON (JavaScript Object Notation) <https://json.org>"
-                    " is a subset of JavaScript syntax (ECMA-262"
-                    " 3rd edition) used as a lightweight data interchange format.")
-            else:
-                self.JSON_DOCSTRING = (
-                    "JSON (JavaScript Object Notation) <http://json.org>"
-                    " is a subset of JavaScript syntax (ECMA-262"
-                    " 3rd edition) used as a lightweight data interchange format.")
-        elif sys.version_info >= (3, 0):
-            self.JSON_LOADS_DOCSTRING = (
-                'Deserialize ``s`` (a ``str`` instance '
-                'containing a JSON document) to a Python object.'
-            )
+        self.JSON_LOADS_DOCSTRING = (
+            'Deserialize ``s`` (a ``str``, ``bytes`` or'
+            ' ``bytearray`` instance containing a JSON'
+            ' document) to a Python object.'
+        )
+        if sys.version_info >= (3, 12):
             self.JSON_DOCSTRING = (
-                "JSON (JavaScript Object Notation) <http://json.org>"
+                "JSON (JavaScript Object Notation) <https://json.org>"
                 " is a subset of JavaScript syntax (ECMA-262"
                 " 3rd edition) used as a lightweight data interchange format.")
         else:
-            self.JSON_LOADS_DOCSTRING = (
-                'Deserialize ``s`` (a ``str`` or ``unicode`` '
-                'instance containing a JSON document) to a Python object.'
-            )
             self.JSON_DOCSTRING = (
                 "JSON (JavaScript Object Notation) <http://json.org>"
                 " is a subset of JavaScript syntax (ECMA-262"
@@ -193,34 +170,24 @@ class TestRPCGetCalltip(RPCGetCalltipTests,
     ADD_CALLTIP = {'index': 0,
                    'params': [u'a', u'b'],
                    'name': u'add'}
-    if compat.PYTHON3:
-        if jedibackend.JEDISUP19:
-            THREAD_CALLTIP = {'name': 'Thread',
-                              'index': 0,
-                              'params': ['group: None=None',
-                                         'target: Callable[..., object] | None=None',
-                                         'name: str | None=None',
-                                         'args: Iterable[Any]=()',
-                                         'kwargs: Mapping[str, Any] | None=None',
-                                         'daemon: bool | None=None']}
-        else:
-            THREAD_CALLTIP = {'name': 'Thread',
-                              'index': 0,
-                              'params': ['group: None=...',
-                                         'target: Optional[Callable[..., Any]]=...',
-                                         'name: Optional[str]=...',
-                                         'args: Iterable[Any]=...',
-                                         'kwargs: Mapping[str, Any]=...',
-                                         'daemon: Optional[bool]=...']}
-
+    if jedibackend.JEDISUP19:
+        THREAD_CALLTIP = {'name': 'Thread',
+                          'index': 0,
+                          'params': ['group: None=None',
+                                     'target: Callable[..., object] | None=None',
+                                     'name: str | None=None',
+                                     'args: Iterable[Any]=()',
+                                     'kwargs: Mapping[str, Any] | None=None',
+                                     'daemon: bool | None=None']}
     else:
-        THREAD_CALLTIP = {'index': 0,
-                          'name': u'Thread',
-                          'params': [u'group: None=...',
-                                     u'target: Optional[Callable[..., Any]]=...',
-                                     u'name: Optional[str]=...',
-                                     u'args: Iterable[Any]=...',
-                                     u'kwargs: Mapping[str, Any]=...']}
+        THREAD_CALLTIP = {'name': 'Thread',
+                          'index': 0,
+                          'params': ['group: None=...',
+                                     'target: Optional[Callable[..., Any]]=...',
+                                     'name: Optional[str]=...',
+                                     'args: Iterable[Any]=...',
+                                     'kwargs: Mapping[str, Any]=...',
+                                     'daemon: Optional[bool]=...']}
 
     def test_should_not_fail_with_get_subscope_by_name(self):
         # Bug #677 / jedi#628

--- a/elpy/tests/test_pydocutils.py
+++ b/elpy/tests/test_pydocutils.py
@@ -4,10 +4,7 @@ import shutil
 import sys
 import tempfile
 
-try:
-    from unittest import mock
-except ImportError:
-    import mock
+from unittest import mock
 
 import elpy.pydocutils
 

--- a/elpy/tests/test_server.py
+++ b/elpy/tests/test_server.py
@@ -6,14 +6,10 @@ import os
 import tempfile
 import unittest
 
-try:
-    from unittest import mock
-except ImportError:
-    import mock
+from unittest import mock
 
 from elpy import rpc
 from elpy import server
-from elpy.tests import compat
 from elpy.tests.support import BackendTestCase
 
 

--- a/elpy/tests/test_yapf.py
+++ b/elpy/tests/test_yapf.py
@@ -9,12 +9,9 @@ from elpy.rpc import Fault
 from elpy.tests.support import BackendTestCase
 
 
-@unittest.skipIf(yapfutil.YAPF_NOT_SUPPORTED,
-                 'yapf not supported for current python version')
 class YAPFTestCase(BackendTestCase):
     def setUp(self):
-        if yapfutil.YAPF_NOT_SUPPORTED:
-            raise unittest.SkipTest
+        super().setUp()
 
     def test_fix_code_should_throw_error_for_invalid_code(self):
         src = 'x = '

--- a/elpy/yapfutil.py
+++ b/elpy/yapfutil.py
@@ -3,32 +3,16 @@
 """
 
 import os
-import sys
+
+from packaging.version import parse as parse_version
 
 from elpy.rpc import Fault
 
-YAPF_NOT_SUPPORTED = sys.version_info < (2, 7) or (
-    sys.version_info >= (3, 0) and sys.version_info < (3, 4))
-
-# This came from elpy/blackutil.py it should probably be in a library
 try:
-    from pkg_resources import parse_version
-except ImportError:  # pragma: no cover
-    try:
-        from packaging.version import parse as parse_version
-    except ImportError:  # pragma: no cover
-        def parse_version(*args, **kwargs):
-            raise Fault("Neither `packaging` nor `pkg_resources` could be imported, "
-                        "please reinstall Elpy RPC virtualenv with"
-                        " `M-x elpy-rpc-reinstall-virtualenv`", code=400)
-try:
-    if YAPF_NOT_SUPPORTED:
-        yapf_api = None
-    else:
-        from yapf.yapflib import yapf_api
-        from yapf.yapflib import file_resources
-        from yapf import __version__
-        yapf_version = parse_version(__version__)
+    from yapf.yapflib import yapf_api
+    from yapf.yapflib import file_resources
+    from yapf import __version__
+    yapf_version = parse_version(__version__)
 except ImportError:  # pragma: no cover
     yapf_api = None
 

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,6 +1,4 @@
 bumpversion
 coverage
-mock
 twine
 wheel
-toml

--- a/requirements-dev2.txt
+++ b/requirements-dev2.txt
@@ -1,1 +1,0 @@
-unittest2

--- a/requirements-rpc.txt
+++ b/requirements-rpc.txt
@@ -1,5 +1,4 @@
 jedi
 autopep8
 yapf
-setuptools; python_version<"3.12"
-packaging; python_version>="3.12"
+packaging

--- a/setup.py
+++ b/setup.py
@@ -13,22 +13,21 @@ setup(
     author="Jorgen Schaefer",
     author_email="contact@jorgenschaefer.de",
     license="GPL",
+    python_requires=">=3.11",
     classifiers=[
         "Development Status :: 5 - Production/Stable",
         "Intended Audience :: Developers",
         ("License :: OSI Approved :: "
          "GNU General Public License v3 or later (GPLv3+)"),
-        'Programming Language :: Python :: 2',
-        'Programming Language :: Python :: 2.6',
-        'Programming Language :: Python :: 2.7',
         'Programming Language :: Python :: 3',
-        'Programming Language :: Python :: 3.3',
-        'Programming Language :: Python :: 3.4',
+        'Programming Language :: Python :: 3.11',
+        'Programming Language :: Python :: 3.12',
+        'Programming Language :: Python :: 3.13',
         "Natural Language :: English",
         "Topic :: Text Editors :: Emacs",
     ],
     packages=find_packages(),
     include_package_data=True,
-    install_requires=["flake8>=2.0"],
+    install_requires=["flake8>=2.0", "packaging"],
     test_suite="elpy"
 )

--- a/test/elpy-flymake-show-error-test.el
+++ b/test/elpy-flymake-show-error-test.el
@@ -1,30 +1,15 @@
 (ert-deftest elpy-flymake-show-error ()
   (elpy-testcase ()
-       ;; Emacs < 26.1
-       (when (version< emacs-version "26.1")
-        (mletf* ((flymake-find-err-info
-                  (info line)
-                  (list (list (flymake-ler-make-ler "" "" "" "test-error-1")
-                              (flymake-ler-make-ler "" "" "" "test-error-2"))))
+       (mletf* ((flymake-diagnostics
+                 (point)
+                 (list (flymake-make-diagnostic (current-buffer)
+                        23 56 :error "test-error-1")
+                       (flymake-make-diagnostic (current-buffer)
+                        62 28 :error "test-error-2")))
                  (output nil)
                  (message (fmt &rest args)
                           (setq output (apply 'format fmt args))))
 
-          (elpy-flymake-show-error)
+        (elpy-flymake-show-error)
 
-          (should (equal output "test-error-1, test-error-2"))))
-       (when (version<= "26.1" emacs-version)
-
-         (mletf* ((flymake-diagnostics
-                   (point)
-                   (list (flymake-make-diagnostic (current-buffer)
-                          23 56 :error "test-error-1")
-                         (flymake-make-diagnostic (current-buffer)
-                          62 28 :error "test-error-2")))
-                   (output nil)
-                   (message (fmt &rest args)
-                            (setq output (apply 'format fmt args))))
-
-          (elpy-flymake-show-error)
-
-          (should (equal output "test-error-1, test-error-2"))))))
+        (should (equal output "test-error-1, test-error-2")))))

--- a/test/elpy-mode-test.el
+++ b/test/elpy-mode-test.el
@@ -41,5 +41,4 @@
       (elpy-enable)
       (python-mode)
       (should (equal python-check-command "flake8"))
-      (if (version<= "26.1" emacs-version)
-          (should (equal python-flymake-command '("flake8" "-")))))))
+      (should (equal python-flymake-command '("flake8" "-"))))))

--- a/test/elpy-module-flymake-test.el
+++ b/test/elpy-module-flymake-test.el
@@ -1,10 +1,6 @@
 (ert-deftest elpy-module-flymake-global-init ()
   (elpy-testcase ()
-    (elpy-module-flymake 'global-init)
-
-    (when (version< emacs-version "26.1")
-        (should (member '("\\.py\\'" elpy-flymake-python-init)
-                        flymake-allowed-file-name-masks)))))
+    (elpy-module-flymake 'global-init)))
 
 (ert-deftest elpy-module-flymake-buffer-init ()
   (elpy-testcase ((:project project-root
@@ -17,13 +13,7 @@
     ;; (should flymake-mode)
 
     (should (equal flymake-no-changes-timeout 60))
-    (should (equal flymake-start-syntax-check-on-newline nil))
-
-    (when (version< emacs-version "26.1")
-        (should (equal "^W[0-9]"
-                       (if (boundp 'flymake-warning-predicate)
-                           flymake-warning-predicate
-                         flymake-warning-re))))))
+    (should (equal flymake-start-syntax-check-on-newline nil))))
 
 (ert-deftest elpy-module-flymake-buffer-stop ()
   (elpy-testcase ()

--- a/test/elpy-refactor-extract-function-test.el
+++ b/test/elpy-refactor-extract-function-test.el
@@ -1,7 +1,5 @@
-(unless (or (version< (elpy-rpc--get-python-version) "3.6" )
-            (version< emacs-version "25.0")  ;; diffs are not parsed properly before emacs 25
-            (string= (alist-get 'success (elpy-rpc-get-rename-diff "foo"))
-                     "Not available"))
+(unless (string= (alist-get 'success (elpy-rpc-get-rename-diff "foo"))
+                 "Not available")
 
 
 (ert-deftest elpy-refactor-rpc-extract-function-should-return-diff ()

--- a/test/elpy-refactor-extract-variable-test.el
+++ b/test/elpy-refactor-extract-variable-test.el
@@ -1,7 +1,5 @@
-(unless (or (version< (elpy-rpc--get-python-version) "3.6" )
-            (version< emacs-version "25.0")  ;; diffs are not parsed properly before emacs 25
-            (string= (alist-get 'success (elpy-rpc-get-rename-diff "foo"))
-                     "Not available"))
+(unless (string= (alist-get 'success (elpy-rpc-get-rename-diff "foo"))
+                 "Not available")
 
 (ert-deftest elpy-refactor-rpc-extract-variable-should-return-diff ()
   (elpy-testcase ((:project project-root "test.py"))

--- a/test/elpy-refactor-inline-test.el
+++ b/test/elpy-refactor-inline-test.el
@@ -1,7 +1,5 @@
-(unless (or (version< (elpy-rpc--get-python-version) "3.6" )
-            (version< emacs-version "25.0")  ;; diffs are not parsed properly before emacs 25
-            (string= (alist-get 'success (elpy-rpc-get-rename-diff "foo"))
-                     "Not available"))
+(unless (string= (alist-get 'success (elpy-rpc-get-rename-diff "foo"))
+                 "Not available")
 
 (ert-deftest elpy-refactor-rpc-inline-should-return-diff ()
   (elpy-testcase ((:project project-root "test.py"))

--- a/test/elpy-refactor-rename-test.el
+++ b/test/elpy-refactor-rename-test.el
@@ -1,7 +1,5 @@
-(unless (or (version< (elpy-rpc--get-python-version) "3.6" )
-            (version< emacs-version "25.0")  ;; diffs are not parsed properly before emacs 25
-            (string= (alist-get 'success (elpy-rpc-get-rename-diff "foo"))
-                     "Not available"))
+(unless (string= (alist-get 'success (elpy-rpc-get-rename-diff "foo"))
+                 "Not available")
 
 (ert-deftest elpy-refactor-rpc-rename-should-return-diff ()
   (elpy-testcase ((:project project-root "test.py"))

--- a/test/elpy-refactor-test.el
+++ b/test/elpy-refactor-test.el
@@ -1,6 +1,5 @@
-(unless (or (version< (elpy-rpc--get-python-version) "3.6" )
-            (string= (alist-get 'success (elpy-rpc-get-rename-diff "foo"))
-                     "Not available"))
+(unless (string= (alist-get 'success (elpy-rpc-get-rename-diff "foo"))
+                 "Not available")
 
 (ert-deftest elpy-refactor-should-warn-about-invalid-symbols ()
   (elpy-testcase ((:project project-root "test.py"))

--- a/test/elpy-test-at-point-test.el
+++ b/test/elpy-test-at-point-test.el
@@ -52,9 +52,7 @@
                      (list "/project/root"
                            "/project/root/tests/test.py"
                            "tests.test"
-                           (if (version< emacs-version "24.3")
-                               nil
-                             "TestClass"))))
+                           "TestClass")))
       (should (eq saved 'one)))))
 
 (ert-deftest elpy-test-at-point-should-return-current-test-method ()
@@ -74,7 +72,5 @@
                      (list "/project/root"
                            "/project/root/tests/test.py"
                            "tests.test"
-                           (if (version< emacs-version "24.3")
-                               "TestClass"
-                             "TestClass.test_method"))))
+                           "TestClass.test_method")))
       (should (eq saved 'one)))))


### PR DESCRIPTION
- Remove support for all Python 2
- Only have support for publicly maintained python versions (3.11+ as of now)
- Remove old test code related to non supported emacs versions
- Remove old test code related to non supported python versions